### PR TITLE
Cluster: Add `skip` mode to `lxc cluster restore` command

### DIFF
--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -223,6 +223,13 @@ func (r *ProtocolLXD) UpdateClusterMemberState(name string, state api.ClusterMem
 		return nil, err
 	}
 
+	if state.Action != "" {
+		err = r.CheckExtension("clustering_restore_skip_mode")
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	u := api.NewURL().Path("cluster", "members", name, "state")
 	op, _, err := r.queryOperation(http.MethodPost, u.String(), state, "", true)
 	if err != nil {

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2668,3 +2668,7 @@ This adds support for listing network ACLs across all projects using the `all-pr
 ## `networks_all_projects`
 
 This adds support for listing networks across all projects using the `all-projects` parameter in `GET /1.0/networks` requests.
+
+## `clustering_restore_skip_mode`
+
+Adds a `skip` mode to the restore request. This mode restores a cluster member's status to `ONLINE` without restarting any of its stopped local instances or migrating back instances that were evacuated to other cluster members.

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1301,10 +1301,17 @@ func (c *cmdClusterEvacuate) command() *cobra.Command {
 	cmd.Aliases = []string{"evac"}
 	cmd.Use = usage("evacuate", i18n.G("[<remote>:]<member>"))
 	cmd.Short = i18n.G("Evacuate cluster member")
-	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Evacuate cluster member`))
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Evacuate cluster member
+
+Evacuation actions:
+ - stop: stop all instances on the member
+ - migrate: migrate all instances on the member to other members
+ - live-migrate: live migrate all instances on the member to other members
+`))
 
 	cmd.Flags().BoolVar(&c.action.flagForce, "force", false, i18n.G(`Force evacuation without user confirmation`)+"``")
-	cmd.Flags().StringVar(&c.action.flagAction, "action", "", i18n.G(`Force a particular evacuation action`)+"``")
+	cmd.Flags().StringVar(&c.action.flagAction, "action", "", i18n.G(`Force a particular instance evacuation action. One of stop, migrate or live-migrate`)+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1334,6 +1334,7 @@ func (c *cmdClusterRestore) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Restore cluster member`))
 
 	cmd.Flags().BoolVar(&c.action.flagForce, "force", false, i18n.G(`Force restoration without user confirmation`)+"``")
+	cmd.Flags().StringVar(&c.action.flagAction, "action", "", i18n.G(`Force a particular instance restore action. Use "skip" to restore only the cluster member status without starting local instances or migrating back evacuated instances`)+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,13 +103,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -613,11 +613,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -625,11 +625,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -678,11 +678,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -807,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -861,21 +861,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -884,8 +884,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1024,15 +1024,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,38 +1127,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1226,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1297,15 +1297,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,11 +1478,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1498,11 +1498,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,18 +1542,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1629,11 +1629,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1649,11 +1649,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,18 +1691,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1711,38 +1711,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1754,16 +1754,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1774,57 +1774,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1834,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1921,11 +1921,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,11 +1937,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1972,7 +1972,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1984,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2020,15 +2020,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2072,8 +2072,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2125,27 +2125,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2155,11 +2155,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2187,8 +2197,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2212,7 +2222,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2224,11 +2234,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2255,12 +2265,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2275,12 +2285,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2310,7 +2320,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2325,7 +2335,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2335,12 +2345,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2384,7 +2394,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2399,7 +2409,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2413,7 +2423,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2423,15 +2433,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2443,7 +2462,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2455,7 +2474,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2484,16 +2503,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2505,7 +2524,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2553,7 +2572,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2561,11 +2580,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2577,11 +2596,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2589,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2601,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2617,11 +2636,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2629,11 +2648,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2641,15 +2660,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2665,7 +2684,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2681,11 +2700,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2713,7 +2732,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2725,27 +2744,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2767,7 +2786,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2775,15 +2794,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2813,11 +2832,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2827,7 +2846,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2839,7 +2858,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2855,11 +2874,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2869,7 +2888,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2896,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2885,7 +2904,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2907,16 +2926,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2937,11 +2956,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2955,11 +2974,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3016,12 +3035,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3066,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3055,15 +3074,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3073,18 +3092,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3115,13 +3134,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3134,7 +3153,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3187,7 +3206,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3207,11 +3226,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3231,7 +3250,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3298,7 +3317,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3410,11 +3429,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3442,11 +3461,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3505,7 +3524,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3518,15 +3537,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3544,11 +3563,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3565,11 +3584,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3577,7 +3596,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3667,7 +3686,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3691,23 +3710,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3865,13 +3884,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3897,8 +3916,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3907,20 +3926,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3931,19 +3950,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3974,40 +3993,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4015,7 +4034,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4040,16 +4059,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4078,7 +4097,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4086,16 +4105,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4112,12 +4131,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4145,7 +4164,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4169,8 +4188,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4178,7 +4197,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4188,22 +4207,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4233,22 +4252,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4278,11 +4297,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4318,19 +4337,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4342,15 +4361,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4360,11 +4379,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4373,11 +4392,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4389,11 +4408,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4402,11 +4421,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4432,11 +4451,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4448,9 +4467,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4462,11 +4481,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4474,7 +4493,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4512,20 +4531,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4533,7 +4552,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4541,7 +4560,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4560,32 +4579,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4602,7 +4621,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,11 +4657,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4656,7 +4675,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4672,7 +4691,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4712,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4702,7 +4721,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4715,7 +4734,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4746,20 +4765,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4768,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4797,11 +4816,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4814,7 +4833,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,8 +4843,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4840,7 +4859,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4871,7 +4890,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4891,7 +4910,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4899,11 +4918,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4915,11 +4934,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4927,15 +4946,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4955,7 +4974,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4984,11 +5003,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5000,15 +5019,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5022,7 +5041,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5045,7 +5064,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5060,11 +5079,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5126,17 +5145,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5161,7 +5180,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5199,7 +5218,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5207,15 +5226,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5224,7 +5243,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5233,15 +5252,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5263,11 +5282,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5276,11 +5295,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5289,11 +5308,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5332,11 +5351,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5384,11 +5403,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5397,7 +5416,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5421,7 +5440,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,11 +5452,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5445,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5457,7 +5476,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5473,23 +5492,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5497,7 +5516,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5517,7 +5536,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5538,11 +5557,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5550,7 +5569,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5558,7 +5577,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5574,15 +5593,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5602,7 +5621,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5622,11 +5641,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5644,7 +5663,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5694,15 +5713,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5737,7 +5756,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5807,21 +5826,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5883,21 +5902,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5972,7 +5991,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5981,22 +6000,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6006,7 +6025,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6026,7 +6045,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6046,12 +6065,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6074,12 +6093,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6091,7 +6110,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6103,7 +6122,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6139,18 +6158,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6165,7 +6184,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6173,7 +6192,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6195,7 +6214,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6231,8 +6250,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6254,13 +6273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6273,7 +6292,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6287,13 +6306,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6303,7 +6322,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6318,7 +6337,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6330,15 +6349,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6346,23 +6365,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6382,7 +6401,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6398,7 +6417,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6410,11 +6429,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6422,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6434,7 +6453,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6450,11 +6469,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6467,7 +6486,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6481,7 +6500,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6490,27 +6509,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6537,15 +6556,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6572,7 +6591,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6605,7 +6624,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6631,22 +6650,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6755,8 +6774,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6766,7 +6785,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6786,15 +6805,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6818,45 +6837,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6885,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6897,12 +6916,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6924,11 +6943,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6948,13 +6967,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6962,56 +6981,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7037,19 +7056,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7062,7 +7081,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7097,49 +7116,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7150,52 +7169,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7248,7 +7267,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7256,15 +7275,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7363,7 +7382,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7371,7 +7390,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7382,13 +7401,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7397,13 +7416,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7426,20 +7445,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7555,7 +7574,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7564,7 +7583,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7572,7 +7591,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7622,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7615,7 +7634,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7623,7 +7642,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7634,7 +7653,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7740,7 +7759,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7748,13 +7767,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7788,16 +7807,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -150,7 +150,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -159,7 +159,7 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -369,7 +369,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -411,7 +411,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -540,7 +540,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -578,7 +578,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -679,17 +679,17 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(kein Wert)"
 
@@ -727,7 +727,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -751,7 +751,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -775,7 +775,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -783,7 +783,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -838,7 +838,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
@@ -863,7 +863,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -885,11 +885,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -897,12 +897,12 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 #, fuzzy
 msgid "Add instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -952,11 +952,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1043,7 +1043,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1071,7 +1071,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Attach network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -1092,11 +1092,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1135,7 +1135,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1148,22 +1148,22 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1172,8 +1172,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1207,15 +1207,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1298,7 +1298,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1323,15 +1323,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1388,7 +1388,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1407,22 +1407,22 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -1432,38 +1432,38 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1471,14 +1471,14 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1494,16 +1494,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1534,24 +1534,24 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1607,15 +1607,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1625,13 +1625,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1744,7 +1744,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1791,7 +1791,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1805,12 +1805,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1830,11 +1830,11 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network zones"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1854,7 +1854,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1879,18 +1879,18 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1906,11 +1906,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1971,11 +1971,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -1994,11 +1994,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2039,18 +2039,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2059,38 +2059,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2102,16 +2102,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2122,60 +2122,60 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, fuzzy, c-format
 msgid "Device %s added to %s"
 msgstr "Gerät %s wurde zu %s hinzugefügt\n"
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, fuzzy, c-format
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
@@ -2185,25 +2185,25 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2230,7 +2230,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2287,12 +2287,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display network zones from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2306,11 +2306,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2342,7 +2342,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2355,7 +2355,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2374,7 +2374,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2389,7 +2389,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2399,16 +2399,16 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network ACL configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2428,7 +2428,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2458,8 +2458,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2512,27 +2512,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2542,7 +2542,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2551,7 +2551,17 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2583,8 +2593,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2608,7 +2618,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2623,12 +2633,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2655,12 +2665,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2675,12 +2685,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2710,7 +2720,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2725,7 +2735,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2735,12 +2745,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2784,7 +2794,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2799,7 +2809,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2813,7 +2823,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2826,15 +2836,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2846,7 +2865,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2859,7 +2878,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2888,16 +2907,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2909,7 +2928,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2958,7 +2977,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2967,11 +2986,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2983,12 +3002,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2998,7 +3017,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Get the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3012,7 +3031,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3030,12 +3049,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -3044,12 +3063,12 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3059,16 +3078,16 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3088,7 +3107,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3106,11 +3125,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3138,7 +3157,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3151,27 +3170,27 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3193,7 +3212,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3202,16 +3221,16 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -3241,11 +3260,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3255,7 +3274,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3268,7 +3287,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3284,11 +3303,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -3298,7 +3317,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3307,7 +3326,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3315,7 +3334,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3339,16 +3358,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3369,12 +3388,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3388,11 +3407,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3450,12 +3469,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid format: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3481,7 +3500,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -3490,16 +3509,16 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -3509,19 +3528,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3556,13 +3575,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3575,7 +3594,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3613,7 +3632,7 @@ msgstr "Architektur: %s\n"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3632,7 +3651,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3654,11 +3673,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3680,7 +3699,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3748,7 +3767,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 #, fuzzy
 msgid "List instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3879,11 +3898,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "List permissions"
 msgstr "Aliasse:\n"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3913,12 +3932,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3978,7 +3997,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3991,17 +4010,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 #, fuzzy
 msgid "Lower device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 #, fuzzy
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4010,7 +4029,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4024,11 +4043,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -4045,11 +4064,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -4057,7 +4076,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4156,7 +4175,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4185,27 +4204,27 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4382,14 +4401,14 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4420,8 +4439,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4432,21 +4451,21 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 #, fuzzy
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
@@ -4459,19 +4478,19 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4505,44 +4524,44 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4551,7 +4570,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4576,17 +4595,17 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4617,7 +4636,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4627,16 +4646,16 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4654,12 +4673,12 @@ msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4687,7 +4706,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4711,8 +4730,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4720,7 +4739,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4730,22 +4749,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
@@ -4775,22 +4794,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4820,12 +4839,12 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 #, fuzzy
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -4863,21 +4882,21 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4890,15 +4909,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, fuzzy, c-format
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
@@ -4908,12 +4927,12 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4922,11 +4941,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4938,11 +4957,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4951,11 +4970,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4981,11 +5000,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4997,9 +5016,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5011,11 +5030,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -5023,7 +5042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -5065,20 +5084,20 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5086,7 +5105,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -5094,7 +5113,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -5113,32 +5132,32 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5158,7 +5177,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5197,11 +5216,11 @@ msgstr ""
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5215,7 +5234,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5231,7 +5250,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5252,7 +5271,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5261,7 +5280,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5274,7 +5293,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5306,22 +5325,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5330,7 +5349,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5361,11 +5380,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5379,7 +5398,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5389,8 +5408,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -5405,7 +5424,7 @@ msgstr "entfernte Instanz %s existiert als <%s>"
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5436,7 +5455,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5460,7 +5479,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5468,12 +5487,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5488,12 +5507,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5502,17 +5521,17 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5535,7 +5554,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5567,11 +5586,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5585,17 +5604,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5609,7 +5628,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5633,7 +5652,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5650,12 +5669,12 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5721,17 +5740,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5756,7 +5775,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5796,7 +5815,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5806,16 +5825,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5824,7 +5843,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5833,16 +5852,16 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5865,11 +5884,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5878,12 +5897,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5892,12 +5911,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5939,11 +5958,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5994,12 +6013,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6008,7 +6027,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6017,7 +6036,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
@@ -6026,7 +6045,7 @@ msgstr "Setzt die gid der Datei beim Übertragen"
 msgid "Set the file's perms on create"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
@@ -6035,7 +6054,7 @@ msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 msgid "Set the file's uid on create"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -6047,12 +6066,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6062,7 +6081,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -6076,7 +6095,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -6094,24 +6113,24 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -6119,7 +6138,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Profil %s erstellt\n"
@@ -6141,7 +6160,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
@@ -6164,11 +6183,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6178,7 +6197,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -6188,7 +6207,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -6206,16 +6225,16 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network ACL log"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Profil %s erstellt\n"
@@ -6240,7 +6259,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6262,12 +6281,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -6286,7 +6305,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6339,16 +6358,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "State"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
@@ -6458,22 +6477,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -6537,22 +6556,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6593,7 +6612,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 #, fuzzy
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
@@ -6631,7 +6650,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6641,22 +6660,22 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6666,7 +6685,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6686,7 +6705,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6706,12 +6725,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6734,13 +6753,13 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6753,7 +6772,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6766,7 +6785,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6804,18 +6823,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -6830,7 +6849,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6838,7 +6857,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6860,7 +6879,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6898,8 +6917,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6921,13 +6940,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6940,7 +6959,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6955,13 +6974,13 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6971,7 +6990,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6986,7 +7005,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -7001,16 +7020,16 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7020,26 +7039,26 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7064,7 +7083,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -7082,7 +7101,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7095,12 +7114,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7110,7 +7129,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7125,7 +7144,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -7143,12 +7162,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7161,7 +7180,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -7176,7 +7195,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7185,28 +7204,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 #, fuzzy
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7233,15 +7252,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -7272,7 +7291,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7310,7 +7329,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7340,7 +7359,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
@@ -7349,7 +7368,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7360,10 +7379,10 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7567,8 +7586,8 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7586,7 +7605,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7627,7 +7646,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7636,7 +7655,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7645,7 +7664,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7693,8 +7712,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7704,7 +7723,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7712,7 +7731,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7720,7 +7739,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -7728,7 +7747,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7736,7 +7755,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7744,7 +7763,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7752,7 +7771,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7760,7 +7779,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7769,7 +7788,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7831,7 +7850,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7857,7 +7876,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7867,7 +7886,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7914,7 +7933,7 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7923,7 +7942,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -7966,9 +7985,9 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7976,7 +7995,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -7992,7 +8011,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -8000,7 +8019,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -8008,9 +8027,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8018,7 +8037,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8026,7 +8045,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8036,8 +8055,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8045,7 +8064,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8053,7 +8072,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8063,13 +8082,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8077,7 +8096,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8127,7 +8146,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -8135,7 +8154,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -8143,7 +8162,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8151,7 +8170,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -8176,7 +8195,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8243,7 +8262,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8254,7 +8273,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8263,7 +8282,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8272,7 +8291,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8281,7 +8300,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8289,7 +8308,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8298,7 +8317,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8306,7 +8325,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8314,7 +8333,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8322,7 +8341,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8331,7 +8350,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -8350,7 +8369,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8359,7 +8378,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8367,7 +8386,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8375,8 +8394,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8384,7 +8403,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8392,7 +8411,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8400,7 +8419,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -8408,7 +8427,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8416,7 +8435,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8424,7 +8443,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8432,7 +8451,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8440,7 +8459,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8547,7 +8566,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8565,7 +8584,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8573,7 +8592,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8581,7 +8600,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8698,7 +8717,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8706,7 +8725,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8717,13 +8736,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8732,13 +8751,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8761,20 +8780,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8894,7 +8913,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8903,7 +8922,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8911,7 +8930,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8942,7 +8961,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8954,7 +8973,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8962,7 +8981,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8973,7 +8992,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -9079,7 +9098,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9087,13 +9106,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9127,16 +9146,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "  Χρήση δικτύου:"
@@ -618,11 +618,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -630,11 +630,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -683,11 +683,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -786,7 +786,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -794,7 +794,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -813,11 +813,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -867,21 +867,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -890,8 +890,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -925,15 +925,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -945,7 +945,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1031,15 +1031,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1048,12 +1048,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1091,7 +1091,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1109,22 +1109,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1134,38 +1134,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1173,14 +1173,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1196,16 +1196,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1233,24 +1233,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1304,15 +1304,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1486,11 +1486,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -1508,11 +1508,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1552,18 +1552,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1579,11 +1579,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1591,7 +1591,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1640,11 +1640,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -1663,11 +1663,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1706,18 +1706,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1726,38 +1726,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1769,16 +1769,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1789,58 +1789,58 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1850,24 +1850,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1941,11 +1941,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1957,11 +1957,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1992,7 +1992,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2021,7 +2021,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2033,7 +2033,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2041,15 +2041,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2069,7 +2069,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit network zone record configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2098,8 +2098,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2151,27 +2151,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2181,11 +2181,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2213,8 +2223,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2238,7 +2248,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2250,11 +2260,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2281,12 +2291,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2301,12 +2311,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2336,7 +2346,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2351,7 +2361,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2361,12 +2371,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2410,7 +2420,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2425,7 +2435,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2439,7 +2449,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2449,15 +2459,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2469,7 +2488,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2500,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2510,16 +2529,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2531,7 +2550,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2579,7 +2598,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2587,11 +2606,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2603,12 +2622,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -2618,7 +2637,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2632,7 +2651,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2649,11 +2668,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2662,11 +2681,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2674,16 +2693,16 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2703,7 +2722,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2720,11 +2739,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2752,7 +2771,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2764,27 +2783,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2806,7 +2825,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2814,15 +2833,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2852,11 +2871,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2866,7 +2885,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2878,7 +2897,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2894,11 +2913,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2908,7 +2927,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2916,7 +2935,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2924,7 +2943,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2946,16 +2965,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2976,11 +2995,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2994,11 +3013,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3055,12 +3074,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3086,7 +3105,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3094,15 +3113,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3112,18 +3131,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3154,13 +3173,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3173,7 +3192,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3210,7 +3229,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3226,7 +3245,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3246,11 +3265,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -3272,7 +3291,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3339,7 +3358,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3451,11 +3470,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3483,11 +3502,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3546,7 +3565,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3559,15 +3578,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3575,7 +3594,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3585,11 +3604,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3606,11 +3625,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3618,7 +3637,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3710,7 +3729,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "  Χρήση δικτύου:"
@@ -3735,25 +3754,25 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -3923,14 +3942,14 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3960,8 +3979,8 @@ msgstr "  Χρήση δικτύου:"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3971,20 +3990,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3995,19 +4014,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4039,41 +4058,41 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4106,16 +4125,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4144,7 +4163,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4152,16 +4171,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4178,12 +4197,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4211,7 +4230,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4235,8 +4254,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4244,7 +4263,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4254,22 +4273,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4299,22 +4318,22 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network Zone %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -4344,12 +4363,12 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 #, fuzzy
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -4386,19 +4405,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4410,15 +4429,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4428,11 +4447,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4441,11 +4460,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4457,11 +4476,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4470,11 +4489,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4500,11 +4519,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4516,9 +4535,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4530,11 +4549,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4542,7 +4561,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4581,20 +4600,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4602,7 +4621,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4610,7 +4629,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4629,32 +4648,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4671,7 +4690,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4707,11 +4726,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4725,7 +4744,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4741,7 +4760,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4762,7 +4781,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4771,7 +4790,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4784,7 +4803,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4815,20 +4834,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4837,7 +4856,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4866,11 +4885,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4883,7 +4902,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4893,8 +4912,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4909,7 +4928,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4940,7 +4959,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4961,7 +4980,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4969,12 +4988,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "  Χρήση δικτύου:"
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4999,16 +5018,16 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5029,7 +5048,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5058,11 +5077,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5074,15 +5093,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5096,7 +5115,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5138,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5134,11 +5153,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5201,17 +5220,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5236,7 +5255,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5274,7 +5293,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5283,15 +5302,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5300,7 +5319,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5309,15 +5328,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5339,11 +5358,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5352,12 +5371,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5366,12 +5385,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5413,11 +5432,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5466,11 +5485,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5479,7 +5498,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5487,7 +5506,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5495,7 +5514,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5503,7 +5522,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5515,12 +5534,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -5530,7 +5549,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5544,7 +5563,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5561,23 +5580,23 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5585,7 +5604,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5606,7 +5625,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5628,11 +5647,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5640,7 +5659,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5648,7 +5667,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5665,15 +5684,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5698,7 +5717,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show network zone record configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5720,11 +5739,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5742,7 +5761,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5793,15 +5812,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5836,7 +5855,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5906,21 +5925,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5982,21 +6001,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6034,7 +6053,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -6071,7 +6090,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6080,22 +6099,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6105,7 +6124,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6125,7 +6144,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6145,12 +6164,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6173,12 +6192,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6190,7 +6209,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
@@ -6203,7 +6222,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6239,18 +6258,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6265,7 +6284,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6273,7 +6292,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6295,7 +6314,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6331,8 +6350,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6354,13 +6373,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6373,7 +6392,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6387,13 +6406,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6403,7 +6422,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6418,7 +6437,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6431,15 +6450,15 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6447,26 +6466,26 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "  Χρήση δικτύου:"
@@ -6491,7 +6510,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6508,7 +6527,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6520,12 +6539,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -6535,7 +6554,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "  Χρήση δικτύου:"
@@ -6550,7 +6569,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6567,11 +6586,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6584,7 +6603,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6598,7 +6617,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6607,27 +6626,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6654,15 +6673,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6689,7 +6708,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6722,7 +6741,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6748,22 +6767,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6872,8 +6891,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6883,7 +6902,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6903,15 +6922,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6935,45 +6954,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7002,7 +7021,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7014,12 +7033,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7041,11 +7060,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -7065,13 +7084,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -7079,56 +7098,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7154,19 +7173,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7179,7 +7198,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7214,49 +7233,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7267,52 +7286,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7365,7 +7384,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7373,15 +7392,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7480,7 +7499,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7488,7 +7507,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7499,13 +7518,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7514,13 +7533,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7543,20 +7562,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7672,7 +7691,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7681,7 +7700,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7689,7 +7708,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7720,7 +7739,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7732,7 +7751,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7740,7 +7759,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7751,7 +7770,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7857,7 +7876,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7865,13 +7884,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7905,16 +7924,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -155,7 +155,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -163,7 +163,7 @@ msgstr ""
 "### Esta es una representación YAML del grupo de clústeres.\n"
 "### Cualquier línea que empiece con un '#' será ignorada."
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -371,7 +371,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -410,7 +410,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -574,7 +574,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -667,17 +667,17 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -714,7 +714,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
@@ -861,11 +861,11 @@ msgstr "Perfil %s creado"
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -873,11 +873,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -927,11 +927,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1014,7 +1014,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -1059,11 +1059,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1101,7 +1101,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1113,21 +1113,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1136,8 +1136,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1172,15 +1172,15 @@ msgstr "Ambas: todas y el nombre del contenedor dado"
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1192,7 +1192,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1281,15 +1281,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1298,12 +1298,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1342,7 +1342,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1361,22 +1361,22 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr "Versión del cliente: %s\n"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -1386,38 +1386,38 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1425,14 +1425,14 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1448,16 +1448,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1487,24 +1487,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1558,15 +1558,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1574,12 +1574,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1593,7 +1593,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1692,7 +1692,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1736,7 +1736,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1748,11 +1748,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Perfil %s creado"
@@ -1770,11 +1770,11 @@ msgstr "Perfil %s creado"
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1815,18 +1815,18 @@ msgstr "Creando el contenedor"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1842,11 +1842,11 @@ msgstr "CONTROLADOR"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
@@ -1927,11 +1927,11 @@ msgstr "Perfil %s creado"
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1948,7 +1948,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1970,18 +1970,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1990,38 +1990,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2033,16 +2033,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2053,58 +2053,58 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2114,25 +2114,25 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2207,12 +2207,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display network zones from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2226,11 +2226,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2262,7 +2262,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2274,7 +2274,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2291,7 +2291,7 @@ msgstr "Perfil %s creado"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2311,15 +2311,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2339,7 +2339,7 @@ msgstr "Perfil %s creado"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2360,7 +2360,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2368,8 +2368,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2421,27 +2421,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2451,12 +2451,22 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -2484,8 +2494,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2510,7 +2520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2524,11 +2534,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2555,12 +2565,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2575,12 +2585,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2610,7 +2620,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2625,7 +2635,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2635,12 +2645,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2684,7 +2694,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2699,7 +2709,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2713,7 +2723,7 @@ msgstr "Acepta certificado"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
@@ -2723,15 +2733,24 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2743,7 +2762,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2756,7 +2775,7 @@ msgstr "Creando el contenedor"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2785,16 +2804,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2806,7 +2825,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2854,7 +2873,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
@@ -2863,11 +2882,11 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2879,12 +2898,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
@@ -2894,7 +2913,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Get the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2908,7 +2927,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2925,11 +2944,11 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2938,11 +2957,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2950,16 +2969,16 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
@@ -2979,7 +2998,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2996,11 +3015,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3028,7 +3047,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3041,27 +3060,27 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3083,7 +3102,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3092,16 +3111,16 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expira: %s"
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -3131,11 +3150,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3145,7 +3164,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3157,7 +3176,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3173,11 +3192,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3187,7 +3206,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3195,7 +3214,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3203,7 +3222,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3226,16 +3245,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3257,11 +3276,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3276,12 +3295,12 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3338,12 +3357,12 @@ msgstr "Versión del cliente: %s\n"
 msgid "Invalid format: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3369,7 +3388,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3378,15 +3397,15 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3396,19 +3415,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3439,13 +3458,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,7 +3477,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3496,7 +3515,7 @@ msgstr "Arquitectura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3515,7 +3534,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
@@ -3537,11 +3556,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nombre del contenedor es: %s"
@@ -3563,7 +3582,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3631,7 +3650,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3746,11 +3765,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "List permissions"
 msgstr "Aliases:"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3779,11 +3798,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3843,7 +3862,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3856,15 +3875,15 @@ msgstr ""
 msgid "Log:"
 msgstr "Registro:"
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3873,7 +3892,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expira: %s"
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3883,11 +3902,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3904,11 +3923,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3916,7 +3935,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4008,7 +4027,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Nombre del Miembro del Cluster"
@@ -4033,25 +4052,25 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nombre del contenedor es: %s"
@@ -4221,14 +4240,14 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4259,8 +4278,8 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
@@ -4271,21 +4290,21 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -4297,19 +4316,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4343,42 +4362,42 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4388,7 +4407,7 @@ msgstr "%s no es un directorio"
 msgid "Missing target network"
 msgstr "%s no es un directorio"
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4413,16 +4432,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4452,7 +4471,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4460,16 +4479,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4486,12 +4505,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4519,7 +4538,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4543,8 +4562,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4552,7 +4571,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4562,22 +4581,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4607,22 +4626,22 @@ msgstr "Perfil %s creado"
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
@@ -4652,11 +4671,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4692,19 +4711,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4716,15 +4735,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4734,11 +4753,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4747,11 +4766,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4763,11 +4782,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4776,11 +4795,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4806,11 +4825,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4822,9 +4841,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4836,11 +4855,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4848,7 +4867,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -4887,20 +4906,20 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4908,7 +4927,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4916,7 +4935,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4935,32 +4954,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -4980,7 +4999,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5017,11 +5036,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5035,7 +5054,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5051,7 +5070,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5072,7 +5091,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5081,7 +5100,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5094,7 +5113,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5125,20 +5144,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5147,7 +5166,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5178,11 +5197,11 @@ msgstr "Creando el contenedor"
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5195,7 +5214,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5205,8 +5224,8 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -5221,7 +5240,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5253,7 +5272,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
@@ -5275,7 +5294,7 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5283,12 +5302,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
@@ -5301,11 +5320,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5313,16 +5332,16 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5343,7 +5362,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5373,11 +5392,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5389,15 +5408,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5411,7 +5430,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5435,7 +5454,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -5452,11 +5471,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -5521,17 +5540,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5556,7 +5575,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5594,7 +5613,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
@@ -5604,15 +5623,15 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5621,7 +5640,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5630,15 +5649,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5660,11 +5679,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5673,12 +5692,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5687,12 +5706,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5734,11 +5753,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5787,11 +5806,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5800,7 +5819,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5808,7 +5827,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5816,7 +5835,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5824,7 +5843,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5836,12 +5855,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -5851,7 +5870,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5865,7 +5884,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5882,23 +5901,23 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5906,7 +5925,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Perfil %s creado"
@@ -5927,7 +5946,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5949,11 +5968,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Dispositivo %s añadido a %s"
@@ -5962,7 +5981,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5970,7 +5989,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5987,15 +6006,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Perfil %s creado"
@@ -6020,7 +6039,7 @@ msgstr "Perfil %s creado"
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6042,11 +6061,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6064,7 +6083,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6115,15 +6134,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -6159,7 +6178,7 @@ msgstr ""
 msgid "State"
 msgstr "Auto actualización: %s"
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
@@ -6229,21 +6248,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6305,21 +6324,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6359,7 +6378,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -6396,7 +6415,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6405,22 +6424,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6430,7 +6449,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6450,7 +6469,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6470,12 +6489,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6498,12 +6517,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6515,7 +6534,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
@@ -6529,7 +6548,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6565,18 +6584,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -6591,7 +6610,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6599,7 +6618,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6621,7 +6640,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6659,8 +6678,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -6682,13 +6701,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6701,7 +6720,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6715,13 +6734,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6731,7 +6750,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6746,7 +6765,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
@@ -6760,15 +6779,15 @@ msgstr "Perfil %s creado"
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6776,26 +6795,26 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
@@ -6820,7 +6839,7 @@ msgstr "Perfil %s creado"
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6837,7 +6856,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6849,12 +6868,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -6864,7 +6883,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Perfil %s creado"
@@ -6879,7 +6898,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6896,11 +6915,11 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6913,7 +6932,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6928,7 +6947,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6937,27 +6956,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6984,15 +7003,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -7019,7 +7038,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7052,7 +7071,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7078,13 +7097,13 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7092,10 +7111,10 @@ msgid ""
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7226,8 +7245,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7239,7 +7258,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7264,17 +7283,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7304,54 +7323,54 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7386,7 +7405,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7401,13 +7420,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7434,12 +7453,12 @@ msgid ""
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7464,14 +7483,14 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7481,65 +7500,65 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7571,22 +7590,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7602,7 +7621,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7645,59 +7664,59 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -7710,63 +7729,63 @@ msgid ""
 "[<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7832,7 +7851,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7842,17 +7861,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7955,7 +7974,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7963,7 +7982,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7974,13 +7993,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7989,13 +8008,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8018,20 +8037,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8147,7 +8166,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8156,7 +8175,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8164,7 +8183,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8195,7 +8214,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8207,7 +8226,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8215,7 +8234,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8226,7 +8245,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8332,7 +8351,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8340,13 +8359,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8380,16 +8399,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -148,7 +148,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -161,7 +161,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -379,7 +379,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -421,7 +421,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -577,7 +577,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -676,17 +676,17 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -722,7 +722,7 @@ msgstr "--console fonctionne seulement avec une instance seule"
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -742,7 +742,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -766,7 +766,7 @@ msgstr "<ancien alias> <nouvel alias>"
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
@@ -775,7 +775,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
@@ -859,7 +859,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -881,11 +881,11 @@ msgstr "Clé de configuration invalide"
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -893,12 +893,12 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Création du conteneur"
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -957,11 +957,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
@@ -1047,7 +1047,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Création du conteneur"
@@ -1075,7 +1075,7 @@ msgstr "Création du conteneur"
 msgid "Attach network interfaces to instances"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -1095,11 +1095,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1151,22 +1151,22 @@ msgstr "Rendre l'image publique"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1175,8 +1175,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1210,15 +1210,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Créé : %s"
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1319,16 +1319,16 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1338,12 +1338,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1401,22 +1401,22 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -1426,38 +1426,38 @@ msgstr "Profil %s ajouté à %s"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1465,14 +1465,14 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1488,16 +1488,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 #, fuzzy
 msgid ""
 "Command line client for LXD\n"
@@ -1536,24 +1536,24 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1609,15 +1609,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1627,13 +1627,13 @@ msgstr "Copie de l'image : %s"
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1647,7 +1647,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1748,7 +1748,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1811,7 +1811,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1825,12 +1825,12 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Copie de l'image : %s"
@@ -1850,11 +1850,11 @@ msgstr "Copie de l'image : %s"
 msgid "Create new network zones"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
@@ -1874,7 +1874,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1899,18 +1899,18 @@ msgstr "Création du conteneur"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1926,11 +1926,11 @@ msgstr "PILOTE"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1939,7 +1939,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1995,11 +1995,11 @@ msgstr "Copie de l'image : %s"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
@@ -2019,11 +2019,11 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -2041,7 +2041,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2065,18 +2065,18 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2085,38 +2085,38 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2128,16 +2128,16 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2148,59 +2148,59 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Périphérique %s ajouté à %s"
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
@@ -2210,25 +2210,25 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2307,12 +2307,12 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display network zones from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2327,11 +2327,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2363,7 +2363,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2376,7 +2376,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2395,7 +2395,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2410,7 +2410,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2420,16 +2420,16 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network ACL configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2449,7 +2449,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2480,8 +2480,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2534,27 +2534,27 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2564,7 +2564,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2576,7 +2576,17 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2613,8 +2623,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2640,7 +2650,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2655,12 +2665,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2688,12 +2698,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2708,12 +2718,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2743,7 +2753,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2758,7 +2768,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2768,12 +2778,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2818,7 +2828,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2833,7 +2843,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2848,7 +2858,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2858,15 +2868,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2879,7 +2898,7 @@ msgstr "Forcer l'allocation d'un pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2894,7 +2913,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of running instances"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -2923,16 +2942,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2944,7 +2963,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2992,7 +3011,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -3001,11 +3020,11 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -3017,12 +3036,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
@@ -3032,7 +3051,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3046,7 +3065,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3064,12 +3083,12 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -3078,12 +3097,12 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3093,17 +3112,17 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3123,7 +3142,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3142,11 +3161,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -3188,27 +3207,27 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 #, fuzzy
 msgid "ID"
 msgstr "PID"
@@ -3231,7 +3250,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3240,16 +3259,16 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expire : %s"
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -3279,11 +3298,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3296,7 +3315,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3309,7 +3328,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3326,11 +3345,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
@@ -3340,7 +3359,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3350,7 +3369,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3358,7 +3377,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3383,16 +3402,16 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3414,12 +3433,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3434,12 +3453,12 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3496,12 +3515,12 @@ msgstr "Afficher la version du client"
 msgid "Invalid format: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3527,7 +3546,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -3536,16 +3555,16 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -3555,19 +3574,19 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3599,13 +3618,13 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3618,7 +3637,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3656,7 +3675,7 @@ msgstr "Architecture : %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3675,7 +3694,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3697,11 +3716,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nom du réseau"
@@ -3723,7 +3742,7 @@ msgstr "Nom du réseau"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3791,7 +3810,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 #, fuzzy
 msgid "List instance devices"
 msgstr "Création du conteneur"
@@ -3968,11 +3987,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "List permissions"
 msgstr "Alias :"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -4002,12 +4021,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4067,7 +4086,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4080,17 +4099,17 @@ msgstr ""
 msgid "Log:"
 msgstr "Journal : "
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 #, fuzzy
 msgid "Lower device"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 #, fuzzy
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4099,7 +4118,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expire : %s"
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4109,11 +4128,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -4130,11 +4149,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -4142,7 +4161,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4240,7 +4259,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -4270,27 +4289,27 @@ msgstr "Copie de l'image : %s"
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nom du réseau"
@@ -4468,14 +4487,14 @@ msgstr "Résumé manquant."
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4506,8 +4525,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4518,21 +4537,21 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 #, fuzzy
 msgid "Missing name"
 msgstr "Résumé manquant."
@@ -4545,19 +4564,19 @@ msgstr "Résumé manquant."
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4592,44 +4611,44 @@ msgstr "Résumé manquant."
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4639,7 +4658,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "Missing target network"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 #, fuzzy
 msgid "Mode"
 msgstr "Publié : %s"
@@ -4665,18 +4684,18 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4707,7 +4726,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -4717,16 +4736,16 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4744,12 +4763,12 @@ msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr "NOM"
 
@@ -4777,7 +4796,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4801,8 +4820,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4811,7 +4830,7 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4821,22 +4840,22 @@ msgstr "Nom : %s"
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
@@ -4866,22 +4885,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4911,12 +4930,12 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 #, fuzzy
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -4955,20 +4974,20 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4981,15 +5000,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4999,12 +5018,12 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -5015,13 +5034,13 @@ msgid ""
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -5036,13 +5055,13 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -5052,11 +5071,11 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5083,11 +5102,11 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -5099,9 +5118,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5113,11 +5132,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -5126,7 +5145,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -5168,20 +5187,20 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -5190,7 +5209,7 @@ msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -5198,7 +5217,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -5217,32 +5236,32 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -5262,7 +5281,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
@@ -5300,11 +5319,11 @@ msgstr ""
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5318,7 +5337,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5334,7 +5353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5355,7 +5374,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5364,7 +5383,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5377,7 +5396,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5409,22 +5428,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5433,7 +5452,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5465,12 +5484,12 @@ msgstr "Création du conteneur"
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -5485,7 +5504,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5495,8 +5514,8 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
@@ -5511,7 +5530,7 @@ msgstr "le serveur distant %s existe en tant que <%s>"
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -5543,7 +5562,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5567,7 +5586,7 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5575,12 +5594,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5595,12 +5614,12 @@ msgstr "Création du conteneur"
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5609,17 +5628,17 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
@@ -5643,7 +5662,7 @@ msgstr "Création du conteneur"
 msgid "Remove trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5675,11 +5694,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5692,17 +5711,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5716,7 +5735,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5741,7 +5760,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5774,12 +5793,12 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5845,17 +5864,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr "ÉTAT"
@@ -5883,7 +5902,7 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5923,7 +5942,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -5933,16 +5952,16 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5951,7 +5970,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5960,16 +5979,16 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5992,12 +6011,12 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6006,12 +6025,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6020,12 +6039,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6067,12 +6086,12 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6123,12 +6142,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6137,7 +6156,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6146,7 +6165,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
@@ -6155,7 +6174,7 @@ msgstr "Définir le gid du fichier lors de l'envoi"
 msgid "Set the file's perms on create"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
@@ -6164,7 +6183,7 @@ msgstr "Définir les permissions du fichier lors de l'envoi"
 msgid "Set the file's uid on create"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -6176,12 +6195,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -6191,7 +6210,7 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -6205,7 +6224,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -6223,24 +6242,24 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -6248,7 +6267,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Afficher la configuration étendue"
@@ -6270,7 +6289,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
@@ -6293,11 +6312,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6307,7 +6326,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -6317,7 +6336,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -6337,17 +6356,17 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network ACL log"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Afficher la configuration étendue"
@@ -6372,7 +6391,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
@@ -6396,12 +6415,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -6421,7 +6440,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -6474,16 +6493,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6520,7 +6539,7 @@ msgstr "Démarrage de %s"
 msgid "State"
 msgstr "État : %s"
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
@@ -6594,22 +6613,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -6675,22 +6694,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6728,7 +6747,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 #, fuzzy
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
@@ -6773,7 +6792,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
@@ -6783,22 +6802,22 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6808,7 +6827,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6828,7 +6847,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6848,12 +6867,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6876,12 +6895,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
@@ -6893,7 +6912,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6907,7 +6926,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6945,7 +6964,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6953,12 +6972,12 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -6973,7 +6992,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7003,7 +7022,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -7042,8 +7061,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -7065,13 +7084,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -7084,7 +7103,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7099,13 +7118,13 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7115,7 +7134,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7130,7 +7149,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -7145,16 +7164,16 @@ msgstr "Clé de configuration invalide"
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7164,27 +7183,27 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
@@ -7209,7 +7228,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7229,7 +7248,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7242,12 +7261,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -7257,7 +7276,7 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Nom du réseau"
@@ -7272,7 +7291,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -7290,12 +7309,12 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7308,7 +7327,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -7323,7 +7342,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7332,28 +7351,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 #, fuzzy
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7381,15 +7400,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -7417,7 +7436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7455,7 +7474,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7485,7 +7504,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
@@ -7494,7 +7513,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7505,10 +7524,10 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7727,8 +7746,8 @@ msgstr ""
 "(configuration, instantanés, …)."
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7746,7 +7765,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7790,7 +7809,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7802,7 +7821,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7814,7 +7833,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7862,8 +7881,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7876,7 +7895,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7884,7 +7903,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7892,7 +7911,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -7900,7 +7919,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7908,7 +7927,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7916,7 +7935,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7924,7 +7943,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7932,7 +7951,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7944,7 +7963,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -8021,7 +8040,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -8053,7 +8072,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -8066,7 +8085,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8125,7 +8144,7 @@ msgstr ""
 "(configuration, instantanés, …)."
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -8137,7 +8156,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -8189,9 +8208,9 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8199,7 +8218,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -8215,7 +8234,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -8223,7 +8242,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -8231,9 +8250,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8241,7 +8260,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8249,7 +8268,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8259,8 +8278,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8268,7 +8287,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8276,7 +8295,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8286,13 +8305,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8300,7 +8319,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8350,7 +8369,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -8358,7 +8377,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -8366,7 +8385,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8374,7 +8393,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -8399,7 +8418,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8466,7 +8485,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8480,7 +8499,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8492,7 +8511,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8504,7 +8523,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8516,7 +8535,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8524,7 +8543,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8536,7 +8555,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8544,7 +8563,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8552,7 +8571,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8560,7 +8579,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8572,7 +8591,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -8591,7 +8610,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8603,7 +8622,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8611,7 +8630,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8619,8 +8638,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8628,7 +8647,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8636,7 +8655,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8644,7 +8663,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -8652,7 +8671,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8660,7 +8679,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8668,7 +8687,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8676,7 +8695,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8684,7 +8703,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8797,7 +8816,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8821,7 +8840,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8829,7 +8848,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8837,7 +8856,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8961,7 +8980,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8969,7 +8988,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8980,13 +8999,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8995,13 +9014,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -9024,20 +9043,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9175,7 +9194,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -9184,7 +9203,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -9192,7 +9211,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9223,7 +9242,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9235,7 +9254,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -9243,7 +9262,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -9254,7 +9273,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -9360,7 +9379,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9368,13 +9387,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9409,16 +9428,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,13 +107,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -517,7 +517,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -617,11 +617,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -629,11 +629,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -682,11 +682,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -784,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -865,21 +865,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -888,8 +888,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1028,15 +1028,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,38 +1131,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1230,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1301,15 +1301,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1482,11 +1482,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1502,11 +1502,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,18 +1546,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1633,11 +1633,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1653,11 +1653,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1695,18 +1695,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1715,38 +1715,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1758,16 +1758,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1778,57 +1778,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1838,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1941,11 +1941,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1976,7 +1976,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1988,7 +1988,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2024,15 +2024,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2048,7 +2048,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2076,8 +2076,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2129,27 +2129,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2159,11 +2159,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2191,8 +2201,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2226,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2238,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2259,12 +2269,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2279,12 +2289,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2314,7 +2324,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2329,7 +2339,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2339,12 +2349,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2388,7 +2398,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2403,7 +2413,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2417,7 +2427,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2427,15 +2437,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2447,7 +2466,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2459,7 +2478,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2488,16 +2507,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2509,7 +2528,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2557,7 +2576,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2565,11 +2584,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2581,11 +2600,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2593,7 +2612,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2605,7 +2624,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2621,11 +2640,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2633,11 +2652,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2645,15 +2664,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2669,7 +2688,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2685,11 +2704,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2717,7 +2736,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2729,27 +2748,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2771,7 +2790,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2779,15 +2798,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2817,11 +2836,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2831,7 +2850,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2843,7 +2862,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2859,11 +2878,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2873,7 +2892,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2900,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2889,7 +2908,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2911,16 +2930,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2941,11 +2960,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2959,11 +2978,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3020,12 +3039,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3051,7 +3070,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3059,15 +3078,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3077,18 +3096,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3119,13 +3138,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3138,7 +3157,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,7 +3194,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3191,7 +3210,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3211,11 +3230,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3235,7 +3254,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3302,7 +3321,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3414,11 +3433,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,11 +3465,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3509,7 +3528,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3522,15 +3541,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3538,7 +3557,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3548,11 +3567,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3569,11 +3588,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3581,7 +3600,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3671,7 +3690,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3695,23 +3714,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3869,13 +3888,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3901,8 +3920,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3911,20 +3930,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3935,19 +3954,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3978,40 +3997,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4019,7 +4038,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4044,16 +4063,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4082,7 +4101,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4090,16 +4109,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4116,12 +4135,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4149,7 +4168,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4173,8 +4192,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4182,7 +4201,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4192,22 +4211,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4237,22 +4256,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4282,11 +4301,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4322,19 +4341,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4346,15 +4365,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4364,11 +4383,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4377,11 +4396,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4393,11 +4412,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4406,11 +4425,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4455,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4452,9 +4471,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,11 +4485,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4478,7 +4497,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4516,20 +4535,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4537,7 +4556,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4545,7 +4564,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4564,32 +4583,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4606,7 +4625,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4642,11 +4661,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4660,7 +4679,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4676,7 +4695,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4716,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4706,7 +4725,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4738,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4750,20 +4769,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4772,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4801,11 +4820,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4818,7 +4837,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4828,8 +4847,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4844,7 +4863,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4875,7 +4894,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4895,7 +4914,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4903,11 +4922,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4919,11 +4938,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4931,15 +4950,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4959,7 +4978,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +5007,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5004,15 +5023,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5026,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5049,7 +5068,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5064,11 +5083,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5130,17 +5149,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5165,7 +5184,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5203,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5211,15 +5230,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5228,7 +5247,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5237,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5267,11 +5286,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5280,11 +5299,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5293,11 +5312,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5336,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5388,11 +5407,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5401,7 +5420,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5409,7 +5428,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5417,7 +5436,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5425,7 +5444,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5437,11 +5456,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5449,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5461,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5477,23 +5496,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5501,7 +5520,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5521,7 +5540,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5542,11 +5561,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5554,7 +5573,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5562,7 +5581,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5578,15 +5597,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5606,7 +5625,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5626,11 +5645,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5648,7 +5667,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5698,15 +5717,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5741,7 +5760,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5811,21 +5830,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5887,21 +5906,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5976,7 +5995,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5985,22 +6004,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6010,7 +6029,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6030,7 +6049,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6050,12 +6069,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6078,12 +6097,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6095,7 +6114,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6107,7 +6126,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6143,18 +6162,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6169,7 +6188,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6177,7 +6196,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6218,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6235,8 +6254,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6258,13 +6277,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6277,7 +6296,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6291,13 +6310,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6307,7 +6326,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6322,7 +6341,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6334,15 +6353,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6350,23 +6369,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6402,7 +6421,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6414,11 +6433,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6426,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6438,7 +6457,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6454,11 +6473,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6471,7 +6490,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6485,7 +6504,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6494,27 +6513,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6541,15 +6560,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6576,7 +6595,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6609,7 +6628,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6635,22 +6654,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6759,8 +6778,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6770,7 +6789,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6790,15 +6809,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6822,45 +6841,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6889,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6901,12 +6920,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6928,11 +6947,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6952,13 +6971,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6966,56 +6985,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7041,19 +7060,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7066,7 +7085,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7101,49 +7120,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7154,52 +7173,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7252,7 +7271,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7260,15 +7279,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7367,7 +7386,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7375,7 +7394,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7386,13 +7405,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7401,13 +7420,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7430,20 +7449,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7559,7 +7578,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7568,7 +7587,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7576,7 +7595,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7607,7 +7626,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7619,7 +7638,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7627,7 +7646,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7638,7 +7657,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7744,7 +7763,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7752,13 +7771,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7792,16 +7811,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -159,7 +159,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -173,7 +173,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -376,7 +376,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -415,7 +415,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -544,7 +544,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -579,7 +579,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -672,17 +672,17 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -718,7 +718,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -760,7 +760,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -819,7 +819,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -841,7 +841,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
@@ -863,11 +863,11 @@ msgstr "Il nome del container è: %s"
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -875,12 +875,12 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -929,11 +929,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -993,7 +993,7 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1042,7 +1042,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -1061,11 +1061,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1103,7 +1103,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1115,21 +1115,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1138,8 +1138,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1173,15 +1173,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1254,7 +1254,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1279,15 +1279,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1296,12 +1296,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1340,7 +1340,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1359,22 +1359,22 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1384,38 +1384,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1423,14 +1423,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1446,16 +1446,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1483,24 +1483,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1555,15 +1555,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1571,12 +1571,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1589,7 +1589,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1688,7 +1688,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1732,7 +1732,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1745,11 +1745,11 @@ msgstr "Creazione del container in corso"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Creazione del container in corso"
@@ -1767,11 +1767,11 @@ msgstr "Creazione del container in corso"
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1787,7 +1787,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1812,18 +1812,18 @@ msgstr "Creazione del container in corso"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1839,11 +1839,11 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1901,11 +1901,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
@@ -1923,11 +1923,11 @@ msgstr "Il nome del container è: %s"
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1944,7 +1944,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1966,18 +1966,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1986,38 +1986,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2029,16 +2029,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2049,58 +2049,58 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2110,25 +2110,25 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2205,12 +2205,12 @@ msgstr "Creazione del container in corso"
 msgid "Display network zones from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
@@ -2224,11 +2224,11 @@ msgstr "Creazione del container in corso"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2260,7 +2260,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2272,7 +2272,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2310,15 +2310,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
@@ -2337,7 +2337,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2366,8 +2366,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2419,27 +2419,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2449,12 +2449,22 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -2482,8 +2492,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2507,7 +2517,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2521,11 +2531,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2552,12 +2562,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2572,12 +2582,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2607,7 +2617,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2622,7 +2632,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2632,12 +2642,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2681,7 +2691,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2696,7 +2706,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2710,7 +2720,7 @@ msgstr "Accetta certificato"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2721,15 +2731,24 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2741,7 +2760,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2754,7 +2773,7 @@ msgstr "Creazione del container in corso"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2783,16 +2802,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2804,7 +2823,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2852,7 +2871,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -2861,11 +2880,11 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2877,11 +2896,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
@@ -2890,7 +2909,7 @@ msgstr "Creazione del container in corso"
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2904,7 +2923,7 @@ msgstr "Creazione del container in corso"
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2921,11 +2940,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2934,11 +2953,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2946,15 +2965,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2974,7 +2993,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2991,11 +3010,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3023,7 +3042,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3036,27 +3055,27 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3078,7 +3097,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3086,15 +3105,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -3124,11 +3143,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3138,7 +3157,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3151,7 +3170,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3167,11 +3186,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3181,7 +3200,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3189,7 +3208,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3197,7 +3216,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3220,16 +3239,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Creazione del container in corso"
@@ -3251,11 +3270,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3269,12 +3288,12 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3331,12 +3350,12 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid format: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3362,7 +3381,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -3371,16 +3390,16 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3390,19 +3409,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3433,13 +3452,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3452,7 +3471,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3490,7 +3509,7 @@ msgstr "Architettura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3509,7 +3528,7 @@ msgstr "Il nome del container è: %s"
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
@@ -3531,11 +3550,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Creazione del container in corso"
@@ -3557,7 +3576,7 @@ msgstr "Creazione del container in corso"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3625,7 +3644,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 #, fuzzy
 msgid "List instance devices"
 msgstr "Creazione del container in corso"
@@ -3741,11 +3760,11 @@ msgstr "Creazione del container in corso"
 msgid "List permissions"
 msgstr "Alias:"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3774,11 +3793,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3838,7 +3857,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3851,17 +3870,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 #, fuzzy
 msgid "Lower device"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 #, fuzzy
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3869,7 +3888,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3879,11 +3898,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3900,11 +3919,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3912,7 +3931,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4007,7 +4026,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -4033,25 +4052,25 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Creazione del container in corso"
@@ -4221,14 +4240,14 @@ msgstr "Il nome del container è: %s"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4259,8 +4278,8 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
@@ -4271,21 +4290,21 @@ msgstr "Il nome del container è: %s"
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -4297,19 +4316,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4343,42 +4362,42 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4387,7 +4406,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4412,16 +4431,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4451,7 +4470,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4459,16 +4478,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4485,12 +4504,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4518,7 +4537,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4542,8 +4561,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4551,7 +4570,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4561,22 +4580,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4606,22 +4625,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4651,11 +4670,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4691,19 +4710,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4716,15 +4735,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4734,12 +4753,12 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4748,11 +4767,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4764,11 +4783,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4777,11 +4796,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4807,11 +4826,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4823,9 +4842,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4837,11 +4856,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4849,7 +4868,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -4889,20 +4908,20 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4910,7 +4929,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4918,7 +4937,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4937,32 +4956,32 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4981,7 +5000,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5017,11 +5036,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5035,7 +5054,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5051,7 +5070,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5072,7 +5091,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5081,7 +5100,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5094,7 +5113,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5125,21 +5144,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5148,7 +5167,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5179,11 +5198,11 @@ msgstr "Creazione del container in corso"
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5196,7 +5215,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5206,8 +5225,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
@@ -5222,7 +5241,7 @@ msgstr "il remote %s esiste come %s"
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
@@ -5254,7 +5273,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
@@ -5276,7 +5295,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5284,12 +5303,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
@@ -5302,12 +5321,12 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5315,16 +5334,16 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5375,11 +5394,11 @@ msgstr "Creazione del container in corso"
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5391,15 +5410,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5437,7 +5456,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -5454,11 +5473,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -5523,17 +5542,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5558,7 +5577,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5596,7 +5615,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -5606,15 +5625,15 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5623,7 +5642,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5632,15 +5651,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5662,11 +5681,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5675,11 +5694,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5688,12 +5707,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5734,11 +5753,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5787,11 +5806,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5800,7 +5819,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5808,7 +5827,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5816,7 +5835,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5824,7 +5843,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5836,11 +5855,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -5849,7 +5868,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5863,7 +5882,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5880,23 +5899,23 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5904,7 +5923,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Il nome del container è: %s"
@@ -5925,7 +5944,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5947,11 +5966,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "errore di processamento degli alias %s\n"
@@ -5960,7 +5979,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5968,7 +5987,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5985,15 +6004,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Il nome del container è: %s"
@@ -6018,7 +6037,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6040,11 +6059,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6062,7 +6081,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6114,15 +6133,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -6159,7 +6178,7 @@ msgstr ""
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6229,21 +6248,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6306,22 +6325,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6359,7 +6378,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
@@ -6396,7 +6415,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
@@ -6406,22 +6425,22 @@ msgstr "il remote %s non esiste"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6431,7 +6450,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6451,7 +6470,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6471,12 +6490,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6499,12 +6518,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6516,7 +6535,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
@@ -6530,7 +6549,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6566,18 +6585,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6592,7 +6611,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6600,7 +6619,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6622,7 +6641,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6659,8 +6678,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6682,13 +6701,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6701,7 +6720,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6716,13 +6735,13 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6732,7 +6751,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6747,7 +6766,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6762,15 +6781,15 @@ msgstr "Il nome del container è: %s"
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6778,24 +6797,24 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
@@ -6819,7 +6838,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6836,7 +6855,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6848,11 +6867,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -6861,7 +6880,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6875,7 +6894,7 @@ msgstr "Creazione del container in corso"
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6892,11 +6911,11 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6909,7 +6928,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6924,7 +6943,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6933,28 +6952,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 #, fuzzy
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6981,15 +7000,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -7016,7 +7035,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7049,7 +7068,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7078,13 +7097,13 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7092,10 +7111,10 @@ msgid ""
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7226,8 +7245,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
@@ -7239,7 +7258,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7264,17 +7283,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7304,54 +7323,54 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
@@ -7386,7 +7405,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -7401,13 +7420,13 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7434,12 +7453,12 @@ msgid ""
 msgstr "Creazione del container in corso"
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
@@ -7464,14 +7483,14 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -7481,65 +7500,65 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7571,22 +7590,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7602,7 +7621,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7645,59 +7664,59 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -7710,63 +7729,63 @@ msgid ""
 "[<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -7832,7 +7851,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7842,17 +7861,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7955,7 +7974,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7963,7 +7982,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7974,13 +7993,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7989,13 +8008,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8018,20 +8037,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8147,7 +8166,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8156,7 +8175,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8164,7 +8183,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8195,7 +8214,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8207,7 +8226,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8215,7 +8234,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8226,7 +8245,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8332,7 +8351,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8340,13 +8359,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8381,16 +8400,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -142,7 +142,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -150,7 +150,7 @@ msgstr ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -409,7 +409,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -532,7 +532,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -568,7 +568,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -664,17 +664,17 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(none)"
 
@@ -709,7 +709,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -729,7 +729,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -750,7 +750,7 @@ msgstr "<old alias> <new alias>"
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
@@ -758,7 +758,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -810,7 +810,7 @@ msgstr "アクセスキー（空白の場合自動生成）"
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -832,7 +832,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスタグループからメンバを削除します"
@@ -853,11 +853,11 @@ msgstr "ネットワークゾーンレコードのエントリを追加します
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
@@ -865,11 +865,11 @@ msgstr "ロードバランサーにバックエンドを追加します"
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr "インスタンスにデバイスを追加します"
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 #, fuzzy
 msgid "Add member to group"
 msgstr "グループからメンバーを削除します"
@@ -938,11 +938,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
@@ -1001,7 +1001,7 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1023,7 +1023,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1041,7 +1041,7 @@ msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
@@ -1049,7 +1049,7 @@ msgstr "インスタンスにプロファイルを割り当てます"
 msgid "Attach network interfaces to instances"
 msgstr "インスタンスにネットワークインターフェースを追加します"
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
@@ -1068,11 +1068,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1114,7 +1114,7 @@ msgstr "自動更新は pull モードのときのみ有効です"
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1126,21 +1126,21 @@ msgstr "利用可能なプロジェクト:"
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1151,8 +1151,8 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1163,7 +1163,7 @@ msgstr "不適切なキー/値のペア: %s"
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1173,7 +1173,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr "ボンディング:"
 
@@ -1186,15 +1186,15 @@ msgstr "--all とインスタンス名を両方同時に指定することはで
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1206,7 +1206,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1266,7 +1266,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1292,15 +1292,15 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1309,14 +1309,14 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
@@ -1357,7 +1357,7 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr "Chassis"
 
@@ -1375,22 +1375,22 @@ msgstr "クライアント証明書がサーバに信頼されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "クラスターグループ %s が削除されました"
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "クラスターグループ %s は現在 %s に適用されていません"
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
@@ -1400,38 +1400,38 @@ msgstr "クラスタグループ名 %s を %s に変更しました"
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1439,14 +1439,14 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1462,16 +1462,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr "LXD のコマンドラインクライアント"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1503,24 +1503,24 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1590,15 +1590,15 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
@@ -1606,12 +1606,12 @@ msgstr "ストレージボリュームをコピーします"
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1624,7 +1624,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1696,7 +1696,7 @@ msgstr "一致するエントリを見つけられませんでした"
 msgid "Create a TLS identity"
 msgstr "警告を削除します"
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
@@ -1721,7 +1721,7 @@ msgstr "警告を削除します"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1768,7 +1768,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1780,11 +1780,11 @@ msgstr "新たにインスタンスのファイルテンプレートを作成し
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr "新たにネットワークフォワードを作成します"
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr "新たにネットワークロードバランサーを作成します"
 
@@ -1800,11 +1800,11 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Create new network zones"
 msgstr "新たにネットワークゾーンを作成します"
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
@@ -1820,7 +1820,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1844,18 +1844,18 @@ msgstr "インスタンスを作成中"
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1871,11 +1871,11 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr "DRM:"
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1883,7 +1883,7 @@ msgstr "圧縮アルゴリズムを指定します: backup or none"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr "クラスタグループを削除します"
 
@@ -1934,11 +1934,11 @@ msgstr "ストレージバケットからキーを削除します"
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
@@ -1954,11 +1954,11 @@ msgstr "ネットワークゾーンレコードを削除します"
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
@@ -1974,7 +1974,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -1996,18 +1996,18 @@ msgstr "警告を削除します"
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2016,38 +2016,38 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2059,16 +2059,16 @@ msgstr "警告を削除します"
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2079,57 +2079,57 @@ msgstr "警告を削除します"
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr "インスタンスからネットワークインターフェースを取り外します"
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr "デバイス %s が %s に追加されました"
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "デバイス %s が %s で上書きされました"
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
@@ -2139,12 +2139,12 @@ msgstr "デバイス %s が %s から削除されました"
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
@@ -2152,7 +2152,7 @@ msgstr ""
 "プロファイルのデバイスは個々のインスタンスでは変更できません。デバイスを上書"
 "きするかプロファイルを変更してください"
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
@@ -2160,7 +2160,7 @@ msgstr ""
 "プロファイルのデバイスは個々のインスタンスでは削除できません。デバイスを上書"
 "きするかプロファイルを変更してください"
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
@@ -2183,7 +2183,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2236,12 +2236,12 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display network zones from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2255,11 +2255,11 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr "Down delay"
 
@@ -2292,7 +2292,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
@@ -2305,7 +2305,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2323,7 +2323,7 @@ msgstr "プロファイル設定をYAMLで編集します"
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを編集します"
@@ -2336,7 +2336,7 @@ msgstr "インスタンスのファイルテンプレートを編集します"
 msgid "Edit instance metadata files"
 msgstr "インスタンスのメタデータファイルを編集します"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
@@ -2344,15 +2344,15 @@ msgstr "インスタンスもしくはサーバの設定をYAMLファイルで�
 msgid "Edit network ACL configurations as YAML"
 msgstr "ネットワーク ACL をYAMLで編集します"
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
@@ -2368,7 +2368,7 @@ msgstr "ネットワークゾーン設定をYAMLで編集します"
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
@@ -2388,7 +2388,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2396,8 +2396,8 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2461,27 +2461,27 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2491,11 +2491,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -2534,8 +2544,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2562,7 +2572,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2574,12 +2584,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2606,12 +2616,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2626,12 +2636,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2661,7 +2671,7 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2676,7 +2686,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2686,12 +2696,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2735,7 +2745,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2750,7 +2760,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2764,7 +2774,7 @@ msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
@@ -2774,15 +2784,25 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+#, fuzzy
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
 msgstr "特定の待避アクションを強制します"
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
+msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2794,7 +2814,7 @@ msgstr "強制的に擬似端末を割り当てます"
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
@@ -2807,7 +2827,7 @@ msgstr "インスタンスを強制停止します"
 msgid "Force the removal of running instances"
 msgstr "稼働中のインスタンスを強制的に削除します"
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -2851,16 +2871,16 @@ msgstr ""
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2872,7 +2892,7 @@ msgstr "フォーマット (json|pretty|yaml)"
 msgid "Format (man|md|rest|yaml)"
 msgstr "フォーマット (man|md|rest|yaml)"
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr "Forward delay"
 
@@ -2920,7 +2940,7 @@ msgstr "すべてのコマンドに対する man ページを作成します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -2929,11 +2949,11 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
@@ -2946,12 +2966,12 @@ msgstr "クラスターグループを作成します"
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
@@ -2961,7 +2981,7 @@ msgstr "ネットワークロードバランサーのポートを管理します
 msgid "Get the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2975,7 +2995,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2993,12 +3013,12 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -3006,11 +3026,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
@@ -3018,15 +3038,15 @@ msgstr "インスタンスもしくはサーバの設定値を取得します"
 msgid "Get values for network ACL configuration keys"
 msgstr "ネットワーク ACL の設定値を取得します"
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
@@ -3042,7 +3062,7 @@ msgstr "ネットワークゾーンの設定値を取得します"
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
@@ -3058,11 +3078,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3091,7 +3111,7 @@ msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 
 msgid "HARDWARE ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3103,27 +3123,27 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3145,7 +3165,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
@@ -3153,15 +3173,15 @@ msgstr "IP ADDRESS"
 msgid "IP addresses"
 msgstr "IP アドレス"
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3194,13 +3214,13 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3210,7 +3230,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3222,7 +3242,7 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -3238,11 +3258,11 @@ msgstr "イメージの失効日（フォーマット: rfc3339）"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
@@ -3252,7 +3272,7 @@ msgstr "イメージ名を指定してください: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3260,7 +3280,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3271,7 +3291,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3298,16 +3318,16 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr "インスタンスのインポート中: %s"
@@ -3328,11 +3348,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3346,12 +3366,12 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3409,12 +3429,12 @@ msgstr "クライアントバージョン: %s\n"
 msgid "Invalid format: %s"
 msgstr "不正なフォーマット %s"
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3443,7 +3463,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
@@ -3453,17 +3473,17 @@ msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -3473,18 +3493,18 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3515,13 +3535,13 @@ msgstr "LAST USED AT"
 msgid "LIMIT"
 msgstr "LIMIT"
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3536,7 +3556,7 @@ msgstr ""
 "を使います。"
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -3574,7 +3594,7 @@ msgstr "リンクを検出: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
@@ -3590,7 +3610,7 @@ msgstr "有効な証明書追加トークンをすべて一覧表示します"
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr "クラスタグループをすべて一覧表示します"
 
@@ -3610,11 +3630,11 @@ msgstr "利用可能なネットワーク ACL を一覧表示します"
 msgid "List available network ACLS"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr "利用可能なネットワークフォワードを一覧表示します"
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr "利用可能なネットワークロードバランサーを一覧表示します"
 
@@ -3634,7 +3654,7 @@ msgstr "利用可能なネットワークゾーンレコードを一覧表示し
 msgid "List available network zoneS"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
@@ -3732,7 +3752,7 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr "インスタンスのデバイスを一覧表示します"
 
@@ -3924,11 +3944,11 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 #, fuzzy
 msgid ""
 "List profiles\n"
@@ -3975,11 +3995,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -4071,7 +4091,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4084,15 +4104,15 @@ msgstr "ログレベルのフィルタリングは pretty フォーマットで�
 msgid "Log:"
 msgstr "ログ:"
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr "Lower device"
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
@@ -4100,7 +4120,7 @@ msgstr "MAC ADDRESS"
 msgid "MAC address"
 msgstr "MAC アドレス"
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
@@ -4110,11 +4130,11 @@ msgstr "MAC アドレス: %s"
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
@@ -4131,11 +4151,11 @@ msgstr "MEMORY USAGE%"
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr "MII 監視頻度"
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr "MII 状態"
 
@@ -4143,7 +4163,7 @@ msgstr "MII 状態"
 msgid "MTU"
 msgstr "MTU"
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr "MTU: %d"
@@ -4249,7 +4269,7 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを管理します"
@@ -4274,23 +4294,23 @@ msgstr "ネットワーク ACL ルールを管理します"
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr "ネットワークフォワードを管理します"
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr "ネットワークロードバランサーを管理します"
 
@@ -4454,13 +4474,13 @@ msgstr "バケット名を指定する必要があります"
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
@@ -4490,8 +4510,8 @@ msgstr "クラスターグループ名がありません"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -4500,20 +4520,20 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
@@ -4524,19 +4544,19 @@ msgstr "名前を指定する必要があります"
 msgid "Missing network ACL name"
 msgstr "ネットワーク ACL 名を指定する必要があります"
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4567,40 +4587,40 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4608,7 +4628,7 @@ msgstr "コピー先のディレクトリを指定する必要があります"
 msgid "Missing target network"
 msgstr "作成するネットワーク名を指定する必要があります"
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr "モード"
 
@@ -4636,18 +4656,18 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4687,7 +4707,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -4695,16 +4715,16 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
@@ -4723,12 +4743,12 @@ msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr "NAME"
 
@@ -4757,7 +4777,7 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4781,8 +4801,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr "名前"
 
@@ -4790,7 +4810,7 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4800,22 +4820,22 @@ msgstr "名前: %s"
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
@@ -4845,22 +4865,22 @@ msgstr "ネットワークゾーン %s を作成しました"
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
@@ -4892,11 +4912,11 @@ msgstr ""
 "ネットワークピア %s はピアリング状態です (ピアネットワーク上で相互ピアリング"
 "を完了させてください)"
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -4933,19 +4953,19 @@ msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 "メンバー %s に対するクラスターへの join トークンがリモート %s にありません"
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
@@ -4959,15 +4979,15 @@ msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
@@ -4977,11 +4997,11 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr "OVN:"
 
@@ -4991,11 +5011,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -5007,11 +5027,11 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -5020,11 +5040,11 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
@@ -5050,11 +5070,11 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr "PORTS"
 
@@ -5066,9 +5086,9 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -5080,11 +5100,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -5092,7 +5112,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -5131,20 +5151,20 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -5154,7 +5174,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
@@ -5162,7 +5182,7 @@ msgstr "ヘルプを表示します"
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
@@ -5181,32 +5201,32 @@ msgstr "エイリアスの処理が失敗しました: %s"
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -5223,7 +5243,7 @@ msgstr "新しいインスタンスに適用するプロファイル"
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
@@ -5259,11 +5279,11 @@ msgstr "リモートで使用するプロジェクト"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5277,7 +5297,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5293,7 +5313,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5314,7 +5334,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5326,7 +5346,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5339,7 +5359,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5373,20 +5393,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5395,7 +5415,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5426,11 +5446,11 @@ msgstr "空のインスタンスを作成"
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -5443,7 +5463,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5453,8 +5473,8 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
@@ -5469,7 +5489,7 @@ msgstr "リモート %s は <%s> として存在します"
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -5501,7 +5521,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
@@ -5522,7 +5542,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
@@ -5530,11 +5550,11 @@ msgstr "マッチするポートをすべて削除します"
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
@@ -5547,11 +5567,11 @@ msgstr "ネットワークゾーンレコードからエントリを削除しま
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
@@ -5560,15 +5580,15 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
@@ -5588,7 +5608,7 @@ msgstr "ACL からルールを削除します"
 msgid "Remove trusted client"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
@@ -5619,11 +5639,11 @@ msgstr "インスタンスまたはインスタンスのスナップショット
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
@@ -5635,16 +5655,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5658,7 +5678,7 @@ msgstr "レンダー: %s (%s)"
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5684,7 +5704,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -5702,11 +5722,11 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -5770,17 +5790,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr "STATE"
@@ -5805,7 +5825,7 @@ msgstr "STORAGE POOL"
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr "STP"
 
@@ -5844,7 +5864,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -5853,15 +5873,15 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr "デバイスの設定項目を設定します"
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5874,7 +5894,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5887,15 +5907,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5925,11 +5945,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5942,11 +5962,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5959,11 +5979,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6014,11 +6034,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6082,11 +6102,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -6100,7 +6120,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -6109,7 +6129,7 @@ msgstr "リモートの URL を設定します"
 msgid "Set the file's gid on create"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
@@ -6118,7 +6138,7 @@ msgstr "プッシュ時にファイルのgidを設定します"
 msgid "Set the file's perms on create"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
@@ -6127,7 +6147,7 @@ msgstr "プッシュ時にファイルのパーミションを設定します"
 msgid "Set the file's uid on create"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -6140,12 +6160,12 @@ msgstr "クラスターグループを作成します"
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
@@ -6155,7 +6175,7 @@ msgstr "ネットワークロードバランサーの設定を行います"
 msgid "Set the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -6169,7 +6189,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -6187,25 +6207,25 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
@@ -6213,7 +6233,7 @@ msgstr "詳細な情報を出力します"
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr "クラスタグループの設定を表示します"
 
@@ -6233,7 +6253,7 @@ msgstr "バックグラウンド操作の詳細を表示します"
 msgid "Show events from all projects"
 msgstr "すべてのプロジェクトのイベントを表示します"
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
@@ -6255,11 +6275,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを表示します"
@@ -6268,7 +6288,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -6276,7 +6296,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -6292,15 +6312,15 @@ msgstr "ネットワーク ACL の設定を表示します"
 msgid "Show network ACL log"
 msgstr "ネットワーク ACL ログを表示します"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr "ネットワークフォワードの設定を表示します"
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr "ネットワークロードバランサーの設定を表示します"
 
@@ -6320,7 +6340,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
@@ -6340,11 +6360,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -6362,7 +6382,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -6413,15 +6433,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6456,7 +6476,7 @@ msgstr "%s を起動中"
 msgid "State"
 msgstr "状態"
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
@@ -6526,21 +6546,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -6602,21 +6622,21 @@ msgid "TOKEN"
 msgstr "TOKEN"
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6655,7 +6675,7 @@ msgstr "--target-project と --target は同時に指定できません"
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
@@ -6697,7 +6717,7 @@ msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:' を試してみてください。"
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
@@ -6706,22 +6726,22 @@ msgstr "プロファイルのデバイスが存在しません"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6731,7 +6751,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6751,7 +6771,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6771,12 +6791,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6801,12 +6821,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
@@ -6820,7 +6840,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6833,7 +6853,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6881,7 +6901,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6891,14 +6911,14 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -6913,7 +6933,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6921,7 +6941,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -6943,7 +6963,7 @@ msgstr "イメージを転送中: %s"
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
@@ -6982,8 +7002,8 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -7005,13 +7025,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr "USAGE"
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -7024,7 +7044,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -7038,13 +7058,13 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -7054,7 +7074,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -7069,7 +7089,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
@@ -7082,15 +7102,15 @@ msgstr "クラスターメンバーの設定を削除します"
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -7098,23 +7118,23 @@ msgstr "インスタンスもしくはサーバの設定を削除します"
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
@@ -7134,7 +7154,7 @@ msgstr "ネットワークゾーンの設定を削除します"
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
@@ -7150,7 +7170,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -7162,12 +7182,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
@@ -7177,7 +7197,7 @@ msgstr "ネットワークロードバランサーの設定を削除します"
 msgid "Unset the key as a network peer property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "ネットワークピアの設定を削除します"
@@ -7192,7 +7212,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -7210,12 +7230,12 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7228,7 +7248,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr "Up delay"
 
@@ -7243,7 +7263,7 @@ msgid ""
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 #, fuzzy
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
@@ -7253,29 +7273,29 @@ msgstr "コピー元の全てのプロファイルがターゲットに存在し
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
@@ -7304,15 +7324,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr "VFs: %d"
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr "VLAN ID"
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr "VLAN フィルタリング"
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr "VLAN:"
 
@@ -7340,7 +7360,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7375,7 +7395,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7404,13 +7424,13 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7418,10 +7438,10 @@ msgid ""
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -7530,8 +7550,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
@@ -7542,7 +7562,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
@@ -7566,15 +7586,15 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7599,47 +7619,47 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "[<remote>:]<instance> <device> <key>"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "[<remote>:]<instance> <device> <key>=<value>..."
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
@@ -7668,7 +7688,7 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
@@ -7681,13 +7701,13 @@ msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7711,11 +7731,11 @@ msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
@@ -7735,13 +7755,13 @@ msgstr "[<remote>:]<member> <new-name>"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>]"
 
@@ -7749,25 +7769,25 @@ msgstr "[<remote>:]<network> <instance> [<device name>]"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -7775,16 +7795,16 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -7792,7 +7812,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -7800,11 +7820,11 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
@@ -7832,20 +7852,20 @@ msgstr "[<remote>:]<network> <peer_name> <key>"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "[<remote>:]<network> <peer_name> <key>=<value>..."
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>]"
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "[<remote>:]<network> <listen_address> [key=value...]"
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
@@ -7858,7 +7878,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7893,7 +7913,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7901,47 +7921,47 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -7954,54 +7974,54 @@ msgid ""
 "[<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "[<remote>:]<profile> <device> <key>"
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
@@ -8055,7 +8075,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -8063,15 +8083,15 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -8194,7 +8214,7 @@ msgstr ""
 "lxc cluster group assign foo default\n"
 "    \"foo\" を \"default\" クラスタグループのみ使用するように再設定します。"
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 #, fuzzy
 msgid ""
 "lxc cluster group create g1\n"
@@ -8207,7 +8227,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8226,7 +8246,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンス内の /opt にマウントし"
 "ます。"
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
@@ -8234,7 +8254,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 #, fuzzy
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
@@ -8252,7 +8272,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 #, fuzzy
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
@@ -8261,7 +8281,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8286,7 +8306,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8295,7 +8315,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -8305,7 +8325,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8486,7 +8506,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8495,7 +8515,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 #, fuzzy
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
@@ -8508,7 +8528,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 #, fuzzy
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
@@ -8556,7 +8576,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8577,7 +8597,7 @@ msgstr ""
 "lxc profile assign foo ''\n"
 "    \"foo\" からすべてのプロファイルを削除します。"
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 #, fuzzy
 msgid ""
 "lxc profile create p1\n"
@@ -8590,7 +8610,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8609,7 +8629,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8752,7 +8772,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 #, fuzzy
 msgid ""
 "lxc storage volume create p1 v1\n"
@@ -8765,7 +8785,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8773,7 +8793,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 #, fuzzy
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
@@ -8812,16 +8832,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,13 +103,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -613,11 +613,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -625,11 +625,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -678,11 +678,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -807,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -861,21 +861,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -884,8 +884,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1024,15 +1024,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,38 +1127,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1226,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1297,15 +1297,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,11 +1478,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1498,11 +1498,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,18 +1542,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1629,11 +1629,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1649,11 +1649,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,18 +1691,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1711,38 +1711,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1754,16 +1754,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1774,57 +1774,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1834,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1921,11 +1921,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,11 +1937,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1972,7 +1972,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1984,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2020,15 +2020,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2072,8 +2072,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2125,27 +2125,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2155,11 +2155,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2187,8 +2197,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2212,7 +2222,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2224,11 +2234,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2255,12 +2265,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2275,12 +2285,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2310,7 +2320,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2325,7 +2335,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2335,12 +2345,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2384,7 +2394,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2399,7 +2409,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2413,7 +2423,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2423,15 +2433,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2443,7 +2462,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2455,7 +2474,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2484,16 +2503,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2505,7 +2524,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2553,7 +2572,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2561,11 +2580,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2577,11 +2596,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2589,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2601,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2617,11 +2636,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2629,11 +2648,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2641,15 +2660,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2665,7 +2684,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2681,11 +2700,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2713,7 +2732,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2725,27 +2744,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2767,7 +2786,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2775,15 +2794,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2813,11 +2832,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2827,7 +2846,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2839,7 +2858,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2855,11 +2874,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2869,7 +2888,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2896,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2885,7 +2904,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2907,16 +2926,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2937,11 +2956,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2955,11 +2974,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3016,12 +3035,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3066,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3055,15 +3074,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3073,18 +3092,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3115,13 +3134,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3134,7 +3153,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3187,7 +3206,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3207,11 +3226,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3231,7 +3250,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3298,7 +3317,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3410,11 +3429,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3442,11 +3461,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3505,7 +3524,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3518,15 +3537,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3544,11 +3563,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3565,11 +3584,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3577,7 +3596,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3667,7 +3686,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3691,23 +3710,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3865,13 +3884,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3897,8 +3916,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3907,20 +3926,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3931,19 +3950,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3974,40 +3993,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4015,7 +4034,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4040,16 +4059,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4078,7 +4097,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4086,16 +4105,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4112,12 +4131,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4145,7 +4164,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4169,8 +4188,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4178,7 +4197,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4188,22 +4207,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4233,22 +4252,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4278,11 +4297,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4318,19 +4337,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4342,15 +4361,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4360,11 +4379,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4373,11 +4392,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4389,11 +4408,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4402,11 +4421,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4432,11 +4451,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4448,9 +4467,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4462,11 +4481,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4474,7 +4493,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4512,20 +4531,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4533,7 +4552,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4541,7 +4560,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4560,32 +4579,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4602,7 +4621,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,11 +4657,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4656,7 +4675,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4672,7 +4691,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4712,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4702,7 +4721,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4715,7 +4734,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4746,20 +4765,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4768,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4797,11 +4816,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4814,7 +4833,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,8 +4843,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4840,7 +4859,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4871,7 +4890,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4891,7 +4910,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4899,11 +4918,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4915,11 +4934,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4927,15 +4946,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4955,7 +4974,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4984,11 +5003,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5000,15 +5019,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5022,7 +5041,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5045,7 +5064,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5060,11 +5079,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5126,17 +5145,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5161,7 +5180,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5199,7 +5218,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5207,15 +5226,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5224,7 +5243,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5233,15 +5252,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5263,11 +5282,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5276,11 +5295,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5289,11 +5308,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5332,11 +5351,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5384,11 +5403,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5397,7 +5416,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5421,7 +5440,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,11 +5452,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5445,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5457,7 +5476,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5473,23 +5492,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5497,7 +5516,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5517,7 +5536,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5538,11 +5557,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5550,7 +5569,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5558,7 +5577,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5574,15 +5593,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5602,7 +5621,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5622,11 +5641,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5644,7 +5663,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5694,15 +5713,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5737,7 +5756,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5807,21 +5826,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5883,21 +5902,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5972,7 +5991,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5981,22 +6000,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6006,7 +6025,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6026,7 +6045,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6046,12 +6065,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6074,12 +6093,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6091,7 +6110,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6103,7 +6122,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6139,18 +6158,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6165,7 +6184,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6173,7 +6192,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6195,7 +6214,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6231,8 +6250,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6254,13 +6273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6273,7 +6292,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6287,13 +6306,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6303,7 +6322,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6318,7 +6337,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6330,15 +6349,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6346,23 +6365,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6382,7 +6401,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6398,7 +6417,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6410,11 +6429,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6422,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6434,7 +6453,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6450,11 +6469,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6467,7 +6486,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6481,7 +6500,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6490,27 +6509,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6537,15 +6556,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6572,7 +6591,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6605,7 +6624,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6631,22 +6650,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6755,8 +6774,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6766,7 +6785,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6786,15 +6805,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6818,45 +6837,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6885,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6897,12 +6916,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6924,11 +6943,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6948,13 +6967,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6962,56 +6981,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7037,19 +7056,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7062,7 +7081,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7097,49 +7116,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7150,52 +7169,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7248,7 +7267,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7256,15 +7275,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7363,7 +7382,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7371,7 +7390,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7382,13 +7401,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7397,13 +7416,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7426,20 +7445,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7555,7 +7574,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7564,7 +7583,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7572,7 +7591,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7622,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7615,7 +7634,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7623,7 +7642,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7634,7 +7653,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7740,7 +7759,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7748,13 +7767,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7788,16 +7807,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-04-24 08:44-0600\n"
+        "POT-Creation-Date: 2025-04-29 07:41-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -57,7 +57,7 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -97,12 +97,12 @@ msgid   "### This is a YAML representation of the certificate.\n"
         "### Note that the fingerprint is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid   "### This is a YAML representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -234,7 +234,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -256,7 +256,7 @@ msgid   "### This is a YAML representation of the network forward.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -319,7 +319,7 @@ msgid   "### This is a YAML representation of the network zone.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid   "### This is a YAML representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -338,7 +338,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -398,17 +398,17 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid   "(none)"
 msgstr  ""
 
@@ -443,7 +443,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -463,7 +463,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844 lxc/info.go:461
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864 lxc/info.go:461
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -483,7 +483,7 @@ msgstr  ""
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid   "<remote> <URL>"
 msgstr  ""
 
@@ -491,7 +491,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -540,7 +540,7 @@ msgstr  ""
 msgid   "Access key: %s"
 msgstr  ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid   "Access the expanded configuration"
 msgstr  ""
 
@@ -561,7 +561,7 @@ msgstr  ""
 msgid   "Add a NIC device to the default profile connected to the specified network"
 msgstr  ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
@@ -581,11 +581,11 @@ msgstr  ""
 msgid   "Add a storage pool to be used as the root device in the default profile"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
@@ -593,11 +593,11 @@ msgstr  ""
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid   "Add instance devices"
 msgstr  ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid   "Add member to group"
 msgstr  ""
 
@@ -639,11 +639,11 @@ msgstr  ""
 msgid   "Add permissions to groups"
 msgstr  ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
@@ -702,7 +702,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid   "All projects"
 msgstr  ""
 
@@ -724,7 +724,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -741,7 +741,7 @@ msgstr  ""
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
@@ -749,7 +749,7 @@ msgstr  ""
 msgid   "Attach network interfaces to instances"
 msgstr  ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
@@ -767,11 +767,11 @@ msgid   "Attach new storage volumes to instances\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr  ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid   "Attach new storage volumes to profiles\n"
         "\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
@@ -807,7 +807,7 @@ msgstr  ""
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid   "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr  ""
 
@@ -819,21 +819,21 @@ msgstr  ""
 msgid   "BASE IMAGE"
 msgstr  ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid   "Backups:"
 msgstr  ""
 
@@ -842,7 +842,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326 lxc/network_load_balancer.go:321 lxc/network_peer.go:309 lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327 lxc/network_load_balancer.go:322 lxc/network_peer.go:309 lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -852,7 +852,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -862,7 +862,7 @@ msgstr  ""
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid   "Bond:"
 msgstr  ""
 
@@ -875,15 +875,15 @@ msgstr  ""
 msgid   "Brand: %v"
 msgstr  ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid   "Bridge:"
 msgstr  ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -895,7 +895,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -955,7 +955,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -980,15 +980,15 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -997,11 +997,11 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
@@ -1038,7 +1038,7 @@ msgstr  ""
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid   "Chassis"
 msgstr  ""
 
@@ -1056,22 +1056,22 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid   "Cluster group %s created"
 msgstr  ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid   "Cluster group %s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid   "Cluster group %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
@@ -1081,27 +1081,27 @@ msgstr  ""
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid   "Cluster member %s added to cluster groups %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid   "Cluster member %s added to group %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid   "Cluster member %s is already in group %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777 lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371 lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:561 lxc/storage_bucket.go:654 lxc/storage_bucket.go:720 lxc/storage_bucket.go:795 lxc/storage_bucket.go:881 lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046 lxc/storage_bucket.go:1182 lxc/storage_volume.go:389 lxc/storage_volume.go:613 lxc/storage_volume.go:718 lxc/storage_volume.go:1020 lxc/storage_volume.go:1246 lxc/storage_volume.go:1375 lxc/storage_volume.go:1866 lxc/storage_volume.go:1964 lxc/storage_volume.go:2103 lxc/storage_volume.go:2263 lxc/storage_volume.go:2379 lxc/storage_volume.go:2440 lxc/storage_volume.go:2567 lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797 lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887 lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381 lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265 lxc/network_forward.go:506 lxc/network_forward.go:658 lxc/network_forward.go:812 lxc/network_forward.go:901 lxc/network_forward.go:987 lxc/network_load_balancer.go:185 lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485 lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775 lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:561 lxc/storage_bucket.go:654 lxc/storage_bucket.go:720 lxc/storage_bucket.go:795 lxc/storage_bucket.go:881 lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046 lxc/storage_bucket.go:1182 lxc/storage_volume.go:399 lxc/storage_volume.go:627 lxc/storage_volume.go:732 lxc/storage_volume.go:1034 lxc/storage_volume.go:1260 lxc/storage_volume.go:1389 lxc/storage_volume.go:1880 lxc/storage_volume.go:1982 lxc/storage_volume.go:2121 lxc/storage_volume.go:2281 lxc/storage_volume.go:2397 lxc/storage_volume.go:2458 lxc/storage_volume.go:2585 lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1117,15 +1117,15 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734 lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid   "Command line client for LXD"
 msgstr  ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid   "Command line client for LXD\n"
         "\n"
         "All of LXD's features can be driven through the various commands below.\n"
@@ -1152,16 +1152,16 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156 lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759 lxc/network_acl.go:716 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:699 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165 lxc/storage_volume.go:1197
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322 lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156 lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769 lxc/network_acl.go:716 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179 lxc/storage_volume.go:1211
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1209,15 +1209,15 @@ msgid   "Copy instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid   "Copy storage volumes"
 msgstr  ""
 
@@ -1225,11 +1225,11 @@ msgstr  ""
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288 lxc/storage_volume.go:402
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1242,7 +1242,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1313,7 +1313,7 @@ msgstr  ""
 msgid   "Create a TLS identity"
 msgstr  ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid   "Create a cluster group"
 msgstr  ""
 
@@ -1337,7 +1337,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1376,7 +1376,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1388,11 +1388,11 @@ msgstr  ""
 msgid   "Create new network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid   "Create new network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid   "Create new network load balancers"
 msgstr  ""
 
@@ -1408,11 +1408,11 @@ msgstr  ""
 msgid   "Create new network zones"
 msgstr  ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid   "Create profiles"
 msgstr  ""
 
@@ -1428,7 +1428,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1452,11 +1452,11 @@ msgstr  ""
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109 lxc/network_acl.go:171 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:528 lxc/storage_bucket.go:852 lxc/storage_volume.go:1750
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119 lxc/network_acl.go:171 lxc/network_forward.go:158 lxc/network_load_balancer.go:161 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:528 lxc/storage_bucket.go:852 lxc/storage_volume.go:1764
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1472,11 +1472,11 @@ msgstr  ""
 msgid   "DRM:"
 msgstr  ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1484,7 +1484,7 @@ msgstr  ""
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid   "Delete a cluster group"
 msgstr  ""
 
@@ -1532,11 +1532,11 @@ msgstr  ""
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid   "Delete network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid   "Delete network load balancers"
 msgstr  ""
 
@@ -1552,11 +1552,11 @@ msgstr  ""
 msgid   "Delete network zones"
 msgstr  ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid   "Delete profiles"
 msgstr  ""
 
@@ -1572,7 +1572,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1580,46 +1580,46 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783 lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062 lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958 lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175 lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348 lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578 lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135 lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703 lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212 lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440 lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382 lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548 lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:461 lxc/storage_bucket.go:555 lxc/storage_bucket.go:649 lxc/storage_bucket.go:718 lxc/storage_bucket.go:752 lxc/storage_bucket.go:793 lxc/storage_bucket.go:872 lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042 lxc/storage_bucket.go:1177 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:309 lxc/storage_volume.go:385 lxc/storage_volume.go:606 lxc/storage_volume.go:715 lxc/storage_volume.go:802 lxc/storage_volume.go:907 lxc/storage_volume.go:1011 lxc/storage_volume.go:1232 lxc/storage_volume.go:1363 lxc/storage_volume.go:1525 lxc/storage_volume.go:1609 lxc/storage_volume.go:1862 lxc/storage_volume.go:1961 lxc/storage_volume.go:2088 lxc/storage_volume.go:2246 lxc/storage_volume.go:2367 lxc/storage_volume.go:2429 lxc/storage_volume.go:2565 lxc/storage_volume.go:2649 lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783 lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062 lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175 lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445 lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673 lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172 lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483 lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702 lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348 lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578 lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135 lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695 lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473 lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884 lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222 lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450 lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382 lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53 lxc/network_forward.go:34 lxc/network_forward.go:91 lxc/network_forward.go:180 lxc/network_forward.go:257 lxc/network_forward.go:413 lxc/network_forward.go:498 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548 lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286 lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644 lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030 lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:461 lxc/storage_bucket.go:555 lxc/storage_bucket.go:649 lxc/storage_bucket.go:718 lxc/storage_bucket.go:752 lxc/storage_bucket.go:793 lxc/storage_bucket.go:872 lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042 lxc/storage_bucket.go:1177 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:314 lxc/storage_volume.go:395 lxc/storage_volume.go:620 lxc/storage_volume.go:729 lxc/storage_volume.go:816 lxc/storage_volume.go:921 lxc/storage_volume.go:1025 lxc/storage_volume.go:1246 lxc/storage_volume.go:1377 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2264 lxc/storage_volume.go:2385 lxc/storage_volume.go:2447 lxc/storage_volume.go:2583 lxc/storage_volume.go:2667 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid   "Destination cluster member name"
 msgstr  ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid   "Detach network interfaces from instances"
 msgstr  ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid   "Device %s overridden for %s"
 msgstr  ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
@@ -1629,19 +1629,19 @@ msgstr  ""
 msgid   "Device already exists: %s"
 msgstr  ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567 lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634 lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid   "Device doesn't exist"
 msgstr  ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid   "Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"
 msgstr  ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid   "Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"
 msgstr  ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
@@ -1662,7 +1662,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1711,11 +1711,11 @@ msgstr  ""
 msgid   "Display network zones from all projects"
 msgstr  ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid   "Display networks from all projects"
 msgstr  ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid   "Display profiles from all projects"
 msgstr  ""
 
@@ -1727,11 +1727,11 @@ msgstr  ""
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid   "Down delay"
 msgstr  ""
 
@@ -1760,7 +1760,7 @@ msgstr  ""
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid   "Edit a cluster group"
 msgstr  ""
 
@@ -1772,7 +1772,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1788,7 +1788,7 @@ msgstr  ""
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid   "Edit instance UEFI variables"
 msgstr  ""
 
@@ -1800,7 +1800,7 @@ msgstr  ""
 msgid   "Edit instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
@@ -1808,15 +1808,15 @@ msgstr  ""
 msgid   "Edit network ACL configurations as YAML"
 msgstr  ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
@@ -1832,7 +1832,7 @@ msgstr  ""
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
@@ -1852,7 +1852,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1860,7 +1860,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776 lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1908,17 +1908,17 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346 lxc/network_acl.go:542 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:523 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622 lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356 lxc/network_acl.go:542 lxc/network_forward.go:581 lxc/network_load_balancer.go:560 lxc/network_peer.go:523 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622 lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:616 lxc/storage_volume.go:2173 lxc/storage_volume.go:2211
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536 lxc/network_forward.go:575 lxc/network_load_balancer.go:554 lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:616 lxc/storage_volume.go:2191 lxc/storage_volume.go:2229
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1928,11 +1928,20 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid   "Evacuate cluster member\n"
+        "\n"
+        "Evacuation actions:\n"
+        " - stop: stop all instances on the member\n"
+        " - migrate: migrate all instances on the member to other members\n"
+        " - live-migrate: live migrate all instances on the member to other members\n"
+msgstr  ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1958,7 +1967,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526 lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540 lxc/storage_volume.go:1590
 msgid   "Expires at"
 msgstr  ""
 
@@ -1981,7 +1990,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1993,11 +2002,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2023,12 +2032,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -2043,12 +2052,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2078,7 +2087,7 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2093,7 +2102,7 @@ msgstr  ""
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2103,12 +2112,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2152,7 +2161,7 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2167,7 +2176,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2181,7 +2190,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126 lxc/operation.go:137
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126 lxc/operation.go:137
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2190,15 +2199,19 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1307
-msgid   "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid   "Force a particular instance evacuation action. One of stop, migrate or live-migrate"
+msgstr  ""
+
+#: lxc/cluster.go:1344
+msgid   "Force a particular instance restore action. Use \"skip\" to restore only the cluster member status without starting local instances or migrating back evacuated instances"
 msgstr  ""
 
 #: lxc/file.go:144
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -2210,7 +2223,7 @@ msgstr  ""
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid   "Force restoration without user confirmation"
 msgstr  ""
 
@@ -2222,7 +2235,7 @@ msgstr  ""
 msgid   "Force the removal of running instances"
 msgstr  ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid   "Force using the local unix socket"
 msgstr  ""
 
@@ -2245,7 +2258,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011 lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:462 lxc/storage_bucket.go:794 lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447 lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021 lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59 lxc/network_forward.go:94 lxc/network_load_balancer.go:98 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:462 lxc/storage_bucket.go:794 lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2257,7 +2270,7 @@ msgstr  ""
 msgid   "Format (man|md|rest|yaml)"
 msgstr  ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid   "Forward delay"
 msgstr  ""
 
@@ -2305,7 +2318,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
@@ -2313,11 +2326,11 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid   "Get image properties"
 msgstr  ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid   "Get runtime information on networks"
 msgstr  ""
 
@@ -2329,11 +2342,11 @@ msgstr  ""
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
@@ -2341,7 +2354,7 @@ msgstr  ""
 msgid   "Get the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid   "Get the key as a network property"
 msgstr  ""
 
@@ -2353,7 +2366,7 @@ msgstr  ""
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid   "Get the key as a profile property"
 msgstr  ""
 
@@ -2369,11 +2382,11 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid   "Get the key as an instance property"
 msgstr  ""
 
@@ -2381,11 +2394,11 @@ msgstr  ""
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
@@ -2393,15 +2406,15 @@ msgstr  ""
 msgid   "Get values for network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
@@ -2417,7 +2430,7 @@ msgstr  ""
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
@@ -2433,11 +2446,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2465,7 +2478,7 @@ msgstr  ""
 msgid   "HARDWARE ADDRESS"
 msgstr  ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -2477,27 +2490,27 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid   "ID"
 msgstr  ""
 
@@ -2519,7 +2532,7 @@ msgstr  ""
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid   "IP ADDRESS"
 msgstr  ""
 
@@ -2527,15 +2540,15 @@ msgstr  ""
 msgid   "IP addresses"
 msgstr  ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid   "IP addresses:"
 msgstr  ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid   "IPV6"
 msgstr  ""
 
@@ -2565,11 +2578,11 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2577,7 +2590,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2589,7 +2602,7 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -2605,11 +2618,11 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
@@ -2619,7 +2632,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2627,7 +2640,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2635,7 +2648,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2655,16 +2668,16 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid   "Importing instance: %s"
 msgstr  ""
@@ -2685,11 +2698,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2703,11 +2716,11 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2764,12 +2777,12 @@ msgstr  ""
 msgid   "Invalid format: %s"
 msgstr  ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2794,7 +2807,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
@@ -2802,15 +2815,15 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2820,16 +2833,16 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296 lxc/storage_volume.go:1420 lxc/storage_volume.go:2009 lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310 lxc/storage_volume.go:1434 lxc/storage_volume.go:2027 lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2860,11 +2873,11 @@ msgstr  ""
 msgid   "LIMIT"
 msgstr  ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164 lxc/network_load_balancer.go:166 lxc/operation.go:178 lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2876,7 +2889,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128 lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128 lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2913,7 +2926,7 @@ msgstr  ""
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid   "List DHCP leases"
 msgstr  ""
 
@@ -2929,7 +2942,7 @@ msgstr  ""
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid   "List all the cluster groups"
 msgstr  ""
 
@@ -2949,11 +2962,11 @@ msgstr  ""
 msgid   "List available network ACLS"
 msgstr  ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid   "List available network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid   "List available network load balancers"
 msgstr  ""
 
@@ -2973,7 +2986,7 @@ msgstr  ""
 msgid   "List available network zoneS"
 msgstr  ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid   "List available networks"
 msgstr  ""
 
@@ -3038,7 +3051,7 @@ msgid   "List images\n"
         "    t - Type"
 msgstr  ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid   "List instance devices"
 msgstr  ""
 
@@ -3141,11 +3154,11 @@ msgstr  ""
 msgid   "List permissions"
 msgstr  ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid   "List profiles\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3172,11 +3185,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3233,7 +3246,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3246,15 +3259,15 @@ msgstr  ""
 msgid   "Log:"
 msgstr  ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid   "Lower device"
 msgstr  ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid   "Lower devices"
 msgstr  ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid   "MAC ADDRESS"
 msgstr  ""
 
@@ -3262,7 +3275,7 @@ msgstr  ""
 msgid   "MAC address"
 msgstr  ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
@@ -3272,11 +3285,11 @@ msgstr  ""
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid   "MEMBERS"
 msgstr  ""
 
@@ -3293,11 +3306,11 @@ msgstr  ""
 msgid   "MESSAGE"
 msgstr  ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid   "MII Frequency"
 msgstr  ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid   "MII state"
 msgstr  ""
 
@@ -3305,7 +3318,7 @@ msgstr  ""
 msgid   "MTU"
 msgstr  ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
@@ -3392,7 +3405,7 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid   "Manage instance UEFI variables"
 msgstr  ""
 
@@ -3416,23 +3429,23 @@ msgstr  ""
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid   "Manage network forward ports"
 msgstr  ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid   "Manage network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid   "Manage network load balancers"
 msgstr  ""
 
@@ -3582,11 +3595,11 @@ msgstr  ""
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349 lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354 lxc/cluster_group.go:706
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129 lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82 lxc/cluster_role.go:150
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134 lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82 lxc/cluster_role.go:150
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -3606,7 +3619,7 @@ msgstr  ""
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
-#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227 lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237 lxc/profile.go:918 lxc/rebuild.go:61
 msgid   "Missing instance name"
 msgstr  ""
 
@@ -3614,11 +3627,11 @@ msgstr  ""
 msgid   "Missing key name"
 msgstr  ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457 lxc/network_forward.go:542 lxc/network_forward.go:717 lxc/network_forward.go:848 lxc/network_forward.go:945 lxc/network_forward.go:1031 lxc/network_load_balancer.go:221 lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521 lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975 lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458 lxc/network_forward.go:543 lxc/network_forward.go:718 lxc/network_forward.go:849 lxc/network_forward.go:946 lxc/network_forward.go:1032 lxc/network_load_balancer.go:222 lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522 lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812 lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid   "Missing listen address"
 msgstr  ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368 lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683 lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441 lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750 lxc/config_device.go:877
 msgid   "Missing name"
 msgstr  ""
 
@@ -3626,7 +3639,7 @@ msgstr  ""
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499 lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908 lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310 lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215 lxc/network_forward.go:292 lxc/network_forward.go:453 lxc/network_forward.go:538 lxc/network_forward.go:713 lxc/network_forward.go:844 lxc/network_forward.go:941 lxc/network_forward.go:1027 lxc/network_load_balancer.go:131 lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286 lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517 lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971 lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645 lxc/network_peer.go:766
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509 lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918 lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320 lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216 lxc/network_forward.go:293 lxc/network_forward.go:454 lxc/network_forward.go:539 lxc/network_forward.go:714 lxc/network_forward.go:845 lxc/network_forward.go:942 lxc/network_forward.go:1028 lxc/network_load_balancer.go:132 lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287 lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518 lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645 lxc/network_peer.go:766
 msgid   "Missing network name"
 msgstr  ""
 
@@ -3642,31 +3655,31 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:486 lxc/storage_bucket.go:584 lxc/storage_bucket.go:676 lxc/storage_bucket.go:818 lxc/storage_bucket.go:905 lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081 lxc/storage_bucket.go:1204 lxc/storage_volume.go:281 lxc/storage_volume.go:351 lxc/storage_volume.go:644 lxc/storage_volume.go:751 lxc/storage_volume.go:842 lxc/storage_volume.go:947 lxc/storage_volume.go:1068 lxc/storage_volume.go:1285 lxc/storage_volume.go:1998 lxc/storage_volume.go:2139 lxc/storage_volume.go:2297 lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:486 lxc/storage_bucket.go:584 lxc/storage_bucket.go:676 lxc/storage_bucket.go:818 lxc/storage_bucket.go:905 lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081 lxc/storage_bucket.go:1204 lxc/storage_volume.go:286 lxc/storage_volume.go:361 lxc/storage_volume.go:658 lxc/storage_volume.go:765 lxc/storage_volume.go:856 lxc/storage_volume.go:961 lxc/storage_volume.go:1082 lxc/storage_volume.go:1299 lxc/storage_volume.go:2016 lxc/storage_volume.go:2157 lxc/storage_volume.go:2315 lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987 lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002 lxc/profile.go:1070 lxc/profile.go:1151
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324 lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827 lxc/project.go:956
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324 lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827 lxc/project.go:956
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3674,7 +3687,7 @@ msgstr  ""
 msgid   "Missing target network"
 msgstr  ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid   "Mode"
 msgstr  ""
 
@@ -3698,15 +3711,15 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869 lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883 lxc/storage_volume.go:987
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3730,7 +3743,7 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -3738,16 +3751,16 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
@@ -3763,7 +3776,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407 lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104 lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527 lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407 lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114 lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527 lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid   "NAME"
 msgstr  ""
 
@@ -3791,7 +3804,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551 lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551 lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid   "NO"
 msgstr  ""
 
@@ -3813,7 +3826,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524 lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538 lxc/storage_volume.go:1588
 msgid   "Name"
 msgstr  ""
 
@@ -3821,7 +3834,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3831,22 +3844,22 @@ msgstr  ""
 msgid   "Name: %v"
 msgstr  ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
@@ -3876,22 +3889,22 @@ msgstr  ""
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
@@ -3920,11 +3933,11 @@ msgstr  ""
 msgid   "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr  ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid   "Network usage:"
 msgstr  ""
 
@@ -3960,19 +3973,19 @@ msgstr  ""
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid   "No matching backend found"
 msgstr  ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid   "No matching port(s) found"
 msgstr  ""
 
@@ -3984,15 +3997,15 @@ msgstr  ""
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid   "No value found in %q"
 msgstr  ""
@@ -4002,11 +4015,11 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid   "Not a snapshot name"
 msgstr  ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid   "OVN:"
 msgstr  ""
 
@@ -4014,11 +4027,11 @@ msgstr  ""
 msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -4030,11 +4043,11 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -4043,11 +4056,11 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid   "Optimized Storage"
 msgstr  ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid   "Override the source project"
 msgstr  ""
 
@@ -4073,11 +4086,11 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid   "POOL"
 msgstr  ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid   "PORTS"
 msgstr  ""
 
@@ -4089,7 +4102,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536 lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176 lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536 lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4101,11 +4114,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4113,7 +4126,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -4151,11 +4164,11 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760 lxc/network_acl.go:717 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:700 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166 lxc/storage_volume.go:1198
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398 lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770 lxc/network_acl.go:717 lxc/network_forward.go:777 lxc/network_load_balancer.go:740 lxc/network_peer.go:700 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180 lxc/storage_volume.go:1212
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4163,7 +4176,7 @@ msgstr  ""
 msgid   "Pretty rendering (short for --format=pretty)"
 msgstr  ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid   "Print help"
 msgstr  ""
 
@@ -4171,7 +4184,7 @@ msgstr  ""
 msgid   "Print the raw response"
 msgstr  ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid   "Print version number"
 msgstr  ""
 
@@ -4190,32 +4203,32 @@ msgstr  ""
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
@@ -4232,7 +4245,7 @@ msgstr  ""
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
@@ -4268,11 +4281,11 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4283,7 +4296,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4296,7 +4309,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4312,7 +4325,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4320,7 +4333,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4331,7 +4344,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4360,20 +4373,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4382,7 +4395,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4411,11 +4424,11 @@ msgstr  ""
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -4428,7 +4441,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4438,7 +4451,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047 lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048 lxc/remote.go:1096
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -4453,7 +4466,7 @@ msgstr  ""
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
@@ -4484,7 +4497,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
@@ -4504,7 +4517,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid   "Remove all ports that match"
 msgstr  ""
 
@@ -4512,11 +4525,11 @@ msgstr  ""
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
@@ -4528,11 +4541,11 @@ msgstr  ""
 msgid   "Remove identities from groups"
 msgstr  ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid   "Remove instance devices"
 msgstr  ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid   "Remove member from group"
 msgstr  ""
 
@@ -4540,15 +4553,15 @@ msgstr  ""
 msgid   "Remove permissions from groups"
 msgstr  ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid   "Remove profiles from instances"
 msgstr  ""
 
@@ -4568,7 +4581,7 @@ msgstr  ""
 msgid   "Remove trusted client"
 msgstr  ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid   "Rename a cluster group"
 msgstr  ""
 
@@ -4596,11 +4609,11 @@ msgstr  ""
 msgid   "Rename network ACLs"
 msgstr  ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid   "Rename profiles"
 msgstr  ""
 
@@ -4612,15 +4625,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4634,7 +4647,7 @@ msgstr  ""
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
@@ -4656,7 +4669,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -4670,11 +4683,11 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -4736,17 +4749,17 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111 lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121 lxc/network_peer.go:151 lxc/storage.go:725
 msgid   "STATE"
 msgstr  ""
 
@@ -4770,7 +4783,7 @@ msgstr  ""
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid   "STP"
 msgstr  ""
 
@@ -4808,7 +4821,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
@@ -4816,37 +4829,37 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid   "Set device configuration keys"
 msgstr  ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid   "Set image properties"
 msgstr  ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4864,33 +4877,33 @@ msgid   "Set network ACL configuration keys\n"
         "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4923,11 +4936,11 @@ msgstr  ""
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4967,18 +4980,18 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4986,7 +4999,7 @@ msgstr  ""
 msgid   "Set the file's gid on create"
 msgstr  ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid   "Set the file's gid on push"
 msgstr  ""
 
@@ -4994,7 +5007,7 @@ msgstr  ""
 msgid   "Set the file's perms on create"
 msgstr  ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid   "Set the file's perms on push"
 msgstr  ""
 
@@ -5002,7 +5015,7 @@ msgstr  ""
 msgid   "Set the file's uid on create"
 msgstr  ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -5014,11 +5027,11 @@ msgstr  ""
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
@@ -5026,7 +5039,7 @@ msgstr  ""
 msgid   "Set the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid   "Set the key as a network property"
 msgstr  ""
 
@@ -5038,7 +5051,7 @@ msgstr  ""
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid   "Set the key as a profile property"
 msgstr  ""
 
@@ -5054,23 +5067,23 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid   "Show all debug messages"
 msgstr  ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid   "Show all information messages"
 msgstr  ""
 
@@ -5078,7 +5091,7 @@ msgstr  ""
 msgid   "Show an identity provider group"
 msgstr  ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid   "Show cluster group configurations"
 msgstr  ""
 
@@ -5098,7 +5111,7 @@ msgstr  ""
 msgid   "Show events from all projects"
 msgstr  ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid   "Show full device configuration"
 msgstr  ""
 
@@ -5115,11 +5128,11 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid   "Show instance UEFI variables"
 msgstr  ""
 
@@ -5127,7 +5140,7 @@ msgstr  ""
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -5135,7 +5148,7 @@ msgstr  ""
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -5151,15 +5164,15 @@ msgstr  ""
 msgid   "Show network ACL log"
 msgstr  ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid   "Show network configurations"
 msgstr  ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid   "Show network forward configurations"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid   "Show network load balancer configurations"
 msgstr  ""
 
@@ -5179,7 +5192,7 @@ msgstr  ""
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid   "Show profile configurations"
 msgstr  ""
 
@@ -5199,11 +5212,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5219,7 +5232,7 @@ msgstr  ""
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -5269,15 +5282,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5312,7 +5325,7 @@ msgstr  ""
 msgid   "State"
 msgstr  ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid   "State: %s"
 msgstr  ""
@@ -5382,21 +5395,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -5457,19 +5470,19 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105 lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115 lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5505,7 +5518,7 @@ msgstr  ""
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid   "The device already exists"
 msgstr  ""
 
@@ -5540,7 +5553,7 @@ msgstr  ""
 msgid   "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr  ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
@@ -5549,22 +5562,22 @@ msgstr  ""
 msgid   "The property %q does not exist on the cluster member %q: %v"
 msgstr  ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid   "The property %q does not exist on the instance %q: %v"
 msgstr  ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid   "The property %q does not exist on the load balancer %q: %v"
 msgstr  ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid   "The property %q does not exist on the network %q: %v"
 msgstr  ""
@@ -5574,7 +5587,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
@@ -5594,7 +5607,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
@@ -5614,12 +5627,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -5640,11 +5653,11 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883 lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897 lxc/storage_volume.go:1001
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
@@ -5656,7 +5669,7 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
@@ -5668,7 +5681,7 @@ msgstr  ""
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote LXD server.\n"
         "\n"
@@ -5700,16 +5713,16 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -5724,7 +5737,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5732,7 +5745,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -5754,7 +5767,7 @@ msgstr  ""
 msgid   "Transferring instance: %s"
 msgstr  ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid   "Transmit policy"
 msgstr  ""
 
@@ -5788,7 +5801,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940 lxc/storage_volume.go:1484
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5810,11 +5823,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid   "USED BY"
 msgstr  ""
 
@@ -5827,7 +5840,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -5841,12 +5854,12 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782 lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5856,7 +5869,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5871,7 +5884,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
@@ -5883,15 +5896,15 @@ msgstr  ""
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -5899,23 +5912,23 @@ msgstr  ""
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid   "Unset network forward keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
@@ -5935,7 +5948,7 @@ msgstr  ""
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
@@ -5951,7 +5964,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -5963,11 +5976,11 @@ msgstr  ""
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
@@ -5975,7 +5988,7 @@ msgstr  ""
 msgid   "Unset the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid   "Unset the key as a network property"
 msgstr  ""
 
@@ -5987,7 +6000,7 @@ msgstr  ""
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
@@ -6003,11 +6016,11 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
@@ -6020,7 +6033,7 @@ msgstr  ""
 msgid   "Unsupported instance type: %s"
 msgstr  ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid   "Up delay"
 msgstr  ""
 
@@ -6032,7 +6045,7 @@ msgstr  ""
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
@@ -6041,24 +6054,24 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid   "Use a different metadata format version than the latest one supported by the server (to support imports on older LXD versions)"
 msgstr  ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
@@ -6084,15 +6097,15 @@ msgstr  ""
 msgid   "VFs: %d"
 msgstr  ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid   "VLAN ID"
 msgstr  ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid   "VLAN filtering"
 msgstr  ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid   "VLAN:"
 msgstr  ""
 
@@ -6119,7 +6132,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6148,7 +6161,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553 lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553 lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid   "YES"
 msgstr  ""
 
@@ -6172,15 +6185,15 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899 lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437 lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32 lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899 lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442 lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32 lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6284,7 +6297,7 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443 lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443 lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173 lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
@@ -6292,7 +6305,7 @@ msgstr  ""
 msgid   "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> [<key>=<value>...]"
 msgstr  ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
@@ -6312,15 +6325,15 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6344,43 +6357,43 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330 lxc/config_device.go:762 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403 lxc/config_device.go:829 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid   "[<remote>:]<instance> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid   "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid   "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid   "[<remote>:]<instance> <key>"
 msgstr  ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
@@ -6408,7 +6421,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -6420,11 +6433,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6444,11 +6457,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773 lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773 lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
@@ -6468,11 +6481,11 @@ msgstr  ""
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131 lxc/network.go:1366 lxc/network_forward.go:87 lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141 lxc/network.go:1376 lxc/network_forward.go:88 lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid   "[<remote>:]<network> <instance> [<device name>]"
 msgstr  ""
 
@@ -6480,47 +6493,47 @@ msgstr  ""
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652 lxc/network_forward.go:805 lxc/network_load_balancer.go:179 lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653 lxc/network_forward.go:806 lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605 lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
@@ -6544,19 +6557,19 @@ msgstr  ""
 msgid   "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid   "[<remote>:]<network> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid   "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr  ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
@@ -6568,7 +6581,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6600,47 +6613,47 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr  ""
 
@@ -6648,51 +6661,51 @@ msgstr  ""
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356 lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366 lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid   "[<remote>:]<profile> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid   "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid   "[<remote>:]<profile> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
@@ -6744,7 +6757,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6752,15 +6765,15 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -6848,14 +6861,14 @@ msgid   "lxc cluster group assign foo default,bar\n"
         "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr  ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid   "lxc cluster group create g1\n"
         "\n"
         "lxc cluster group create g1 < config.yaml\n"
         "	Create a cluster group with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid   "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/c1 path=/opt\n"
         "    Will mount the host's /share/c1 onto /opt in the instance.\n"
         "\n"
@@ -6863,12 +6876,12 @@ msgid   "lxc config device add [<remote>:]instance1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid   "lxc config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
@@ -6876,12 +6889,12 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
         "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr  ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
         "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""
@@ -6898,17 +6911,17 @@ msgid   "lxc file create foo/bar\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -7004,7 +7017,7 @@ msgid   "lxc network acl create a1\n"
         "    Create network acl with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid   "lxc network create foo\n"
         "    Create a new network called foo\n"
         "\n"
@@ -7012,14 +7025,14 @@ msgid   "lxc network create foo\n"
         "    Create a new OVN network called bar using baz as its uplink network"
 msgstr  ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid   "lxc network forward create n1 127.0.0.1\n"
         "\n"
         "lxc network forward create n1 127.0.0.1 < config.yaml\n"
         "    Create a new network forward for network n1 from config.yaml"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid   "lxc network load-balancer create n1 127.0.0.1\n"
         "\n"
         "lxc network load-balancer create n1 127.0.0.1 < config.yaml\n"
@@ -7045,7 +7058,7 @@ msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid   "lxc profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -7056,14 +7069,14 @@ msgid   "lxc profile assign foo default,bar\n"
         "    Remove all profile from \"foo\""
 msgstr  ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid   "lxc profile create p1\n"
         "\n"
         "lxc profile create p1 < config.yaml\n"
         "    Create profile with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/c1 path=/opt\n"
         "    Will mount the host's /share/c1 onto /opt in the instance.\n"
         "\n"
@@ -7071,7 +7084,7 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
@@ -7158,19 +7171,19 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid   "lxc storage volume create p1 v1\n"
         "\n"
         "lxc storage volume create p1 v1 < config.yaml\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"
@@ -7202,16 +7215,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -149,7 +149,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -162,7 +162,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -368,7 +368,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -406,7 +406,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -525,7 +525,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -559,7 +559,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -654,17 +654,17 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(geen)"
 
@@ -699,7 +699,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -740,7 +740,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -840,11 +840,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -905,11 +905,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -968,7 +968,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -1034,11 +1034,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1088,21 +1088,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1111,8 +1111,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1146,15 +1146,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1226,7 +1226,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1251,15 +1251,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1268,12 +1268,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1329,22 +1329,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1354,38 +1354,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1393,14 +1393,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1416,16 +1416,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1453,24 +1453,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1524,15 +1524,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1540,12 +1540,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1629,7 +1629,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1705,11 +1705,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1725,11 +1725,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1769,18 +1769,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1796,11 +1796,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1808,7 +1808,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1856,11 +1856,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1876,11 +1876,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1896,7 +1896,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1918,18 +1918,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1938,38 +1938,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1981,16 +1981,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2001,57 +2001,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2061,24 +2061,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2148,11 +2148,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2164,11 +2164,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2199,7 +2199,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2211,7 +2211,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2227,7 +2227,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2247,15 +2247,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2271,7 +2271,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2291,7 +2291,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2299,8 +2299,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2352,27 +2352,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2382,11 +2382,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2414,8 +2424,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2439,7 +2449,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2451,11 +2461,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2482,12 +2492,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2502,12 +2512,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2537,7 +2547,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2552,7 +2562,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2562,12 +2572,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2611,7 +2621,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2626,7 +2636,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2640,7 +2650,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2650,15 +2660,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2670,7 +2689,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2682,7 +2701,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2711,16 +2730,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2732,7 +2751,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2780,7 +2799,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2788,11 +2807,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2804,11 +2823,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2816,7 +2835,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2828,7 +2847,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2844,11 +2863,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2856,11 +2875,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2868,15 +2887,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2892,7 +2911,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2908,11 +2927,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2940,7 +2959,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2952,27 +2971,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2994,7 +3013,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3002,15 +3021,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -3040,11 +3059,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3054,7 +3073,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3066,7 +3085,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3082,11 +3101,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3096,7 +3115,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3104,7 +3123,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3112,7 +3131,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3134,16 +3153,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3164,11 +3183,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3182,11 +3201,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3243,12 +3262,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3274,7 +3293,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3282,15 +3301,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3300,18 +3319,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3342,13 +3361,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3361,7 +3380,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3398,7 +3417,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3414,7 +3433,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3434,11 +3453,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3458,7 +3477,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3525,7 +3544,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3637,11 +3656,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3669,11 +3688,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3732,7 +3751,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3745,15 +3764,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3761,7 +3780,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3771,11 +3790,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3792,11 +3811,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3804,7 +3823,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3894,7 +3913,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3918,23 +3937,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -4092,13 +4111,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -4124,8 +4143,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4134,20 +4153,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -4158,19 +4177,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4201,40 +4220,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4242,7 +4261,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4267,16 +4286,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4305,7 +4324,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4313,16 +4332,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4339,12 +4358,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4372,7 +4391,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4396,8 +4415,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4405,7 +4424,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4415,22 +4434,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4460,22 +4479,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4505,11 +4524,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4545,19 +4564,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4569,15 +4588,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4587,11 +4606,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4600,11 +4619,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4616,11 +4635,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4629,11 +4648,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4659,11 +4678,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4675,9 +4694,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4689,11 +4708,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4701,7 +4720,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4739,20 +4758,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4760,7 +4779,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4768,7 +4787,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4787,32 +4806,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4829,7 +4848,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4865,11 +4884,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4883,7 +4902,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4899,7 +4918,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4920,7 +4939,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4929,7 +4948,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4942,7 +4961,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4973,20 +4992,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4995,7 +5014,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5024,11 +5043,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5041,7 +5060,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5051,8 +5070,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -5067,7 +5086,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5098,7 +5117,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -5118,7 +5137,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5126,11 +5145,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -5142,11 +5161,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5154,15 +5173,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5182,7 +5201,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5211,11 +5230,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5227,15 +5246,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5249,7 +5268,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5272,7 +5291,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5287,11 +5306,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5353,17 +5372,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5388,7 +5407,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5426,7 +5445,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5434,15 +5453,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5451,7 +5470,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5460,15 +5479,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5490,11 +5509,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5503,11 +5522,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5516,11 +5535,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5559,11 +5578,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5611,11 +5630,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5624,7 +5643,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5632,7 +5651,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5640,7 +5659,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5648,7 +5667,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5660,11 +5679,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5672,7 +5691,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5684,7 +5703,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5700,23 +5719,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5724,7 +5743,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5744,7 +5763,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5765,11 +5784,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5777,7 +5796,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5785,7 +5804,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5801,15 +5820,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5829,7 +5848,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5849,11 +5868,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5871,7 +5890,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5921,15 +5940,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5964,7 +5983,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6034,21 +6053,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6110,21 +6129,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6162,7 +6181,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -6199,7 +6218,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6208,22 +6227,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6233,7 +6252,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6253,7 +6272,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6273,12 +6292,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6301,12 +6320,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6318,7 +6337,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6330,7 +6349,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6366,18 +6385,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6392,7 +6411,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6400,7 +6419,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6422,7 +6441,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6458,8 +6477,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6481,13 +6500,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6500,7 +6519,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6514,13 +6533,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6530,7 +6549,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6557,15 +6576,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6573,23 +6592,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6609,7 +6628,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6625,7 +6644,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6637,11 +6656,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6649,7 +6668,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6661,7 +6680,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6677,11 +6696,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6694,7 +6713,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6708,7 +6727,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6717,27 +6736,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6764,15 +6783,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6799,7 +6818,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6832,7 +6851,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6858,22 +6877,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6982,8 +7001,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6993,7 +7012,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -7013,15 +7032,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -7045,45 +7064,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7112,7 +7131,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7124,12 +7143,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7151,11 +7170,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -7175,13 +7194,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -7189,56 +7208,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7264,19 +7283,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7289,7 +7308,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7324,49 +7343,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7377,52 +7396,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7475,7 +7494,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7483,15 +7502,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7590,7 +7609,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7598,7 +7617,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7609,13 +7628,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7624,13 +7643,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7653,20 +7672,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7782,7 +7801,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7791,7 +7810,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7799,7 +7818,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7830,7 +7849,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7842,7 +7861,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7850,7 +7869,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7861,7 +7880,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7967,7 +7986,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7975,13 +7994,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8015,16 +8034,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -151,7 +151,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -168,7 +168,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -386,7 +386,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -428,7 +428,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -555,7 +555,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -593,7 +593,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -692,17 +692,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -778,7 +778,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -878,11 +878,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -890,11 +890,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -943,11 +943,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1045,7 +1045,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -1072,11 +1072,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1114,7 +1114,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1126,21 +1126,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1149,8 +1149,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1171,7 +1171,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1184,15 +1184,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -1204,7 +1204,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1289,15 +1289,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1306,12 +1306,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1367,22 +1367,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1392,38 +1392,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1431,14 +1431,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1454,16 +1454,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1491,24 +1491,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1562,15 +1562,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1578,12 +1578,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1691,7 +1691,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1731,7 +1731,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1743,11 +1743,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1763,11 +1763,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1807,18 +1807,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1834,11 +1834,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1846,7 +1846,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1894,11 +1894,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1914,11 +1914,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1956,18 +1956,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1976,38 +1976,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2019,16 +2019,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2039,57 +2039,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2099,24 +2099,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2137,7 +2137,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2186,11 +2186,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2202,11 +2202,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2237,7 +2237,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2249,7 +2249,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2265,7 +2265,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2285,15 +2285,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2337,8 +2337,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2390,27 +2390,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2420,11 +2420,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2452,8 +2462,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2489,11 +2499,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2520,12 +2530,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2540,12 +2550,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2575,7 +2585,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2590,7 +2600,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2600,12 +2610,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2649,7 +2659,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2664,7 +2674,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2678,7 +2688,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2688,15 +2698,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2708,7 +2727,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2720,7 +2739,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2749,16 +2768,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2818,7 +2837,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2826,11 +2845,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2842,11 +2861,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2854,7 +2873,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2866,7 +2885,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2882,11 +2901,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2894,11 +2913,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2906,15 +2925,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2930,7 +2949,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2946,11 +2965,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2978,7 +2997,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2990,27 +3009,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3032,7 +3051,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3040,15 +3059,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -3078,11 +3097,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3092,7 +3111,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3104,7 +3123,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3120,11 +3139,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3134,7 +3153,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3142,7 +3161,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3150,7 +3169,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3172,16 +3191,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3202,11 +3221,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3220,11 +3239,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3281,12 +3300,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3312,7 +3331,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3320,15 +3339,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3338,18 +3357,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3380,13 +3399,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3399,7 +3418,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3436,7 +3455,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3452,7 +3471,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3472,11 +3491,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3563,7 +3582,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3675,11 +3694,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3707,11 +3726,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3770,7 +3789,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3783,15 +3802,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3799,7 +3818,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3809,11 +3828,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3830,11 +3849,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3842,7 +3861,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3932,7 +3951,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3956,23 +3975,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -4130,13 +4149,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -4162,8 +4181,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4172,20 +4191,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -4196,19 +4215,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4239,40 +4258,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4280,7 +4299,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4305,16 +4324,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4343,7 +4362,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4351,16 +4370,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4377,12 +4396,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4410,7 +4429,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4434,8 +4453,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4443,7 +4462,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4453,22 +4472,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4498,22 +4517,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4543,11 +4562,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4583,19 +4602,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4607,15 +4626,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4625,11 +4644,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4638,11 +4657,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4654,11 +4673,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4667,11 +4686,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4697,11 +4716,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4713,9 +4732,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4727,11 +4746,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4739,7 +4758,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4777,20 +4796,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4798,7 +4817,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4806,7 +4825,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4825,32 +4844,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4867,7 +4886,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4903,11 +4922,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4921,7 +4940,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4937,7 +4956,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4958,7 +4977,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4967,7 +4986,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4980,7 +4999,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5011,20 +5030,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5033,7 +5052,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5062,11 +5081,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5079,7 +5098,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5089,8 +5108,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -5105,7 +5124,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5136,7 +5155,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -5156,7 +5175,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5164,11 +5183,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -5180,11 +5199,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5192,15 +5211,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5220,7 +5239,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5249,11 +5268,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5265,15 +5284,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5287,7 +5306,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5310,7 +5329,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5325,11 +5344,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5391,17 +5410,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5426,7 +5445,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5464,7 +5483,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5472,15 +5491,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5489,7 +5508,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5498,15 +5517,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5528,11 +5547,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5541,11 +5560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5554,11 +5573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5597,11 +5616,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5649,11 +5668,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5662,7 +5681,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5670,7 +5689,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5678,7 +5697,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5686,7 +5705,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5698,11 +5717,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5710,7 +5729,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5722,7 +5741,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5738,23 +5757,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5762,7 +5781,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5782,7 +5801,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5803,11 +5822,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5815,7 +5834,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5823,7 +5842,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5867,7 +5886,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5887,11 +5906,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5909,7 +5928,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5959,15 +5978,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -6002,7 +6021,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6072,21 +6091,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6148,21 +6167,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6200,7 +6219,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -6237,7 +6256,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6246,22 +6265,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6271,7 +6290,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6291,7 +6310,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6311,12 +6330,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6339,12 +6358,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6356,7 +6375,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6368,7 +6387,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6404,18 +6423,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6430,7 +6449,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6438,7 +6457,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6460,7 +6479,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6496,8 +6515,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6519,13 +6538,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6538,7 +6557,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6552,13 +6571,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6568,7 +6587,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6583,7 +6602,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6595,15 +6614,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6611,23 +6630,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6647,7 +6666,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6663,7 +6682,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6675,11 +6694,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6687,7 +6706,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6699,7 +6718,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6715,11 +6734,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6732,7 +6751,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6746,7 +6765,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6755,27 +6774,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6802,15 +6821,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6837,7 +6856,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6870,7 +6889,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6896,22 +6915,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7020,8 +7039,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -7031,7 +7050,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -7051,15 +7070,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -7083,45 +7102,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7150,7 +7169,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7162,12 +7181,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7189,11 +7208,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -7213,13 +7232,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -7227,56 +7246,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7302,19 +7321,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7327,7 +7346,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7362,49 +7381,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7415,52 +7434,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7513,7 +7532,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7521,15 +7540,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7628,7 +7647,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7636,7 +7655,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7647,13 +7666,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7662,13 +7681,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7691,20 +7710,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7820,7 +7839,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7829,7 +7848,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7837,7 +7856,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7868,7 +7887,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7880,7 +7899,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7888,7 +7907,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7899,7 +7918,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8005,7 +8024,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8013,13 +8032,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8053,16 +8072,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,13 +103,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -613,11 +613,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -625,11 +625,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -678,11 +678,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -807,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -861,21 +861,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -884,8 +884,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1024,15 +1024,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,38 +1127,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1226,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1297,15 +1297,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,11 +1478,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1498,11 +1498,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,18 +1542,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1629,11 +1629,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1649,11 +1649,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,18 +1691,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1711,38 +1711,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1754,16 +1754,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1774,57 +1774,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1834,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1921,11 +1921,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,11 +1937,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1972,7 +1972,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1984,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2020,15 +2020,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2072,8 +2072,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2125,27 +2125,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2155,11 +2155,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2187,8 +2197,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2212,7 +2222,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2224,11 +2234,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2255,12 +2265,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2275,12 +2285,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2310,7 +2320,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2325,7 +2335,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2335,12 +2345,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2384,7 +2394,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2399,7 +2409,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2413,7 +2423,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2423,15 +2433,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2443,7 +2462,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2455,7 +2474,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2484,16 +2503,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2505,7 +2524,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2553,7 +2572,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2561,11 +2580,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2577,11 +2596,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2589,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2601,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2617,11 +2636,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2629,11 +2648,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2641,15 +2660,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2665,7 +2684,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2681,11 +2700,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2713,7 +2732,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2725,27 +2744,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2767,7 +2786,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2775,15 +2794,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2813,11 +2832,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2827,7 +2846,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2839,7 +2858,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2855,11 +2874,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2869,7 +2888,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2896,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2885,7 +2904,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2907,16 +2926,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2937,11 +2956,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2955,11 +2974,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3016,12 +3035,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3066,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3055,15 +3074,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3073,18 +3092,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3115,13 +3134,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3134,7 +3153,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3187,7 +3206,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3207,11 +3226,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3231,7 +3250,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3298,7 +3317,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3410,11 +3429,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3442,11 +3461,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3505,7 +3524,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3518,15 +3537,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3544,11 +3563,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3565,11 +3584,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3577,7 +3596,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3667,7 +3686,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3691,23 +3710,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3865,13 +3884,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3897,8 +3916,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3907,20 +3926,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3931,19 +3950,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3974,40 +3993,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4015,7 +4034,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4040,16 +4059,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4078,7 +4097,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4086,16 +4105,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4112,12 +4131,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4145,7 +4164,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4169,8 +4188,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4178,7 +4197,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4188,22 +4207,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4233,22 +4252,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4278,11 +4297,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4318,19 +4337,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4342,15 +4361,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4360,11 +4379,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4373,11 +4392,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4389,11 +4408,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4402,11 +4421,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4432,11 +4451,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4448,9 +4467,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4462,11 +4481,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4474,7 +4493,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4512,20 +4531,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4533,7 +4552,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4541,7 +4560,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4560,32 +4579,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4602,7 +4621,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,11 +4657,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4656,7 +4675,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4672,7 +4691,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4712,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4702,7 +4721,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4715,7 +4734,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4746,20 +4765,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4768,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4797,11 +4816,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4814,7 +4833,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,8 +4843,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4840,7 +4859,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4871,7 +4890,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4891,7 +4910,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4899,11 +4918,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4915,11 +4934,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4927,15 +4946,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4955,7 +4974,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4984,11 +5003,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5000,15 +5019,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5022,7 +5041,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5045,7 +5064,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5060,11 +5079,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5126,17 +5145,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5161,7 +5180,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5199,7 +5218,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5207,15 +5226,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5224,7 +5243,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5233,15 +5252,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5263,11 +5282,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5276,11 +5295,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5289,11 +5308,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5332,11 +5351,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5384,11 +5403,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5397,7 +5416,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5421,7 +5440,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,11 +5452,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5445,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5457,7 +5476,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5473,23 +5492,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5497,7 +5516,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5517,7 +5536,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5538,11 +5557,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5550,7 +5569,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5558,7 +5577,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5574,15 +5593,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5602,7 +5621,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5622,11 +5641,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5644,7 +5663,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5694,15 +5713,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5737,7 +5756,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5807,21 +5826,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5883,21 +5902,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5972,7 +5991,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5981,22 +6000,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6006,7 +6025,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6026,7 +6045,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6046,12 +6065,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6074,12 +6093,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6091,7 +6110,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6103,7 +6122,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6139,18 +6158,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6165,7 +6184,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6173,7 +6192,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6195,7 +6214,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6231,8 +6250,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6254,13 +6273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6273,7 +6292,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6287,13 +6306,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6303,7 +6322,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6318,7 +6337,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6330,15 +6349,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6346,23 +6365,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6382,7 +6401,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6398,7 +6417,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6410,11 +6429,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6422,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6434,7 +6453,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6450,11 +6469,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6467,7 +6486,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6481,7 +6500,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6490,27 +6509,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6537,15 +6556,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6572,7 +6591,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6605,7 +6624,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6631,22 +6650,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6755,8 +6774,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6766,7 +6785,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6786,15 +6805,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6818,45 +6837,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6885,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6897,12 +6916,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6924,11 +6943,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6948,13 +6967,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6962,56 +6981,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7037,19 +7056,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7062,7 +7081,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7097,49 +7116,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7150,52 +7169,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7248,7 +7267,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7256,15 +7275,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7363,7 +7382,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7371,7 +7390,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7382,13 +7401,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7397,13 +7416,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7426,20 +7445,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7555,7 +7574,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7564,7 +7583,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7572,7 +7591,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7622,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7615,7 +7634,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7623,7 +7642,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7634,7 +7653,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7740,7 +7759,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7748,13 +7767,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7788,16 +7807,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -152,7 +152,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -165,7 +165,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -377,7 +377,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -418,7 +418,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -543,7 +543,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -580,7 +580,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -678,17 +678,17 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -727,7 +727,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -752,7 +752,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -774,7 +774,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
@@ -856,7 +856,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
@@ -878,11 +878,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -890,12 +890,12 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -945,11 +945,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1035,7 +1035,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
@@ -1063,7 +1063,7 @@ msgstr "Atribuir conjuntos de perfis aos containers"
 msgid "Attach network interfaces to instances"
 msgstr "Anexar interfaces de rede aos containers"
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
@@ -1084,11 +1084,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1140,21 +1140,21 @@ msgstr "Criar projetos"
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1163,8 +1163,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1175,7 +1175,7 @@ msgstr "par de chave/valor inválido %s"
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1185,7 +1185,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1198,15 +1198,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1218,7 +1218,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1305,15 +1305,15 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1322,12 +1322,12 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1366,7 +1366,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1385,22 +1385,22 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1410,38 +1410,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1449,14 +1449,14 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1472,16 +1472,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr "Cliente de linha de comando para LXD"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1518,24 +1518,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1591,15 +1591,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1607,12 +1607,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1724,7 +1724,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1773,7 +1773,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1787,12 +1787,12 @@ msgstr "Editar templates de arquivo do container"
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Criar novas redes"
@@ -1812,11 +1812,11 @@ msgstr "Criar novas redes"
 msgid "Create new network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr "Criar perfis"
 
@@ -1832,7 +1832,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1857,18 +1857,18 @@ msgstr "Criando %s"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1884,11 +1884,11 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1897,7 +1897,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1952,12 +1952,12 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
@@ -1977,11 +1977,11 @@ msgstr "Criar novas redes"
 msgid "Delete network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1998,7 +1998,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2020,18 +2020,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2040,38 +2040,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2083,16 +2083,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2103,60 +2103,60 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "Dispositivo %s sobreposto em %s"
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
@@ -2166,25 +2166,25 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Device already exists: %s"
 msgstr "O dispositivo já existe: %s"
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Alias %s não existe"
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2260,12 +2260,12 @@ msgstr "Criar projetos"
 msgid "Display network zones from all projects"
 msgstr "Criar projetos"
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Criar projetos"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
@@ -2279,11 +2279,11 @@ msgstr "Criar projetos"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2315,7 +2315,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2348,7 +2348,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -2363,7 +2363,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Edit instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -2373,16 +2373,16 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Edit network ACL configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2402,7 +2402,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2433,8 +2433,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2486,27 +2486,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2516,12 +2516,22 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2549,8 +2559,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2574,7 +2584,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2586,11 +2596,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2617,12 +2627,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2637,12 +2647,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2672,7 +2682,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2687,7 +2697,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2697,12 +2707,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2746,7 +2756,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2761,7 +2771,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2775,7 +2785,7 @@ msgstr "Aceitar certificado"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2785,15 +2795,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2805,7 +2824,7 @@ msgstr "Forçar alocação de pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2818,7 +2837,7 @@ msgstr "Ignorar o estado do container"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2847,16 +2866,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2868,7 +2887,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2916,7 +2935,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -2925,12 +2944,12 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2942,12 +2961,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -2957,7 +2976,7 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2971,7 +2990,7 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2988,12 +3007,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -3002,12 +3021,12 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3017,16 +3036,16 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3046,7 +3065,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3064,11 +3083,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3096,7 +3115,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3108,27 +3127,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3150,7 +3169,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3158,15 +3177,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3196,11 +3215,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3210,7 +3229,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3223,7 +3242,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3239,11 +3258,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
@@ -3253,7 +3272,7 @@ msgstr "Falta o identificador da imagem: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3262,7 +3281,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3270,7 +3289,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3292,16 +3311,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Editar arquivos no container"
@@ -3322,11 +3341,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3340,11 +3359,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3401,12 +3420,12 @@ msgstr "Versão do cliente: %s\n"
 msgid "Invalid format: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3432,7 +3451,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
@@ -3441,15 +3460,15 @@ msgstr "Editar arquivos no container"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3459,19 +3478,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3502,13 +3521,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3521,7 +3540,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3559,7 +3578,7 @@ msgstr "Arquitetura: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3577,7 +3596,7 @@ msgstr "Nome de membro do cluster"
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
@@ -3598,11 +3617,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Criar novas redes"
@@ -3624,7 +3643,7 @@ msgstr "Criar novas redes"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3691,7 +3710,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3806,11 +3825,11 @@ msgstr "Criar projetos"
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3838,11 +3857,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3901,7 +3920,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3914,17 +3933,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 #, fuzzy
 msgid "Lower device"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 #, fuzzy
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3932,7 +3951,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3942,11 +3961,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3963,11 +3982,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3975,7 +3994,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4070,7 +4089,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -4099,27 +4118,27 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Criar novas redes"
@@ -4291,14 +4310,14 @@ msgstr "Nome de membro do cluster"
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4329,8 +4348,8 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4340,21 +4359,21 @@ msgstr ""
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -4366,19 +4385,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4412,41 +4431,41 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4455,7 +4474,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4480,16 +4499,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4519,7 +4538,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4527,16 +4546,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4553,12 +4572,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4586,7 +4605,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4610,8 +4629,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4619,7 +4638,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4629,22 +4648,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4674,22 +4693,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4719,11 +4738,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4759,19 +4778,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4783,15 +4802,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4801,11 +4820,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4814,11 +4833,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4830,11 +4849,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4843,11 +4862,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4873,11 +4892,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4889,9 +4908,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4903,11 +4922,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4915,7 +4934,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4954,20 +4973,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4975,7 +4994,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4983,7 +5002,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -5002,32 +5021,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -5047,7 +5066,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5085,11 +5104,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5103,7 +5122,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5119,7 +5138,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5140,7 +5159,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5149,7 +5168,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5162,7 +5181,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5193,21 +5212,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5216,7 +5235,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5247,11 +5266,11 @@ msgstr "Editar arquivos no container"
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5264,7 +5283,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5274,8 +5293,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -5290,7 +5309,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5323,7 +5342,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
@@ -5346,7 +5365,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5354,12 +5373,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
@@ -5374,11 +5393,11 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5387,17 +5406,17 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
@@ -5421,7 +5440,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5451,11 +5470,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5467,15 +5486,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5489,7 +5508,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5513,7 +5532,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -5534,11 +5553,11 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -5603,17 +5622,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5638,7 +5657,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5676,7 +5695,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -5686,16 +5705,16 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5704,7 +5723,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5713,17 +5732,17 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5746,11 +5765,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5759,12 +5778,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5773,12 +5792,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5820,11 +5839,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5874,11 +5893,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5887,7 +5906,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5895,7 +5914,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5903,7 +5922,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5911,7 +5930,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5923,12 +5942,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -5938,7 +5957,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5952,7 +5971,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5969,24 +5988,24 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5994,7 +6013,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6016,7 +6035,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
@@ -6039,11 +6058,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -6053,7 +6072,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6063,7 +6082,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -6081,16 +6100,16 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network ACL log"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6115,7 +6134,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6137,11 +6156,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6160,7 +6179,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6213,15 +6232,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -6256,7 +6275,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6326,21 +6345,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6403,22 +6422,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6459,7 +6478,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -6496,7 +6515,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6505,22 +6524,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6530,7 +6549,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6550,7 +6569,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6570,12 +6589,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6598,12 +6617,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6615,7 +6634,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
@@ -6629,7 +6648,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6665,18 +6684,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6691,7 +6710,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6699,7 +6718,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6721,7 +6740,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6759,8 +6778,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6782,13 +6801,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6801,7 +6820,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6816,13 +6835,13 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6832,7 +6851,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6847,7 +6866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6862,17 +6881,17 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6882,26 +6901,26 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
@@ -6926,7 +6945,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6944,7 +6963,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6956,12 +6975,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -6971,7 +6990,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Criar novas redes"
@@ -6986,7 +7005,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -7003,11 +7022,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7020,7 +7039,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -7035,7 +7054,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7044,28 +7063,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 #, fuzzy
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7092,15 +7111,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -7127,7 +7146,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7160,7 +7179,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7186,13 +7205,13 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7200,10 +7219,10 @@ msgid ""
 msgstr "Criar perfis"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7326,8 +7345,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
@@ -7339,7 +7358,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "Criar perfis"
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
@@ -7364,16 +7383,16 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7399,47 +7418,47 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7470,7 +7489,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7483,12 +7502,12 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7511,11 +7530,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
@@ -7539,13 +7558,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -7553,62 +7572,62 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7639,20 +7658,20 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Criar perfis"
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7665,7 +7684,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7705,54 +7724,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -7765,57 +7784,57 @@ msgid ""
 "[<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7877,7 +7896,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7885,15 +7904,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -7996,7 +8015,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8004,7 +8023,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8015,13 +8034,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8030,13 +8049,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8059,20 +8078,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8188,7 +8207,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8197,7 +8216,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8205,7 +8224,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8236,7 +8255,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8248,7 +8267,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8256,7 +8275,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8267,7 +8286,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8373,7 +8392,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8381,13 +8400,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8421,16 +8440,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -156,7 +156,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -169,7 +169,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -378,7 +378,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -419,7 +419,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -551,7 +551,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -588,7 +588,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -687,17 +687,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr "(пусто)"
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
@@ -881,11 +881,11 @@ msgstr "Копирование образа: %s"
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -893,12 +893,12 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -948,11 +948,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1036,7 +1036,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -1082,11 +1082,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1137,21 +1137,21 @@ msgstr "Доступные команды:"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1160,8 +1160,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1195,15 +1195,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1302,15 +1302,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1319,12 +1319,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1366,7 +1366,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1385,22 +1385,22 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1410,38 +1410,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1449,14 +1449,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1472,16 +1472,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1509,24 +1509,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1581,15 +1581,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
@@ -1598,12 +1598,12 @@ msgstr "Копирование образа: %s"
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1617,7 +1617,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1715,7 +1715,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1762,7 +1762,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1776,12 +1776,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Копирование образа: %s"
@@ -1801,11 +1801,11 @@ msgstr "Копирование образа: %s"
 msgid "Create new network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1848,18 +1848,18 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1875,11 +1875,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1887,7 +1887,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr "Копирование образа: %s"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
@@ -1963,11 +1963,11 @@ msgstr "Копирование образа: %s"
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1984,7 +1984,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -2007,18 +2007,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2027,38 +2027,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -2070,16 +2070,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2090,59 +2090,59 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2152,24 +2152,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2247,12 +2247,12 @@ msgstr "Копирование образа: %s"
 msgid "Display network zones from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
@@ -2266,11 +2266,11 @@ msgstr "Копирование образа: %s"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2301,7 +2301,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2330,7 +2330,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2345,7 +2345,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2353,15 +2353,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2381,7 +2381,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2410,8 +2410,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2463,27 +2463,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2493,7 +2493,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2501,7 +2501,17 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2529,8 +2539,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2555,7 +2565,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2570,12 +2580,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2602,12 +2612,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2622,12 +2632,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2657,7 +2667,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2672,7 +2682,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2682,12 +2692,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2731,7 +2741,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2746,7 +2756,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2760,7 +2770,7 @@ msgstr "Принять сертификат"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2770,15 +2780,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2790,7 +2809,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2803,7 +2822,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2832,16 +2851,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2853,7 +2872,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2901,7 +2920,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2910,11 +2929,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2926,12 +2945,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -2941,7 +2960,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2955,7 +2974,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2973,12 +2992,12 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2987,11 +3006,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2999,16 +3018,16 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
@@ -3028,7 +3047,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3045,11 +3064,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3077,7 +3096,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3090,27 +3109,27 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3132,7 +3151,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3140,15 +3159,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -3178,11 +3197,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3192,7 +3211,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3205,7 +3224,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3221,11 +3240,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3235,7 +3254,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3243,7 +3262,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3251,7 +3270,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3276,16 +3295,16 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3307,11 +3326,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3326,12 +3345,12 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3388,12 +3407,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3419,7 +3438,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -3428,15 +3447,15 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3446,19 +3465,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3489,13 +3508,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3508,7 +3527,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3546,7 +3565,7 @@ msgstr "Архитектура: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3565,7 +3584,7 @@ msgstr "Копирование образа: %s"
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
@@ -3587,11 +3606,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Копирование образа: %s"
@@ -3613,7 +3632,7 @@ msgstr "Копирование образа: %s"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3681,7 +3700,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 #, fuzzy
 msgid "List instance devices"
 msgstr "Копирование образа: %s"
@@ -3798,11 +3817,11 @@ msgstr "Копирование образа: %s"
 msgid "List permissions"
 msgstr "Псевдонимы:"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3832,12 +3851,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3897,7 +3916,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3910,17 +3929,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 #, fuzzy
 msgid "Lower device"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 #, fuzzy
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3928,7 +3947,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3938,11 +3957,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3959,11 +3978,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3971,7 +3990,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4066,7 +4085,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4094,27 +4113,27 @@ msgstr "Копирование образа: %s"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Копирование образа: %s"
@@ -4289,14 +4308,14 @@ msgstr "Имя контейнера: %s"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4327,8 +4346,8 @@ msgstr "Копирование образа: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
@@ -4339,21 +4358,21 @@ msgstr "Имя контейнера: %s"
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -4365,19 +4384,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4411,43 +4430,43 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4456,7 +4475,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4481,16 +4500,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4520,7 +4539,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -4529,16 +4548,16 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4555,12 +4574,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4588,7 +4607,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4612,8 +4631,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4621,7 +4640,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4631,22 +4650,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4676,22 +4695,22 @@ msgstr " Использование сети:"
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
@@ -4721,12 +4740,12 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 #, fuzzy
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -4763,20 +4782,20 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4788,15 +4807,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4806,12 +4825,12 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4820,11 +4839,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4836,11 +4855,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4849,11 +4868,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4879,11 +4898,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4895,9 +4914,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4909,11 +4928,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4921,7 +4940,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -4960,20 +4979,20 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4981,7 +5000,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4989,7 +5008,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -5008,32 +5027,32 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -5050,7 +5069,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5086,11 +5105,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5104,7 +5123,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5120,7 +5139,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5141,7 +5160,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5150,7 +5169,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5163,7 +5182,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5194,20 +5213,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5216,7 +5235,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5247,11 +5266,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -5266,7 +5285,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5276,8 +5295,8 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -5292,7 +5311,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5324,7 +5343,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
@@ -5346,7 +5365,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5354,12 +5373,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
@@ -5372,12 +5391,12 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5385,16 +5404,16 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5415,7 +5434,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5447,11 +5466,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5463,17 +5482,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5487,7 +5506,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5511,7 +5530,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -5528,12 +5547,12 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -5598,17 +5617,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5633,7 +5652,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5671,7 +5690,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5681,15 +5700,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5698,7 +5717,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5707,15 +5726,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5737,11 +5756,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5750,12 +5769,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5764,12 +5783,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5811,11 +5830,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5864,11 +5883,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5877,7 +5896,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5893,7 +5912,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5901,7 +5920,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5913,12 +5932,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -5928,7 +5947,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5942,7 +5961,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5960,24 +5979,24 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5985,7 +6004,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Копирование образа: %s"
@@ -6007,7 +6026,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -6029,11 +6048,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6043,7 +6062,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -6051,7 +6070,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -6068,16 +6087,16 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Копирование образа: %s"
@@ -6102,7 +6121,7 @@ msgstr "Копирование образа: %s"
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6124,11 +6143,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -6147,7 +6166,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6200,16 +6219,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -6245,7 +6264,7 @@ msgstr ""
 msgid "State"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
@@ -6317,21 +6336,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6394,21 +6413,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6446,7 +6465,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -6483,7 +6502,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6492,22 +6511,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Копирование образа: %s"
@@ -6517,7 +6536,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
@@ -6537,7 +6556,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
@@ -6557,12 +6576,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6585,12 +6604,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6602,7 +6621,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
@@ -6615,7 +6634,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6651,18 +6670,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -6677,7 +6696,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6685,7 +6704,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6707,7 +6726,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6744,8 +6763,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6767,13 +6786,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6786,7 +6805,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6800,13 +6819,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6816,7 +6835,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6831,7 +6850,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6845,15 +6864,15 @@ msgstr "Копирование образа: %s"
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6861,26 +6880,26 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
@@ -6905,7 +6924,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6922,7 +6941,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6934,12 +6953,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -6949,7 +6968,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Копирование образа: %s"
@@ -6964,7 +6983,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6982,12 +7001,12 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7000,7 +7019,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -7015,7 +7034,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7024,28 +7043,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 #, fuzzy
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7072,15 +7091,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -7107,7 +7126,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7140,7 +7159,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7166,7 +7185,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
@@ -7175,7 +7194,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7186,10 +7205,10 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7386,8 +7405,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7405,7 +7424,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7445,7 +7464,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7453,7 +7472,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7461,7 +7480,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7509,8 +7528,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7519,7 +7538,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7527,7 +7546,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7535,7 +7554,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -7543,7 +7562,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7551,7 +7570,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7559,7 +7578,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7567,7 +7586,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7575,7 +7594,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7583,7 +7602,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7640,7 +7659,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7664,7 +7683,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7673,7 +7692,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7715,7 +7734,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7723,7 +7742,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -7763,9 +7782,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7773,7 +7792,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -7789,7 +7808,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -7797,7 +7816,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -7805,9 +7824,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7815,7 +7834,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -7823,7 +7842,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -7833,8 +7852,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -7842,7 +7861,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7850,7 +7869,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -7860,13 +7879,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -7874,7 +7893,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -7924,7 +7943,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -7932,7 +7951,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -7940,7 +7959,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -7948,7 +7967,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -7973,7 +7992,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8040,7 +8059,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8050,7 +8069,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8058,7 +8077,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8066,7 +8085,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8074,7 +8093,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8082,7 +8101,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8090,7 +8109,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8098,7 +8117,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8106,7 +8125,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8114,7 +8133,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8122,7 +8141,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -8141,7 +8160,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8149,7 +8168,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8157,7 +8176,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8165,8 +8184,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8174,7 +8193,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8182,7 +8201,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8190,7 +8209,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -8198,7 +8217,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8206,7 +8225,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8214,7 +8233,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8222,7 +8241,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8230,7 +8249,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8335,7 +8354,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8351,7 +8370,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8359,7 +8378,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8367,7 +8386,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8482,7 +8501,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8490,7 +8509,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8501,13 +8520,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8516,13 +8535,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8545,20 +8564,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8674,7 +8693,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8683,7 +8702,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8691,7 +8710,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8722,7 +8741,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8734,7 +8753,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8742,7 +8761,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8753,7 +8772,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8859,7 +8878,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8867,13 +8886,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8907,16 +8926,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,13 +107,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -517,7 +517,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -617,11 +617,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -629,11 +629,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -682,11 +682,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -784,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -865,21 +865,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -888,8 +888,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1028,15 +1028,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,38 +1131,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1230,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1301,15 +1301,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1482,11 +1482,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1502,11 +1502,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,18 +1546,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1633,11 +1633,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1653,11 +1653,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1695,18 +1695,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1715,38 +1715,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1758,16 +1758,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1778,57 +1778,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1838,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1941,11 +1941,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1976,7 +1976,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1988,7 +1988,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2024,15 +2024,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2048,7 +2048,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2076,8 +2076,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2129,27 +2129,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2159,11 +2159,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2191,8 +2201,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2226,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2238,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2259,12 +2269,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2279,12 +2289,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2314,7 +2324,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2329,7 +2339,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2339,12 +2349,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2388,7 +2398,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2403,7 +2413,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2417,7 +2427,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2427,15 +2437,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2447,7 +2466,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2459,7 +2478,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2488,16 +2507,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2509,7 +2528,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2557,7 +2576,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2565,11 +2584,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2581,11 +2600,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2593,7 +2612,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2605,7 +2624,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2621,11 +2640,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2633,11 +2652,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2645,15 +2664,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2669,7 +2688,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2685,11 +2704,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2717,7 +2736,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2729,27 +2748,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2771,7 +2790,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2779,15 +2798,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2817,11 +2836,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2831,7 +2850,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2843,7 +2862,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2859,11 +2878,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2873,7 +2892,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2900,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2889,7 +2908,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2911,16 +2930,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2941,11 +2960,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2959,11 +2978,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3020,12 +3039,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3051,7 +3070,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3059,15 +3078,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3077,18 +3096,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3119,13 +3138,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3138,7 +3157,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,7 +3194,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3191,7 +3210,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3211,11 +3230,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3235,7 +3254,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3302,7 +3321,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3414,11 +3433,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,11 +3465,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3509,7 +3528,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3522,15 +3541,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3538,7 +3557,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3548,11 +3567,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3569,11 +3588,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3581,7 +3600,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3671,7 +3690,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3695,23 +3714,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3869,13 +3888,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3901,8 +3920,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3911,20 +3930,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3935,19 +3954,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3978,40 +3997,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4019,7 +4038,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4044,16 +4063,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4082,7 +4101,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4090,16 +4109,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4116,12 +4135,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4149,7 +4168,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4173,8 +4192,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4182,7 +4201,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4192,22 +4211,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4237,22 +4256,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4282,11 +4301,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4322,19 +4341,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4346,15 +4365,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4364,11 +4383,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4377,11 +4396,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4393,11 +4412,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4406,11 +4425,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4455,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4452,9 +4471,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,11 +4485,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4478,7 +4497,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4516,20 +4535,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4537,7 +4556,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4545,7 +4564,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4564,32 +4583,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4606,7 +4625,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4642,11 +4661,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4660,7 +4679,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4676,7 +4695,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4716,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4706,7 +4725,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4738,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4750,20 +4769,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4772,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4801,11 +4820,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4818,7 +4837,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4828,8 +4847,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4844,7 +4863,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4875,7 +4894,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4895,7 +4914,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4903,11 +4922,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4919,11 +4938,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4931,15 +4950,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4959,7 +4978,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +5007,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5004,15 +5023,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5026,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5049,7 +5068,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5064,11 +5083,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5130,17 +5149,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5165,7 +5184,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5203,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5211,15 +5230,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5228,7 +5247,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5237,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5267,11 +5286,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5280,11 +5299,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5293,11 +5312,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5336,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5388,11 +5407,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5401,7 +5420,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5409,7 +5428,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5417,7 +5436,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5425,7 +5444,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5437,11 +5456,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5449,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5461,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5477,23 +5496,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5501,7 +5520,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5521,7 +5540,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5542,11 +5561,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5554,7 +5573,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5562,7 +5581,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5578,15 +5597,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5606,7 +5625,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5626,11 +5645,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5648,7 +5667,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5698,15 +5717,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5741,7 +5760,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5811,21 +5830,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5887,21 +5906,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5976,7 +5995,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5985,22 +6004,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6010,7 +6029,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6030,7 +6049,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6050,12 +6069,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6078,12 +6097,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6095,7 +6114,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6107,7 +6126,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6143,18 +6162,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6169,7 +6188,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6177,7 +6196,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6218,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6235,8 +6254,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6258,13 +6277,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6277,7 +6296,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6291,13 +6310,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6307,7 +6326,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6322,7 +6341,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6334,15 +6353,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6350,23 +6369,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6402,7 +6421,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6414,11 +6433,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6426,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6438,7 +6457,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6454,11 +6473,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6471,7 +6490,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6485,7 +6504,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6494,27 +6513,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6541,15 +6560,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6576,7 +6595,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6609,7 +6628,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6635,22 +6654,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6759,8 +6778,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6770,7 +6789,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6790,15 +6809,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6822,45 +6841,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6889,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6901,12 +6920,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6928,11 +6947,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6952,13 +6971,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6966,56 +6985,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7041,19 +7060,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7066,7 +7085,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7101,49 +7120,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7154,52 +7173,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7252,7 +7271,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7260,15 +7279,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7367,7 +7386,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7375,7 +7394,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7386,13 +7405,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7401,13 +7420,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7430,20 +7449,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7559,7 +7578,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7568,7 +7587,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7576,7 +7595,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7607,7 +7626,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7619,7 +7638,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7627,7 +7646,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7638,7 +7657,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7744,7 +7763,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7752,13 +7771,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7792,16 +7811,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,13 +107,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -517,7 +517,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -617,11 +617,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -629,11 +629,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -682,11 +682,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -784,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -865,21 +865,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -888,8 +888,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1028,15 +1028,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,38 +1131,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1230,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1301,15 +1301,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1482,11 +1482,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1502,11 +1502,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,18 +1546,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1633,11 +1633,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1653,11 +1653,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1695,18 +1695,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1715,38 +1715,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1758,16 +1758,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1778,57 +1778,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1838,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1941,11 +1941,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1976,7 +1976,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1988,7 +1988,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2024,15 +2024,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2048,7 +2048,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2076,8 +2076,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2129,27 +2129,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2159,11 +2159,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2191,8 +2201,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2226,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2238,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2259,12 +2269,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2279,12 +2289,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2314,7 +2324,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2329,7 +2339,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2339,12 +2349,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2388,7 +2398,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2403,7 +2413,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2417,7 +2427,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2427,15 +2437,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2447,7 +2466,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2459,7 +2478,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2488,16 +2507,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2509,7 +2528,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2557,7 +2576,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2565,11 +2584,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2581,11 +2600,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2593,7 +2612,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2605,7 +2624,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2621,11 +2640,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2633,11 +2652,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2645,15 +2664,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2669,7 +2688,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2685,11 +2704,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2717,7 +2736,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2729,27 +2748,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2771,7 +2790,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2779,15 +2798,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2817,11 +2836,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2831,7 +2850,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2843,7 +2862,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2859,11 +2878,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2873,7 +2892,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2900,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2889,7 +2908,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2911,16 +2930,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2941,11 +2960,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2959,11 +2978,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3020,12 +3039,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3051,7 +3070,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3059,15 +3078,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3077,18 +3096,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3119,13 +3138,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3138,7 +3157,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,7 +3194,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3191,7 +3210,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3211,11 +3230,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3235,7 +3254,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3302,7 +3321,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3414,11 +3433,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,11 +3465,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3509,7 +3528,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3522,15 +3541,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3538,7 +3557,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3548,11 +3567,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3569,11 +3588,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3581,7 +3600,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3671,7 +3690,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3695,23 +3714,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3869,13 +3888,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3901,8 +3920,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3911,20 +3930,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3935,19 +3954,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3978,40 +3997,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4019,7 +4038,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4044,16 +4063,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4082,7 +4101,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4090,16 +4109,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4116,12 +4135,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4149,7 +4168,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4173,8 +4192,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4182,7 +4201,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4192,22 +4211,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4237,22 +4256,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4282,11 +4301,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4322,19 +4341,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4346,15 +4365,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4364,11 +4383,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4377,11 +4396,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4393,11 +4412,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4406,11 +4425,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4455,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4452,9 +4471,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,11 +4485,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4478,7 +4497,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4516,20 +4535,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4537,7 +4556,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4545,7 +4564,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4564,32 +4583,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4606,7 +4625,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4642,11 +4661,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4660,7 +4679,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4676,7 +4695,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4716,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4706,7 +4725,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4738,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4750,20 +4769,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4772,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4801,11 +4820,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4818,7 +4837,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4828,8 +4847,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4844,7 +4863,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4875,7 +4894,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4895,7 +4914,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4903,11 +4922,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4919,11 +4938,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4931,15 +4950,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4959,7 +4978,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +5007,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5004,15 +5023,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5026,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5049,7 +5068,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5064,11 +5083,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5130,17 +5149,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5165,7 +5184,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5203,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5211,15 +5230,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5228,7 +5247,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5237,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5267,11 +5286,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5280,11 +5299,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5293,11 +5312,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5336,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5388,11 +5407,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5401,7 +5420,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5409,7 +5428,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5417,7 +5436,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5425,7 +5444,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5437,11 +5456,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5449,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5461,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5477,23 +5496,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5501,7 +5520,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5521,7 +5540,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5542,11 +5561,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5554,7 +5573,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5562,7 +5581,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5578,15 +5597,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5606,7 +5625,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5626,11 +5645,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5648,7 +5667,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5698,15 +5717,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5741,7 +5760,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5811,21 +5830,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5887,21 +5906,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5976,7 +5995,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5985,22 +6004,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6010,7 +6029,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6030,7 +6049,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6050,12 +6069,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6078,12 +6097,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6095,7 +6114,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6107,7 +6126,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6143,18 +6162,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6169,7 +6188,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6177,7 +6196,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6218,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6235,8 +6254,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6258,13 +6277,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6277,7 +6296,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6291,13 +6310,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6307,7 +6326,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6322,7 +6341,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6334,15 +6353,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6350,23 +6369,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6402,7 +6421,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6414,11 +6433,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6426,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6438,7 +6457,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6454,11 +6473,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6471,7 +6490,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6485,7 +6504,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6494,27 +6513,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6541,15 +6560,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6576,7 +6595,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6609,7 +6628,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6635,22 +6654,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6759,8 +6778,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6770,7 +6789,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6790,15 +6809,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6822,45 +6841,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6889,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6901,12 +6920,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6928,11 +6947,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6952,13 +6971,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6966,56 +6985,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7041,19 +7060,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7066,7 +7085,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7101,49 +7120,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7154,52 +7173,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7252,7 +7271,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7260,15 +7279,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7367,7 +7386,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7375,7 +7394,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7386,13 +7405,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7401,13 +7420,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7430,20 +7449,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7559,7 +7578,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7568,7 +7587,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7576,7 +7595,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7607,7 +7626,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7619,7 +7638,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7627,7 +7646,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7638,7 +7657,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7744,7 +7763,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7752,13 +7771,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7792,16 +7811,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,13 +103,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -613,11 +613,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -625,11 +625,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -678,11 +678,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -807,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -861,21 +861,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -884,8 +884,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1024,15 +1024,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,38 +1127,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1226,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1297,15 +1297,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,11 +1478,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1498,11 +1498,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,18 +1542,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1629,11 +1629,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1649,11 +1649,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,18 +1691,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1711,38 +1711,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1754,16 +1754,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1774,57 +1774,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1834,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1921,11 +1921,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,11 +1937,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1972,7 +1972,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1984,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2020,15 +2020,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2072,8 +2072,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2125,27 +2125,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2155,11 +2155,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2187,8 +2197,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2212,7 +2222,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2224,11 +2234,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2255,12 +2265,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2275,12 +2285,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2310,7 +2320,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2325,7 +2335,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2335,12 +2345,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2384,7 +2394,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2399,7 +2409,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2413,7 +2423,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2423,15 +2433,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2443,7 +2462,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2455,7 +2474,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2484,16 +2503,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2505,7 +2524,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2553,7 +2572,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2561,11 +2580,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2577,11 +2596,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2589,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2601,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2617,11 +2636,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2629,11 +2648,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2641,15 +2660,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2665,7 +2684,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2681,11 +2700,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2713,7 +2732,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2725,27 +2744,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2767,7 +2786,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2775,15 +2794,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2813,11 +2832,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2827,7 +2846,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2839,7 +2858,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2855,11 +2874,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2869,7 +2888,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2896,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2885,7 +2904,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2907,16 +2926,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2937,11 +2956,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2955,11 +2974,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3016,12 +3035,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3066,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3055,15 +3074,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3073,18 +3092,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3115,13 +3134,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3134,7 +3153,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3187,7 +3206,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3207,11 +3226,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3231,7 +3250,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3298,7 +3317,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3410,11 +3429,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3442,11 +3461,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3505,7 +3524,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3518,15 +3537,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3544,11 +3563,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3565,11 +3584,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3577,7 +3596,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3667,7 +3686,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3691,23 +3710,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3865,13 +3884,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3897,8 +3916,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3907,20 +3926,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3931,19 +3950,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3974,40 +3993,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4015,7 +4034,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4040,16 +4059,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4078,7 +4097,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4086,16 +4105,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4112,12 +4131,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4145,7 +4164,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4169,8 +4188,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4178,7 +4197,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4188,22 +4207,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4233,22 +4252,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4278,11 +4297,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4318,19 +4337,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4342,15 +4361,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4360,11 +4379,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4373,11 +4392,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4389,11 +4408,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4402,11 +4421,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4432,11 +4451,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4448,9 +4467,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4462,11 +4481,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4474,7 +4493,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4512,20 +4531,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4533,7 +4552,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4541,7 +4560,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4560,32 +4579,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4602,7 +4621,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,11 +4657,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4656,7 +4675,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4672,7 +4691,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4712,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4702,7 +4721,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4715,7 +4734,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4746,20 +4765,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4768,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4797,11 +4816,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4814,7 +4833,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,8 +4843,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4840,7 +4859,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4871,7 +4890,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4891,7 +4910,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4899,11 +4918,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4915,11 +4934,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4927,15 +4946,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4955,7 +4974,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4984,11 +5003,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5000,15 +5019,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5022,7 +5041,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5045,7 +5064,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5060,11 +5079,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5126,17 +5145,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5161,7 +5180,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5199,7 +5218,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5207,15 +5226,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5224,7 +5243,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5233,15 +5252,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5263,11 +5282,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5276,11 +5295,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5289,11 +5308,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5332,11 +5351,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5384,11 +5403,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5397,7 +5416,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5421,7 +5440,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,11 +5452,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5445,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5457,7 +5476,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5473,23 +5492,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5497,7 +5516,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5517,7 +5536,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5538,11 +5557,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5550,7 +5569,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5558,7 +5577,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5574,15 +5593,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5602,7 +5621,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5622,11 +5641,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5644,7 +5663,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5694,15 +5713,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5737,7 +5756,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5807,21 +5826,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5883,21 +5902,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5972,7 +5991,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5981,22 +6000,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6006,7 +6025,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6026,7 +6045,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6046,12 +6065,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6074,12 +6093,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6091,7 +6110,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6103,7 +6122,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6139,18 +6158,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6165,7 +6184,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6173,7 +6192,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6195,7 +6214,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6231,8 +6250,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6254,13 +6273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6273,7 +6292,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6287,13 +6306,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6303,7 +6322,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6318,7 +6337,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6330,15 +6349,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6346,23 +6365,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6382,7 +6401,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6398,7 +6417,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6410,11 +6429,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6422,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6434,7 +6453,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6450,11 +6469,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6467,7 +6486,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6481,7 +6500,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6490,27 +6509,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6537,15 +6556,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6572,7 +6591,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6605,7 +6624,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6631,22 +6650,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6755,8 +6774,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6766,7 +6785,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6786,15 +6805,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6818,45 +6837,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6885,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6897,12 +6916,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6924,11 +6943,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6948,13 +6967,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6962,56 +6981,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7037,19 +7056,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7062,7 +7081,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7097,49 +7116,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7150,52 +7169,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7248,7 +7267,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7256,15 +7275,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7363,7 +7382,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7371,7 +7390,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7382,13 +7401,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7397,13 +7416,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7426,20 +7445,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7555,7 +7574,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7564,7 +7583,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7572,7 +7591,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7622,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7615,7 +7634,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7623,7 +7642,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7634,7 +7653,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7740,7 +7759,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7748,13 +7767,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7788,16 +7807,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,13 +107,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -517,7 +517,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -617,11 +617,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -629,11 +629,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -682,11 +682,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -784,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -865,21 +865,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -888,8 +888,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1028,15 +1028,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,38 +1131,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1230,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1301,15 +1301,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1482,11 +1482,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1502,11 +1502,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,18 +1546,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1633,11 +1633,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1653,11 +1653,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1695,18 +1695,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1715,38 +1715,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1758,16 +1758,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1778,57 +1778,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1838,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1941,11 +1941,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1976,7 +1976,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1988,7 +1988,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2024,15 +2024,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2048,7 +2048,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2076,8 +2076,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2129,27 +2129,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2159,11 +2159,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2191,8 +2201,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2226,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2238,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2259,12 +2269,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2279,12 +2289,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2314,7 +2324,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2329,7 +2339,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2339,12 +2349,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2388,7 +2398,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2403,7 +2413,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2417,7 +2427,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2427,15 +2437,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2447,7 +2466,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2459,7 +2478,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2488,16 +2507,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2509,7 +2528,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2557,7 +2576,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2565,11 +2584,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2581,11 +2600,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2593,7 +2612,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2605,7 +2624,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2621,11 +2640,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2633,11 +2652,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2645,15 +2664,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2669,7 +2688,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2685,11 +2704,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2717,7 +2736,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2729,27 +2748,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2771,7 +2790,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2779,15 +2798,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2817,11 +2836,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2831,7 +2850,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2843,7 +2862,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2859,11 +2878,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2873,7 +2892,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2900,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2889,7 +2908,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2911,16 +2930,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2941,11 +2960,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2959,11 +2978,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3020,12 +3039,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3051,7 +3070,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3059,15 +3078,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3077,18 +3096,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3119,13 +3138,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3138,7 +3157,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,7 +3194,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3191,7 +3210,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3211,11 +3230,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3235,7 +3254,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3302,7 +3321,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3414,11 +3433,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,11 +3465,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3509,7 +3528,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3522,15 +3541,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3538,7 +3557,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3548,11 +3567,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3569,11 +3588,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3581,7 +3600,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3671,7 +3690,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3695,23 +3714,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3869,13 +3888,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3901,8 +3920,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3911,20 +3930,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3935,19 +3954,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3978,40 +3997,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4019,7 +4038,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4044,16 +4063,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4082,7 +4101,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4090,16 +4109,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4116,12 +4135,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4149,7 +4168,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4173,8 +4192,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4182,7 +4201,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4192,22 +4211,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4237,22 +4256,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4282,11 +4301,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4322,19 +4341,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4346,15 +4365,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4364,11 +4383,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4377,11 +4396,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4393,11 +4412,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4406,11 +4425,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4455,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4452,9 +4471,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,11 +4485,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4478,7 +4497,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4516,20 +4535,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4537,7 +4556,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4545,7 +4564,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4564,32 +4583,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4606,7 +4625,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4642,11 +4661,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4660,7 +4679,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4676,7 +4695,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4716,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4706,7 +4725,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4738,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4750,20 +4769,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4772,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4801,11 +4820,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4818,7 +4837,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4828,8 +4847,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4844,7 +4863,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4875,7 +4894,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4895,7 +4914,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4903,11 +4922,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4919,11 +4938,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4931,15 +4950,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4959,7 +4978,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +5007,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5004,15 +5023,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5026,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5049,7 +5068,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5064,11 +5083,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5130,17 +5149,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5165,7 +5184,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5203,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5211,15 +5230,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5228,7 +5247,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5237,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5267,11 +5286,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5280,11 +5299,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5293,11 +5312,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5336,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5388,11 +5407,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5401,7 +5420,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5409,7 +5428,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5417,7 +5436,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5425,7 +5444,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5437,11 +5456,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5449,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5461,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5477,23 +5496,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5501,7 +5520,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5521,7 +5540,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5542,11 +5561,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5554,7 +5573,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5562,7 +5581,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5578,15 +5597,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5606,7 +5625,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5626,11 +5645,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5648,7 +5667,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5698,15 +5717,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5741,7 +5760,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5811,21 +5830,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5887,21 +5906,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5976,7 +5995,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5985,22 +6004,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6010,7 +6029,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6030,7 +6049,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6050,12 +6069,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6078,12 +6097,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6095,7 +6114,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6107,7 +6126,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6143,18 +6162,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6169,7 +6188,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6177,7 +6196,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6218,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6235,8 +6254,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6258,13 +6277,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6277,7 +6296,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6291,13 +6310,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6307,7 +6326,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6322,7 +6341,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6334,15 +6353,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6350,23 +6369,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6402,7 +6421,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6414,11 +6433,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6426,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6438,7 +6457,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6454,11 +6473,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6471,7 +6490,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6485,7 +6504,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6494,27 +6513,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6541,15 +6560,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6576,7 +6595,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6609,7 +6628,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6635,22 +6654,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6759,8 +6778,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6770,7 +6789,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6790,15 +6809,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6822,45 +6841,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6889,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6901,12 +6920,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6928,11 +6947,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6952,13 +6971,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6966,56 +6985,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7041,19 +7060,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7066,7 +7085,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7101,49 +7120,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7154,52 +7173,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7252,7 +7271,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7260,15 +7279,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7367,7 +7386,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7375,7 +7394,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7386,13 +7405,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7401,13 +7420,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7430,20 +7449,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7559,7 +7578,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7568,7 +7587,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7576,7 +7595,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7607,7 +7626,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7619,7 +7638,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7627,7 +7646,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7638,7 +7657,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7744,7 +7763,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7752,13 +7771,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7792,16 +7811,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -151,7 +151,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -168,7 +168,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -339,7 +339,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -363,7 +363,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -490,7 +490,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -510,7 +510,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -591,17 +591,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -677,7 +677,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -777,11 +777,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -842,11 +842,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -944,7 +944,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -971,11 +971,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -1025,21 +1025,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1048,8 +1048,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -1083,15 +1083,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -1103,7 +1103,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1188,15 +1188,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1205,12 +1205,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1248,7 +1248,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1266,22 +1266,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1291,38 +1291,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1330,14 +1330,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1353,16 +1353,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1390,24 +1390,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1461,15 +1461,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1477,12 +1477,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1590,7 +1590,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1642,11 +1642,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1662,11 +1662,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1706,18 +1706,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1733,11 +1733,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1793,11 +1793,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1813,11 +1813,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1855,18 +1855,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1875,38 +1875,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1918,16 +1918,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1938,57 +1938,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1998,24 +1998,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2085,11 +2085,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2101,11 +2101,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -2136,7 +2136,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2148,7 +2148,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2184,15 +2184,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2208,7 +2208,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2228,7 +2228,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2236,8 +2236,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2289,27 +2289,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2319,11 +2319,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2351,8 +2361,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2376,7 +2386,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2388,11 +2398,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2419,12 +2429,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2439,12 +2449,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2474,7 +2484,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2489,7 +2499,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2499,12 +2509,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2548,7 +2558,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2563,7 +2573,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2577,7 +2587,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2587,15 +2597,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2607,7 +2626,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2619,7 +2638,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2648,16 +2667,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2669,7 +2688,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2717,7 +2736,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2725,11 +2744,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2741,11 +2760,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2753,7 +2772,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2765,7 +2784,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2781,11 +2800,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2793,11 +2812,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2805,15 +2824,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2829,7 +2848,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2845,11 +2864,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2877,7 +2896,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2889,27 +2908,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2931,7 +2950,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2939,15 +2958,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2977,11 +2996,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2991,7 +3010,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3003,7 +3022,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -3019,11 +3038,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3033,7 +3052,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3041,7 +3060,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3049,7 +3068,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3071,16 +3090,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3101,11 +3120,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3119,11 +3138,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3180,12 +3199,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3211,7 +3230,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3219,15 +3238,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3237,18 +3256,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3279,13 +3298,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3298,7 +3317,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3335,7 +3354,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3351,7 +3370,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3371,11 +3390,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3395,7 +3414,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3462,7 +3481,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3574,11 +3593,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3606,11 +3625,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3669,7 +3688,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3682,15 +3701,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3698,7 +3717,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3708,11 +3727,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3729,11 +3748,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3741,7 +3760,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3831,7 +3850,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3855,23 +3874,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -4029,13 +4048,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -4061,8 +4080,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4071,20 +4090,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -4095,19 +4114,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4138,40 +4157,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4179,7 +4198,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4204,16 +4223,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4242,7 +4261,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4250,16 +4269,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4276,12 +4295,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4309,7 +4328,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4333,8 +4352,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4342,7 +4361,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4352,22 +4371,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4397,22 +4416,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4442,11 +4461,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4482,19 +4501,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4506,15 +4525,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4524,11 +4543,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4537,11 +4556,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4553,11 +4572,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4566,11 +4585,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4596,11 +4615,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4612,9 +4631,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4626,11 +4645,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4638,7 +4657,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4676,20 +4695,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4697,7 +4716,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4705,7 +4724,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4724,32 +4743,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4766,7 +4785,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4802,11 +4821,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4820,7 +4839,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4836,7 +4855,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4857,7 +4876,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4866,7 +4885,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4879,7 +4898,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4910,20 +4929,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4932,7 +4951,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4961,11 +4980,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4978,7 +4997,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4988,8 +5007,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -5004,7 +5023,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5035,7 +5054,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -5055,7 +5074,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -5079,11 +5098,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -5091,15 +5110,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5119,7 +5138,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5148,11 +5167,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5164,15 +5183,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5186,7 +5205,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5209,7 +5228,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5224,11 +5243,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5290,17 +5309,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5325,7 +5344,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5363,7 +5382,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5371,15 +5390,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5388,7 +5407,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5397,15 +5416,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5427,11 +5446,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5440,11 +5459,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5453,11 +5472,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5496,11 +5515,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5548,11 +5567,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5561,7 +5580,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5569,7 +5588,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5577,7 +5596,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5585,7 +5604,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5597,11 +5616,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5609,7 +5628,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5621,7 +5640,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5637,23 +5656,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5661,7 +5680,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5681,7 +5700,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5702,11 +5721,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5714,7 +5733,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5722,7 +5741,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5738,15 +5757,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5766,7 +5785,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5786,11 +5805,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5808,7 +5827,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5858,15 +5877,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5901,7 +5920,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5971,21 +5990,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6047,21 +6066,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6099,7 +6118,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -6136,7 +6155,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6145,22 +6164,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6170,7 +6189,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6190,7 +6209,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6210,12 +6229,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6238,12 +6257,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6255,7 +6274,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6267,7 +6286,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6303,18 +6322,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6329,7 +6348,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6337,7 +6356,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6359,7 +6378,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6395,8 +6414,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6418,13 +6437,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6451,13 +6470,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6467,7 +6486,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6482,7 +6501,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6494,15 +6513,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6510,23 +6529,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6546,7 +6565,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6562,7 +6581,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6574,11 +6593,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6586,7 +6605,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6598,7 +6617,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6614,11 +6633,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6631,7 +6650,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6645,7 +6664,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6654,27 +6673,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6701,15 +6720,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6736,7 +6755,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6795,22 +6814,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6919,8 +6938,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6930,7 +6949,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6950,15 +6969,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6982,45 +7001,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7049,7 +7068,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7061,12 +7080,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7088,11 +7107,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -7112,13 +7131,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -7126,56 +7145,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7201,19 +7220,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7226,7 +7245,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7261,49 +7280,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7314,52 +7333,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7412,7 +7431,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7420,15 +7439,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7527,7 +7546,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7535,7 +7554,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7546,13 +7565,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7561,13 +7580,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7590,20 +7609,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7719,7 +7738,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7728,7 +7747,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7736,7 +7755,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7767,7 +7786,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7779,7 +7798,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7787,7 +7806,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7798,7 +7817,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7904,7 +7923,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7912,13 +7931,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7952,16 +7971,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-24 08:44-0600\n"
+"POT-Creation-Date: 2025-04-29 07:41-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1053
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1242
+#: lxc/config.go:1280
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,13 +106,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:421
+#: lxc/cluster_group.go:426
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:163
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:637
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:674
+#: lxc/network.go:684
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:528
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1171
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1069
+#: lxc/file.go:1061
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:154 lxc/profile.go:262
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:818
+#: lxc/config.go:532 lxc/config.go:838
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
+#: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1064
+#: lxc/remote.go:1065
 msgid "<remote> <URL>"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:701
+#: lxc/file.go:693
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:437
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:725
+#: lxc/cluster_group.go:735
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -616,11 +616,11 @@ msgstr ""
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -628,11 +628,11 @@ msgstr ""
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:78 lxc/config_device.go:79
+#: lxc/config_device.go:171 lxc/config_device.go:172
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:724
+#: lxc/cluster_group.go:734
 msgid "Add member to group"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:896 lxc/network_forward.go:897
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1376
+#: lxc/cluster.go:1384
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -783,7 +783,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:189 lxc/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:232 lxc/network.go:233
+#: lxc/network.go:237 lxc/network.go:238
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:308
+#: lxc/storage_volume.go:313
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:309
+#: lxc/storage_volume.go:314
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:265 lxc/network_load_balancer.go:267
+#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
@@ -864,21 +864,21 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:114
+#: lxc/export.go:122
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2728
+#: lxc/storage_volume.go:2746
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:200 lxc/storage_volume.go:2805
+#: lxc/export.go:208 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1539
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -887,8 +887,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:449 lxc/network_forward.go:326
-#: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
+#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
+#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:962
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:975
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:954
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:955
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:577
+#: lxc/file.go:569
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:791
+#: lxc/file.go:783
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:703 lxc/config.go:1099
+#: lxc/config.go:723 lxc/config.go:1137
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:487
+#: lxc/storage_volume.go:501
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:441
+#: lxc/storage_volume.go:455
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:986
+#: lxc/network.go:996
 msgid "Chassis"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:243
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:299
+#: lxc/cluster_group.go:304
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:569
+#: lxc/cluster_group.go:579
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:646
+#: lxc/cluster_group.go:656
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,38 +1130,38 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:153
+#: lxc/cluster_group.go:158
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:782
+#: lxc/cluster_group.go:797
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:771
+#: lxc/cluster_group.go:786
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:589
+#: lxc/cluster_group.go:599
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
-#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1012 lxc/network.go:1278 lxc/network.go:1371
-#: lxc/network.go:1443 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:505 lxc/network_forward.go:657
-#: lxc/network_forward.go:811 lxc/network_forward.go:900
-#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
-#: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
-#: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
-#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
-#: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
+#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
+#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
+#: lxc/network_forward.go:506 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
+#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
 #: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
 #: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:389
-#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
-#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
-#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
-#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
-#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2827
+#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
+#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
+#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
+#: lxc/storage_volume.go:1621 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:82
+#: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1229,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:759
-#: lxc/network_acl.go:716 lxc/network_forward.go:775
-#: lxc/network_load_balancer.go:738 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1165
-#: lxc/storage_volume.go:1197
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
+#: lxc/storage_volume.go:1211
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:628
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1300,15 +1300,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:409 lxc/config_device.go:410
+#: lxc/config_device.go:482 lxc/config_device.go:483
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:285 lxc/profile.go:286
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:391
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:169 lxc/cluster_group.go:170
+#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:476 lxc/file.go:710
+#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1481,11 +1481,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_forward.go:256
+#: lxc/network_forward.go:256 lxc/network_forward.go:257
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1501,11 +1501,11 @@ msgstr ""
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:317 lxc/network.go:318
+#: lxc/network.go:327 lxc/network.go:328
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:367 lxc/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,18 +1545,18 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:158
+#: lxc/network_forward.go:159
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1109
-#: lxc/network_acl.go:171 lxc/network_forward.go:157
-#: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
+#: lxc/network_acl.go:171 lxc/network_forward.go:158
+#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:979
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2673
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:256
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1632,11 +1632,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:807 lxc/network_forward.go:808
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:770 lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:404 lxc/network.go:405
+#: lxc/network.go:414 lxc/network.go:415
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:449 lxc/profile.go:450
 msgid "Delete profiles"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
+#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,18 +1694,18 @@ msgstr ""
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
 #: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
-#: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
-#: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
-#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
-#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
-#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
-#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
+#: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
+#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
+#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
+#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
+#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1714,38 +1714,38 @@ msgstr ""
 #: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
 #: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:384 lxc/file.go:470 lxc/file.go:703
-#: lxc/file.go:1230 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
+#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
-#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
-#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
+#: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
+#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1007 lxc/network.go:1133 lxc/network.go:1212
-#: lxc/network.go:1272 lxc/network.go:1368 lxc/network.go:1440
+#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
+#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
+#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
+#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
 #: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
 #: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
 #: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
 #: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
 #: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:33 lxc/network_forward.go:90
-#: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:412 lxc/network_forward.go:497
-#: lxc/network_forward.go:607 lxc/network_forward.go:654
-#: lxc/network_forward.go:808 lxc/network_forward.go:882
-#: lxc/network_forward.go:897 lxc/network_forward.go:982
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
-#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
-#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_forward.go:34 lxc/network_forward.go:91
+#: lxc/network_forward.go:180 lxc/network_forward.go:257
+#: lxc/network_forward.go:413 lxc/network_forward.go:498
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
 #: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
@@ -1757,16 +1757,16 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
+#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
+#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
+#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1777,57 +1777,57 @@ msgstr ""
 #: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
 #: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
 #: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
-#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
-#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
-#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
-#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2822 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1463
+#: lxc/storage_volume.go:1477
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:462 lxc/network.go:463
+#: lxc/network.go:472 lxc/network.go:473
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:559 lxc/network.go:560
+#: lxc/network.go:569 lxc/network.go:570
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
+#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:207
+#: lxc/config_device.go:280
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:488
+#: lxc/config_device.go:555
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:609
+#: lxc/config_device.go:676
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1837,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
-#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
+#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
+#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:728
+#: lxc/config_device.go:795
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:591
+#: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:306
+#: lxc/config_device.go:379
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1230
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1924,11 +1924,11 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1013
+#: lxc/network.go:1023
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:738
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1940,11 +1940,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:956
+#: lxc/network.go:966
 msgid "Down delay"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:315 lxc/cluster_group.go:316
+#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:384
+#: lxc/file.go:375 lxc/file.go:376
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1228 lxc/config.go:1229
+#: lxc/config.go:1266 lxc/config.go:1267
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:140 lxc/config.go:141
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2023,15 +2023,15 @@ msgstr ""
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:656 lxc/network.go:657
+#: lxc/network.go:666 lxc/network.go:667
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:653 lxc/network_forward.go:654
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:507 lxc/profile.go:508
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2075,8 +2075,8 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
+#: lxc/storage_volume.go:1798 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,27 +2128,27 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1346
-#: lxc/network_acl.go:542 lxc/network_forward.go:580
-#: lxc/network_load_balancer.go:559 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
+#: lxc/network_acl.go:542 lxc/network_forward.go:581
+#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:657 lxc/config.go:689
+#: lxc/config.go:677 lxc/config.go:709
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1340 lxc/network_acl.go:536
-#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
+#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
+#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
 #: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2173
-#: lxc/storage_volume.go:2211
+#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2158,11 +2158,21 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303 lxc/cluster.go:1304
+#: lxc/cluster.go:1303
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1401
+#: lxc/cluster.go:1304
+msgid ""
+"Evacuate cluster member\n"
+"\n"
+"Evacuation actions:\n"
+" - stop: stop all instances on the member\n"
+" - migrate: migrate all instances on the member to other members\n"
+" - live-migrate: live migrate all instances on the member to other members\n"
+msgstr ""
+
+#: lxc/cluster.go:1409
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2190,8 +2200,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
-#: lxc/storage_volume.go:1576
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2215,7 +2225,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2227,11 +2237,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2670
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:160 lxc/storage_volume.go:2788
+#: lxc/export.go:168 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1493
+#: lxc/file.go:1485
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1516
+#: lxc/file.go:1508
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2278,12 +2288,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1543
+#: lxc/file.go:1535
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1320
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2313,7 +2323,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1449
+#: lxc/file.go:1441
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2328,7 +2338,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1454
+#: lxc/file.go:1446
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2338,12 +2348,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1346
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1481
+#: lxc/file.go:1473
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2387,7 +2397,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1466
+#: lxc/file.go:1458
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1064
+#: lxc/file.go:1056
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1048 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2426,15 +2436,24 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1307
-msgid "Force a particular evacuation action"
+#: lxc/cluster.go:1314
+msgid ""
+"Force a particular instance evacuation action. One of stop, migrate or live-"
+"migrate"
+msgstr ""
+
+#: lxc/cluster.go:1344
+msgid ""
+"Force a particular instance restore action. Use \"skip\" to restore only the "
+"cluster member status without starting local instances or migrating back "
+"evacuated instances"
 msgstr ""
 
 #: lxc/file.go:144
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1313
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2446,7 +2465,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1336
+#: lxc/cluster.go:1343
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2458,7 +2477,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2487,16 +2506,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1011
-#: lxc/network.go:1135 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
+#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
+#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2508,7 +2527,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:978
 msgid "Forward delay"
 msgstr ""
 
@@ -2556,7 +2575,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:997 lxc/config.go:998
+#: lxc/config.go:1035 lxc/config.go:1036
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2564,11 +2583,11 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1608 lxc/image.go:1609
+#: lxc/image.go:1612 lxc/image.go:1613
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:873 lxc/network.go:874
+#: lxc/network.go:883 lxc/network.go:884
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -2580,11 +2599,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:414
+#: lxc/network_forward.go:415
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:412
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:797
+#: lxc/network.go:807
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -2604,7 +2623,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:649
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2620,11 +2639,11 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1247
+#: lxc/storage_volume.go:1261
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:438
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2632,11 +2651,11 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:229 lxc/config_device.go:230
+#: lxc/config_device.go:302 lxc/config_device.go:303
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:433 lxc/config.go:434
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2644,15 +2663,15 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:792 lxc/network.go:793
+#: lxc/network.go:802 lxc/network.go:803
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:412
+#: lxc/network_forward.go:412 lxc/network_forward.go:413
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:408
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2668,7 +2687,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:643 lxc/profile.go:644
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,11 +2703,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:470
+#: lxc/storage_volume.go:484
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2716,7 +2735,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1188
+#: lxc/network.go:1198
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2728,27 +2747,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1566
+#: lxc/file.go:1558
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1370
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1388
+#: lxc/file.go:1380
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:171
+#: lxc/network.go:976 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1190
+#: lxc/network.go:1200
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2778,15 +2797,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:935
+#: lxc/network.go:945
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1107
+#: lxc/list.go:560 lxc/network.go:1117
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1108
+#: lxc/list.go:561 lxc/network.go:1118
 msgid "IPV6"
 msgstr ""
 
@@ -2816,11 +2835,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:415
+#: lxc/main.go:444
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2830,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2438
+#: lxc/storage_volume.go:2456
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2842,7 +2861,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1524
+#: lxc/image.go:1528
 msgid "Image already up to date."
 msgstr ""
 
@@ -2858,11 +2877,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:365 lxc/image.go:1479
+#: lxc/image.go:365 lxc/image.go:1483
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:445 lxc/image.go:1705
+#: lxc/image.go:445 lxc/image.go:1709
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2872,7 +2891,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1526
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2840
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2888,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2839
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2910,16 +2929,16 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2829
+#: lxc/storage_volume.go:2847
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2903
+#: lxc/storage_volume.go:2921
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:96
+#: lxc/import.go:110
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -2940,11 +2959,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1372
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1557
+#: lxc/file.go:1549
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2958,11 +2977,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
+#: lxc/config.go:1061 lxc/config.go:1119 lxc/config.go:1238 lxc/config.go:1330
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1292
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3019,12 +3038,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:88
+#: lxc/snapshot.go:95
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1295
+#: lxc/file.go:1287
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3050,7 +3069,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2024
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,15 +3077,15 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2020
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:518
+#: lxc/main.go:547
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:359
+#: lxc/file.go:351
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3076,18 +3095,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
-#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
-#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
+#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
+#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:550
+#: lxc/file.go:542
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:740
+#: lxc/file.go:185 lxc/file.go:732
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3118,13 +3137,13 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:156 lxc/network_load_balancer.go:159
+#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1195 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1757 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
+#: lxc/network_load_balancer.go:166 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,7 +3156,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:485
+#: lxc/cluster.go:1236 lxc/cluster_group.go:490
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,7 +3193,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1132 lxc/network.go:1133
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3190,7 +3209,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:439 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3210,11 +3229,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:89 lxc/network_forward.go:90
+#: lxc/network_forward.go:90 lxc/network_forward.go:91
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3234,7 +3253,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1006 lxc/network.go:1007
+#: lxc/network.go:1016 lxc/network.go:1017
 msgid "List available networks"
 msgstr ""
 
@@ -3301,7 +3320,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:326 lxc/config_device.go:327
+#: lxc/config_device.go:399 lxc/config_device.go:400
 msgid "List instance devices"
 msgstr ""
 
@@ -3413,11 +3432,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:719
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:720
 msgid ""
 "List profiles\n"
 "\n"
@@ -3445,11 +3464,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1604
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3508,7 +3527,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1479
+#: lxc/info.go:489 lxc/storage_volume.go:1493
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3521,15 +3540,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:988
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:959
+#: lxc/network.go:969
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1189
+#: lxc/network.go:1199
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3537,7 +3556,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:927
+#: lxc/network.go:937
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3547,11 +3566,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1106
+#: lxc/network.go:1116
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:505
+#: lxc/cluster_group.go:510
 msgid "MEMBERS"
 msgstr ""
 
@@ -3568,11 +3587,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:967
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:958
+#: lxc/network.go:968
 msgid "MII state"
 msgstr ""
 
@@ -3580,7 +3599,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:928
+#: lxc/network.go:938
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3670,7 +3689,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:957 lxc/config.go:958
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3694,23 +3713,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:881 lxc/network_forward.go:882
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:32 lxc/network_forward.go:33
+#: lxc/network_forward.go:33 lxc/network_forward.go:34
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:843 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1032 lxc/network_load_balancer.go:1033
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3868,13 +3887,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:223 lxc/cluster_group.go:289 lxc/cluster_group.go:349
-#: lxc/cluster_group.go:696
+#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
+#: lxc/cluster_group.go:706
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
-#: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
+#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
+#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3900,8 +3919,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
+#: lxc/profile.go:918 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3910,20 +3929,20 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:457
-#: lxc/network_forward.go:542 lxc/network_forward.go:717
-#: lxc/network_forward.go:848 lxc/network_forward.go:945
-#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
-#: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
-#: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
-#: lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:220 lxc/network_forward.go:458
+#: lxc/network_forward.go:543 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
+#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
-#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
+#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
+#: lxc/config_device.go:877
 msgid "Missing name"
 msgstr ""
 
@@ -3934,19 +3953,19 @@ msgstr ""
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
-#: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1166 lxc/network.go:1244 lxc/network.go:1310
-#: lxc/network.go:1402 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:292 lxc/network_forward.go:453
-#: lxc/network_forward.go:538 lxc/network_forward.go:713
-#: lxc/network_forward.go:844 lxc/network_forward.go:941
-#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
-#: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
-#: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
-#: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
-#: lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971
-#: lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158
+#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
+#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
+#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
+#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
+#: lxc/network_forward.go:293 lxc/network_forward.go:454
+#: lxc/network_forward.go:539 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
+#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
+#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -3977,40 +3996,40 @@ msgstr ""
 #: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
 #: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
 #: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:281
-#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
-#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
-#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
-#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
-#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
-#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
+#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
+#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
+#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
+#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
+#: lxc/profile.go:1070 lxc/profile.go:1151
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:325
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1423
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:843
+#: lxc/file.go:835
 msgid "Missing target directory"
 msgstr ""
 
@@ -4018,7 +4037,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:963
 msgid "Mode"
 msgstr ""
 
@@ -4043,16 +4062,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
-#: lxc/storage_volume.go:973
+#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:522
+#: lxc/file.go:514
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1229 lxc/file.go:1230
+#: lxc/file.go:1221 lxc/file.go:1222
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4100,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4089,16 +4108,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:527
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4115,12 +4134,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1104
+#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
 #: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1749
+#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4148,7 +4167,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1077 lxc/operation.go:155 lxc/project.go:531
+#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
 #: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
 #: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4172,8 +4191,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
-#: lxc/storage_volume.go:1574
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4181,7 +4200,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
+#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4191,22 +4210,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:387
+#: lxc/network.go:397
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:447
+#: lxc/network.go:457
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:385
+#: lxc/network.go:395
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1254
+#: lxc/network.go:1264
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,22 +4255,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:394
+#: lxc/network_forward.go:395
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:865
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:390
+#: lxc/network_load_balancer.go:391
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:828
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4281,11 +4300,11 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:336
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:953
 msgid "Network usage:"
 msgstr ""
 
@@ -4321,19 +4340,19 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:528 lxc/network.go:625
+#: lxc/network.go:538 lxc/network.go:635
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1006
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4345,15 +4364,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
+#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:152 lxc/config_device.go:466
+#: lxc/config_device.go:225 lxc/config_device.go:533
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4363,11 +4382,11 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:985
+#: lxc/network.go:995
 msgid "OVN:"
 msgstr ""
 
@@ -4376,11 +4395,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2705
+#: lxc/storage_volume.go:2723
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2501
+#: lxc/storage_volume.go:2519
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4392,11 +4411,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1427
+#: lxc/storage_volume.go:1441
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1325
+#: lxc/network.go:745 lxc/network.go:1335
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4405,11 +4424,11 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1578
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Override the source project"
 msgstr ""
 
@@ -4435,11 +4454,11 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1768
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:159 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
 msgid "PORTS"
 msgstr ""
 
@@ -4451,9 +4470,9 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1115 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
+#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4465,11 +4484,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:956
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:957
 msgid "Packets sent"
 msgstr ""
 
@@ -4477,7 +4496,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:376
+#: lxc/main.go:405
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4515,20 +4534,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1358
+#: lxc/file.go:1350
 msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:760
-#: lxc/network_acl.go:717 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1166
-#: lxc/storage_volume.go:1198
+#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4536,7 +4555,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print help"
 msgstr ""
 
@@ -4544,7 +4563,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:93
+#: lxc/main.go:94
 msgid "Print version number"
 msgstr ""
 
@@ -4563,32 +4582,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:173
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:433
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:492
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:928
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:953
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1012
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:266
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1656
+#: lxc/image.go:1660
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1379
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4659,7 +4678,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4694,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2248
+#: lxc/storage_volume.go:2266
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4696,7 +4715,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1027
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,7 +4724,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2093
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4737,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2369
+#: lxc/storage_volume.go:2387
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:470
+#: lxc/file.go:461 lxc/file.go:462
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:653 lxc/file.go:1011
+#: lxc/file.go:645 lxc/file.go:1003
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:703
+#: lxc/file.go:694 lxc/file.go:695
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:944 lxc/file.go:1111
+#: lxc/file.go:936 lxc/file.go:1103
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1550
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4800,11 +4819,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:477 lxc/file.go:709
+#: lxc/file.go:469 lxc/file.go:701
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4817,7 +4836,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1488
+#: lxc/image.go:1492
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4827,8 +4846,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
-#: lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
+#: lxc/remote.go:1096
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4843,7 +4862,7 @@ msgstr ""
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4874,7 +4893,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:522
+#: lxc/cluster_group.go:527
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4894,7 +4913,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4902,11 +4921,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4918,11 +4937,11 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:511 lxc/config_device.go:512
+#: lxc/config_device.go:578 lxc/config_device.go:579
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:521
+#: lxc/cluster_group.go:526
 msgid "Remove member from group"
 msgstr ""
 
@@ -4930,15 +4949,15 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_forward.go:982
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1120 lxc/network_load_balancer.go:1121
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:876 lxc/profile.go:877
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4958,7 +4977,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:606 lxc/cluster_group.go:607
+#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4987,11 +5006,11 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1211 lxc/network.go:1212
+#: lxc/network.go:1221 lxc/network.go:1222
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:969 lxc/profile.go:970
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5025,7 +5044,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1034
+#: lxc/config.go:1072
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5048,7 +5067,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1333 lxc/cluster.go:1334
+#: lxc/cluster.go:1340 lxc/cluster.go:1341
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5063,11 +5082,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1399
+#: lxc/cluster.go:1407
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,17 +5148,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1478
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1487
+#: lxc/file.go:1479
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1111
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5164,7 +5183,7 @@ msgstr ""
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:977
 msgid "STP"
 msgstr ""
 
@@ -5202,7 +5221,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1052 lxc/config.go:1053
+#: lxc/config.go:1090 lxc/config.go:1091
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5229,15 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1239
+#: lxc/file.go:1231
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:625
+#: lxc/config_device.go:692
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:628
+#: lxc/config_device.go:695
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5227,7 +5246,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:635
+#: lxc/config_device.go:702
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5236,15 +5255,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1672 lxc/image.go:1673
+#: lxc/image.go:1676 lxc/image.go:1677
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:577
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:578
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5266,11 +5285,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1271
+#: lxc/network.go:1281
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1272
+#: lxc/network.go:1282
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5279,11 +5298,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:497
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5292,11 +5311,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:475
+#: lxc/network_load_balancer.go:476
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5335,11 +5354,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1029
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1030
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5387,11 +5406,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5400,7 +5419,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1065 lxc/remote.go:1066
+#: lxc/remote.go:1066 lxc/remote.go:1067
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5408,7 +5427,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:704
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:713
+#: lxc/file.go:705
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:703
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5436,11 +5455,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:504
+#: lxc/network_forward.go:505
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:483
+#: lxc/network_load_balancer.go:484
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5448,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1279
+#: lxc/network.go:1289
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1037
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5476,23 +5495,23 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:556
+#: lxc/config.go:591
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1229
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all information messages"
 msgstr ""
 
@@ -5500,7 +5519,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:662 lxc/cluster_group.go:663
+#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5520,7 +5539,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:767 lxc/config_device.go:768
+#: lxc/config_device.go:834 lxc/config_device.go:835
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5541,11 +5560,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1546 lxc/image.go:1547
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1174 lxc/config.go:1175
+#: lxc/config.go:1212 lxc/config.go:1213
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5553,7 +5572,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:772 lxc/config.go:773
+#: lxc/config.go:792 lxc/config.go:793
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:280 lxc/main.go:281
+#: lxc/main.go:305 lxc/main.go:306
 msgid "Show less common commands"
 msgstr ""
 
@@ -5577,15 +5596,15 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1367 lxc/network.go:1368
+#: lxc/network.go:1377 lxc/network.go:1378
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:179
+#: lxc/network_forward.go:179 lxc/network_forward.go:180
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5605,7 +5624,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1118 lxc/profile.go:1119
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,11 +5644,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5647,7 +5666,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:776
+#: lxc/config.go:796
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5697,15 +5716,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1503
+#: lxc/info.go:619 lxc/storage_volume.go:1517
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,7 +5759,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:929
+#: lxc/network.go:939
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5810,21 +5829,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:697
+#: lxc/storage_volume.go:711
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:785
+#: lxc/storage_volume.go:799
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:510
+#: lxc/storage_volume.go:524
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:528
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5886,21 +5905,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1105
-#: lxc/network.go:1191 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
+#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1280
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1274
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
+#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
 msgid "The device already exists"
 msgstr ""
 
@@ -5975,7 +5994,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:459
+#: lxc/config_device.go:526
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5984,22 +6003,22 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:518
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:494
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:449
+#: lxc/network_load_balancer.go:450
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:859
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:470
+#: lxc/network_forward.go:471
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6029,7 +6048,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:695
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6049,12 +6068,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1338
+#: lxc/storage_volume.go:1352
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1315
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6077,12 +6096,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:537 lxc/network.go:634
+#: lxc/network.go:547 lxc/network.go:644
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:675
+#: lxc/config.go:695
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6106,7 +6125,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:307
+#: lxc/main.go:336
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6142,18 +6161,18 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:421
+#: lxc/main.go:450
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1488
+#: lxc/storage_volume.go:1502
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6168,7 +6187,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6176,7 +6195,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:954
+#: lxc/network.go:964
 msgid "Transmit policy"
 msgstr ""
 
@@ -6234,8 +6253,8 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6257,13 +6276,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1753
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1110 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
+#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6276,7 +6295,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:417
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6290,13 +6309,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1501
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
+#: lxc/storage_volume.go:1804 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6306,7 +6325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1051
+#: lxc/file.go:1043
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1143 lxc/config.go:1144
+#: lxc/config.go:1181 lxc/config.go:1182
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6333,15 +6352,15 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:852 lxc/config_device.go:853
+#: lxc/config_device.go:925 lxc/config_device.go:926
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1735 lxc/image.go:1736
+#: lxc/image.go:1739 lxc/image.go:1740
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:904 lxc/config.go:905
+#: lxc/config.go:924 lxc/config.go:925
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6349,23 +6368,23 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1439 lxc/network.go:1440
+#: lxc/network.go:1449 lxc/network.go:1450
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:606
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:585
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6385,7 +6404,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1182 lxc/profile.go:1183
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6401,7 +6420,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6413,11 +6432,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:610
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:589
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1444
+#: lxc/network.go:1454
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6437,7 +6456,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1187
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6453,11 +6472,11 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2398
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:909
+#: lxc/config.go:929
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6470,7 +6489,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:955
+#: lxc/network.go:965
 msgid "Up delay"
 msgstr ""
 
@@ -6484,7 +6503,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:289
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6493,27 +6512,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:981
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1484
+#: lxc/storage_volume.go:1498
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2657
+#: lxc/export.go:46 lxc/storage_volume.go:2675
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2654
+#: lxc/export.go:43 lxc/storage_volume.go:2672
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,15 +6559,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:989
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:980
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:987
 msgid "VLAN:"
 msgstr ""
 
@@ -6575,7 +6594,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1577
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6608,7 +6627,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1079 lxc/operation.go:157 lxc/project.go:533
+#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
 #: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
 #: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6634,22 +6653,22 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:905
+#: lxc/storage_volume.go:919
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:307
+#: lxc/storage_volume.go:312
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1004 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
+#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6758,8 +6777,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:168
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
+#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:604
+#: lxc/cluster_group.go:614
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6789,15 +6808,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1545
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1734
+#: lxc/image.go:1611 lxc/image.go:1738
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1671
+#: lxc/image.go:1675
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6821,45 +6840,45 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
-#: lxc/config_device.go:762 lxc/config_metadata.go:54
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
+#: lxc/config_device.go:829 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:224 lxc/config_device.go:847
+#: lxc/config_device.go:297 lxc/config_device.go:920
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:694
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:82
+#: lxc/config_device.go:175
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:408
+#: lxc/config_device.go:481
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:1142
+#: lxc/config.go:1034 lxc/config.go:1180
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1051
+#: lxc/config.go:1089
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:572
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:108 lxc/profile.go:875
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:382
+#: lxc/file.go:374
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6900,12 +6919,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:460
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1228
+#: lxc/file.go:1220
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6927,11 +6946,11 @@ msgid ""
 msgstr ""
 
 #: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:520 lxc/cluster_group.go:723
+#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6951,13 +6970,13 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1131
-#: lxc/network.go:1366 lxc/network_forward.go:87
-#: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
+#: lxc/network.go:1376 lxc/network_forward.go:88
+#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:461
+#: lxc/network.go:471
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -6965,56 +6984,56 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1438
+#: lxc/network.go:801 lxc/network.go:1448
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1270
+#: lxc/network.go:1280
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:652
-#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
-#: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:178 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:857
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:410 lxc/network_forward.go:605
-#: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:411 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1046
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:895
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1209
+#: lxc/network.go:1219
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7040,19 +7059,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:568
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:231
+#: lxc/network.go:236
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:254 lxc/network_load_balancer.go:256
+#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:316
+#: lxc/network.go:326
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7065,7 +7084,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2838
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7100,49 +7119,49 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2563
+#: lxc/storage_volume.go:2581
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2445
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:604
+#: lxc/storage_volume.go:618
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:712
+#: lxc/storage_volume.go:726
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2365
+#: lxc/storage_volume.go:2383
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2244
+#: lxc/storage_volume.go:2262
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:800
+#: lxc/storage_volume.go:814
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
@@ -7153,52 +7172,52 @@ msgid ""
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1230
+#: lxc/storage_volume.go:1244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1859
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:382
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
+#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:226 lxc/config_device.go:849
+#: lxc/config_device.go:299 lxc/config_device.go:922
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:701
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:90
+#: lxc/config_device.go:183
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:642 lxc/profile.go:1181
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1028
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:574
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:967
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/profile.go:283
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7251,7 +7270,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:771
+#: lxc/config.go:139 lxc/config.go:791
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7259,15 +7278,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:903
+#: lxc/config.go:432 lxc/config.go:923
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:576
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1602
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7366,7 +7385,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:173
+#: lxc/cluster_group.go:178
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7374,7 +7393,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:83
+#: lxc/config_device.go:176
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7385,13 +7404,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:143
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:548
+#: lxc/config.go:583
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7400,13 +7419,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1231
+#: lxc/config.go:1269
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1055
+#: lxc/config.go:1093
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7429,20 +7448,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1224
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:472
+#: lxc/file.go:464
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:697
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,7 +7577,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:319
+#: lxc/network.go:329
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7567,7 +7586,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:257
+#: lxc/network_forward.go:258
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7575,7 +7594,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:260
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7606,7 +7625,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:192
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7618,7 +7637,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:370
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7626,7 +7645,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:91
+#: lxc/config_device.go:184
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7637,7 +7656,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:510
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7743,7 +7762,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:608
+#: lxc/storage_volume.go:622
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7751,13 +7770,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2824
+#: lxc/storage_volume.go:2842
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2431
+#: lxc/storage_volume.go:2449
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7791,16 +7810,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1398
+#: lxc/file.go:1390
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1357
+#: lxc/file.go:1349
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1302
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -287,7 +287,7 @@ type ClusterMemberStatePost struct {
 	// Override the configured evacuation mode.
 	// Example: stop
 	//
-	// API extension: clustering_evacuate_mode
+	// API extension: clustering_evacuation_mode
 	Mode string `json:"mode" yaml:"mode"`
 }
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -449,6 +449,7 @@ var APIExtensions = []string{
 	"storage_buckets_all_projects",
 	"network_acls_all_projects",
 	"networks_all_projects",
+	"clustering_restore_skip_mode",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
JIRA ticket: https://warthogs.atlassian.net/browse/LXD-2602?atlOrigin=eyJpIjoiOGUwYzQ5ODJmZjNkNGEyMzk4MTlmN2ZhZWY1YWM5MzciLCJwIjoiaiJ9

This adds a `skip` mode to the `lxc cluster restore` command, which allows a cluster member to be restored to the online state without affecting any instances.

## Problem

When a node is evacuated and then restored using `lxc cluster restore`:

* Instances with local storage that were stopped during evacuation are automatically restarted.
* Instances with remote storage that were migrated to other nodes are automatically migrated back.

We may want to restore just the node's status to online without affecting the current state and location of instances.

## Solution

`skip` mode:

* Does NOT restart any local instances that were stopped.
* Does NOT migrate back any instances that were evacuated to other nodes.

## API extension

`clustering_restore_mode_skip_instances`

## Testing

* Restoring a node with local and remote storage instances using the `skip-instances` mode.
* Verifying that instances remain in their evacuated state/location after restore.
* Confirming that a standard restore without the flag exhibits the original behavior.