### PR TITLE
Lower log level of error messages when checking disk usage fails

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7350,7 +7350,7 @@ func (d *lxc) diskState() map[string]api.InstanceStateDisk {
 			usage, err = pool.GetInstanceUsage(d)
 			if err != nil {
 				if !errors.Is(err, storageDrivers.ErrNotSupported) {
-					d.logger.Error("Error getting disk usage", logger.Ctx{"err": err})
+					d.logger.Info("Unable to get disk usage", logger.Ctx{"err": err})
 				}
 
 				continue

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7365,7 +7365,7 @@ func (d *lxc) diskState() map[string]api.InstanceStateDisk {
 			usage, err = pool.GetCustomVolumeUsage(d.Project().Name, dev.Config["source"])
 			if err != nil {
 				if !errors.Is(err, storageDrivers.ErrNotSupported) {
-					d.logger.Error("Error getting volume usage", logger.Ctx{"volume": dev.Config["source"], "err": err})
+					d.logger.Info("Unable to get volume usage", logger.Ctx{"volume": dev.Config["source"], "err": err})
 				}
 
 				continue

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8038,7 +8038,7 @@ func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error
 	status.StatusCode = statusCode
 	status.Disk, err = d.diskState()
 	if err != nil && !errors.Is(err, storageDrivers.ErrNotSupported) {
-		d.logger.Warn("Error getting disk usage", logger.Ctx{"err": err})
+		d.logger.Info("Unable to get disk usage", logger.Ctx{"err": err})
 	}
 
 	return status, nil


### PR DESCRIPTION
Addresses #15254 to silence this kind of log spam for instances/volumes backed by `ceph`:

```
# journalctl -b0 -fu snap.lxd.daemon
Mar 27 19:34:37 micro1 lxd.daemon[1779]: time="2025-03-27T19:34:37Z" level=warning msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=vm01 instanceType=virtual-machine project=e2e-testing
Mar 27 19:35:34 micro1 lxd.daemon[1779]: time="2025-03-27T19:35:34Z" level=warning msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=vm01 instanceType=virtual-machine project=e2e-testing
Mar 27 19:35:35 micro1 lxd.daemon[1779]: time="2025-03-27T19:35:35Z" level=warning msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=vm01 instanceType=virtual-machine project=e2e-testing
Mar 27 19:35:39 micro1 lxd.daemon[1779]: time="2025-03-27T19:35:39Z" level=warning msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=vm01 instanceType=virtual-machine project=e2e-testing
Mar 27 19:48:42 micro1 lxd.daemon[1779]: time="2025-03-27T19:48:42Z" level=error msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=c01 instanceType=container project=e2e-testing
Mar 27 19:51:15 micro1 lxd.daemon[1779]: time="2025-03-27T19:51:15Z" level=error msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=c01 instanceType=container project=e2e-testing
Mar 27 19:52:59 micro1 lxd.daemon[1779]: time="2025-03-27T19:52:59Z" level=error msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=c01 instanceType=container project=e2e-testing
Mar 27 20:47:22 micro1 lxd.daemon[1779]: time="2025-03-27T20:47:22Z" level=error msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=c01 instanceType=container project=e2e-testing
Mar 27 20:48:14 micro1 lxd.daemon[1779]: time="2025-03-27T20:48:14Z" level=error msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=c01 instanceType=container project=e2e-testing
Mar 27 20:50:29 micro1 lxd.daemon[1779]: time="2025-03-27T20:50:29Z" level=error msg="Error getting disk usage" err="Cannot get disk usage of unmounted volume when ceph.rbd.du is false" instance=c01 instanceType=container project=e2e-testing
```