### PR TITLE
doc: Fix swagger definition for `POST /1.0/auth/identities/tls`

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -7774,7 +7774,7 @@ paths:
                   name: TLS identity
                   required: true
                   schema:
-                    $ref: '#/definitions/IdentitiesPostTLS'
+                    $ref: '#/definitions/IdentitiesTLSPost'
             produces:
                 - application/json
             responses:

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -250,7 +250,7 @@ func identityAccessHandler(authenticationMethod string, entitlement auth.Entitle
 //	    description: TLS Identity
 //	    required: true
 //	    schema:
-//	      $ref: "#/definitions/IdentitiesPostTLS"
+//	      $ref: "#/definitions/IdentitiesTLSPost"
 //	responses:
 //	  "201":
 //	    oneOf:


### PR DESCRIPTION
The swagger comment was incorrectly referencing the struct type name.