### PR TITLE
VM: Fix NUMA node binding when using CPU count without pinning

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8475,6 +8475,36 @@ func (d *qemu) cpuTopology(limit string) (*cpuTopology, error) {
 		topology.cores = nrLimit
 		topology.threads = 1
 
+		// Check for NUMA node assignment without pinning
+		if d.expandedConfig["limits.cpu.nodes"] != "" {
+			numaNodeIDs, err := resources.ParseNumaNodeSet(d.expandedConfig["limits.cpu.nodes"])
+			if err != nil {
+				return nil, fmt.Errorf("Invalid NUMA node selection: %v", err)
+			}
+
+			topology.vcpus = map[uint64]uint64{}
+			topology.nodes = map[uint64][]uint64{}
+
+			// Assign all vCPUs to the first specified node if a single NUMA node is specified
+			// (Note: virtual to physical mapping doesn't matter in non-pinned mode)
+			if len(numaNodeIDs) == 1 {
+				node := numaNodeIDs[0]
+				topology.nodes[uint64(node)] = []uint64{}
+				for i := uint64(0); i < uint64(nrLimit); i++ {
+					topology.vcpus[i] = i
+					topology.nodes[uint64(node)] = append(topology.nodes[uint64(node)], i)
+				}
+			} else {
+				// If multiple NUMA nodes are given, distribute vCPUs evenly across specified nodes.
+				node := numaNodeIDs[0]
+				topology.nodes[uint64(node)] = []uint64{}
+				for i := uint64(0); i < uint64(nrLimit); i++ {
+					topology.vcpus[i] = i
+					topology.nodes[uint64(node)] = append(topology.nodes[uint64(node)], i)
+				}
+			}
+		}
+
 		return topology, nil
 	}
 


### PR DESCRIPTION
closes https://github.com/canonical/lxd/issues/15082

When configuring VMs with `limits.cpu.nodes` but without CPU pinning (using a simple CPU count in `limits.cpu`), the NUMA node selection was not being properly applied. This resulted in VM memory always being allocated from NUMA node 0, regardless of the specified node in `limits.cpu.nodes`.

The issue occurs because the `cpuTopology` function only populates the NUMA node mapping (nodes map) when CPU pinning is used, but not when using a simple CPU count. As a result, when limits.cpu.nodes is specified along with a simple CPU count like `limits.cpu=4`, the memory would still be allocated from NUMA node 0 instead of the requested node.

This modifies the `cpuTopology` function to handle NUMA node assignments correctly even when using a simple CPU count. When `limits.cpu.nodes` is specified without CPU pinning, we now:

* Populate the vcpus map with a basic virtual-to-physical CPU mapping.
* Create a nodes map that assigns all vCPUs to the specified NUMA nodes.
* Ensure this information is properly passed to QEMU.

## Testing

```bash
numactl --hardware
#available: 2 nodes (0-1)
#node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47
#node 0 size: 15731 MB
#node 0 free: 7890 MB
#node 1 cpus: 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63
#node 1 size: 16070 MB
#node 1 free: 12475 MB
#node distances:
#node   0   1 
#  0:  10  21 
#  1:  21  10

lxc init ubuntu/24.04 v1 --vm -c limits.cpu=4 -c limits.memory=1GiB -c limits.cpu.nodes=1
lxc start v1
QEMU_PID=$(pgrep -f "qemu-system.*v1")
sudo numastat -p $QEMU_PID
#Per-node process memory usage (in MBs) for PID 7743 (qemu-system-x86)
#                           Node 0          Node 1           Total
#                  --------------- --------------- ---------------
#Huge                         0.00            0.00            0.00
#Heap                        10.07           12.31           22.38
#Stack                        0.69            0.03            0.71
#Private                     24.56          674.35          698.91
#----------------  --------------- --------------- ---------------
#Total                       35.32          686.68          722.01

#Note: node 1 has 686.68 MB allocated (95.1% of total VM memory) and node 0 has only 35.32 MB allocated (4.9% of total VM memory), which is a good indicator that the fix seems effective.
```