### PR TITLE
doc: improve network ACLs docs

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -2,6 +2,7 @@ AAAA
 ABI
 ACL
 ACLs
+ACL's
 AGPL
 AIO
 allocator
@@ -173,6 +174,7 @@ NBD
 NFS
 NIC
 NICs
+NIC's
 NUMA
 NVMe
 NVML

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -740,6 +740,36 @@ Note that the request _inserted_ the new `user.limit` key without affecting the 
 
 `````
 
+(network-acls-delete)=
+## Delete an ACL
+
+You can only delete an ACL that is not assigned to a NIC or network. See the {ref}`network-acls-assign` section for more information on ACL assignment.
+
+`````{tabs}
+````{group-tab} CLI
+
+To delete an ACL, run:
+
+```bash
+lxc network acl delete <ACL_name>
+```
+
+````
+% End of group-tab CLI
+
+````{group-tab} API
+
+```bash
+lxc query --request DELETE /1.0/network-acls/{name}
+```
+
+See [the API reference](swagger:/network-acls/network_acl_delete) for more information.
+
+````
+% End of group-tab API
+
+`````
+
 (network-acls-assign)=
 ## Assign an ACL
 

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -348,14 +348,49 @@ Otherwise, the ACL cannot be applied to it.
 (network-acls-log)=
 ### Log traffic
 
-Generally, ACL rules are meant to control the network traffic between instances and networks.
-However, you can also use them to log specific network traffic, which can be useful for monitoring, or to test rules before actually enabling them.
+ACL rules are primarily used to control network traffic between instances and networks. However, they can also be used to log specific types of traffic, which is useful for monitoring or testing rules before enabling them.
 
-To add a rule for logging, create it with the `state=logged` property.
-You can then display the log output for all logging rules in the ACL with the following command:
+To configure a rule so that it only logs traffic, configure its `state` to `logged` when you {ref}`add the rule <network-acls-rules>` or {ref}`edit the ACL <network-acls-edit>`.
+
+#### View logs
+
+`````{tabs}
+````{group-tab} CLI
+
+To display the logs for all `logged` rules in an ACL, run:
 
 ```bash
 lxc network acl show-log <ACL_name>
+```
+
+````
+% End of CLI group-tab
+
+````{group-tab} API
+
+To display the logs for all `logged` rules in an ACL, query the following endpoint:
+
+```bash
+lxc query --request GET /1.0/network-acls/{name}/log
+```
+
+See [the API reference](swagger:/network-acls/network_acl_log_get) for more information.
+
+##### Example
+
+```
+lxc query --request GET /1.0/network-acls/my-logged-acl/log
+```
+
+````
+% End of API group-tab
+`````
+% End of tabs
+
+```{note}
+LXD does not validate whether the specified ACL contains any rules with a `state` of `logged`. As a result, if your attempt to view logs returns no data, it could due to one of the following:
+- The ACL includes one or more `logged` rules, but none have matched any traffic yet.
+- The ACL does not contain any rules with a `state` of `logged`.
 ```
 
 (network-acls-edit)=

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -20,6 +20,76 @@ When assigned to a network, the ACL applies to all NICs connected to the network
 The instance NICs that have a particular ACL applied (either explicitly or implicitly through a network) make up a logical group, which can be referenced from other rules as a source or destination.
 See {ref}`network-acls-groups` for more information.
 
+## List ACLs
+
+`````{tabs}
+````{group-tab} CLI
+
+To list all ACLs, run:
+
+```
+lxc network acl list
+```
+
+````
+
+````{group-tab} API
+
+To list all ACLs, query the `/1.0/network-acls` endpoint:
+
+```
+lxc query --request GET /1.0/network-acls
+```
+
+See [the API reference](swagger:/network-acls/network_acls_get) for more information.
+
+You can also use {ref}`recursion <rest-api-recursion>` to list the ACLs with a higher level of detail:
+
+```
+lxc query --request GET /1.0/network-acls?recursion=1
+```
+
+````
+`````
+
+## Show an ACL
+
+`````{tabs}
+````{group-tab} CLI
+
+To show details about a specific ACL, run:
+
+```
+lxc network acl show <acl_name>
+```
+
+Example:
+
+```
+lxc network acl show my-acl
+```
+
+````
+
+````{group-tab} API
+
+For details about a specific ACL, query the following endpoint:
+
+```
+lxc query --request GET /1.0/network-acls/{name}
+```
+
+See [the API reference](swagger:/network-acls/network_acl_get) for more information.
+
+Example:
+
+```
+lxc query --request GET /1.0/network-acls/my-acl
+```
+
+````
+`````
+
 ## Create an ACL
 
 Use the following command to create an ACL:


### PR DESCRIPTION
Improvements to network ACLs docs, including:
- Document the ability to provide a YAML file to create an ACL
- Clarify that the only arguments accepted for CLI-based ACL creation (aside from a YAML file) are the ACL name and the custom user keys
- Add missing sections for listing ACLs, showing an ACL, renaming an ACL, deleting an ACL
- Add API instruction counterparts to all CLI instructions
- Add links to relevant parts of API reference
- Add command syntax examples
- Improve descriptions of ACL and ACL rule properties
- Detailed information about how to edit the ACL via the API, where and how to use PATCH and POST
- Clarify how logging works
- General formatting improvements and copyedits
