### PR TITLE
Configurable instance placement

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2638,3 +2638,9 @@ Adds new {config:option}`instance-security:security.delegate_bpf`.* group of opt
 ## `override_snapshot_profiles_on_copy`
 
 This adds a request option to set snapshot's target profile on instance copy to be inherited from target instance.
+
+## `instance_placement_rules`
+
+This API extension adds a new `placement_rules` field to instances and profiles.
+Placement rules are used to configure where an instance will be created in the cluster.
+Multiple placement rules can be used to define complex scheduling scenarios.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1761,6 +1761,15 @@ definitions:
                         type: disk
                 type: object
                 x-go-name: ExpandedDevices
+            expanded_placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    PlacementRules are a map of rule name to InstancePlacementRule.
+
+                    API Extension: instance_placement_rules
+                type: object
+                x-go-name: ExpandedPlacementRules
             last_used_at:
                 description: Last start timestamp
                 example: "2021-03-23T20:00:00-04:00"
@@ -1777,6 +1786,15 @@ definitions:
                 example: foo
                 type: string
                 x-go-name: Name
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    PlacementRules are a map of rule name to InstancePlacementRule.
+
+                    API Extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
             profiles:
                 description: List of profiles applied to the instance
                 example:
@@ -2059,6 +2077,15 @@ definitions:
                         type: disk
                 type: object
                 x-go-name: ExpandedDevices
+            expanded_placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    PlacementRules are a map of rule name to InstancePlacementRule.
+
+                    API Extension: instance_placement_rules
+                type: object
+                x-go-name: ExpandedPlacementRules
             last_used_at:
                 description: Last start timestamp
                 example: "2021-03-23T20:00:00-04:00"
@@ -2075,6 +2102,15 @@ definitions:
                 example: foo
                 type: string
                 x-go-name: Name
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    PlacementRules are a map of rule name to InstancePlacementRule.
+
+                    API Extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
             profiles:
                 description: List of profiles applied to the instance
                 example:
@@ -2115,6 +2151,33 @@ definitions:
                 x-go-name: Type
         title: InstanceFull is a combination of Instance, InstanceBackup, InstanceState and InstanceSnapshot.
         type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    InstancePlacementRule:
+        properties:
+            kind:
+                $ref: '#/definitions/InstancePlacementRuleKind'
+            priority:
+                description: |-
+                    Priority indicates the apply order of the rule if it is not required.
+                    Non-required rules are applied in descending order of priority.
+                example: 1
+                format: int64
+                type: integer
+                x-go-name: Priority
+            required:
+                description: Required indicates that placement should fail if the rule cannot be satisfied.
+                example: true
+                type: boolean
+                x-go-name: Required
+            selector:
+                $ref: '#/definitions/Selector'
+        title: InstancePlacementRule represents a scheduling rule for an instance.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    InstancePlacementRuleKind:
+        description: 'API extension: instance_placement_rules.'
+        title: InstancePlacementRuleKind denotes the placement strategy for a set of selectors under InstancePlacementRule.
+        type: string
         x-go-package: github.com/canonical/lxd/shared/api
     InstancePost:
         properties:
@@ -2256,6 +2319,15 @@ definitions:
                 example: false
                 type: boolean
                 x-go-name: Ephemeral
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    PlacementRules are a map of rule name to InstancePlacementRule.
+
+                    API Extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
             profiles:
                 description: List of profiles applied to the instance
                 example:
@@ -2344,6 +2416,15 @@ definitions:
                         type: disk
                 type: object
                 x-go-name: ExpandedDevices
+            expanded_placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    Expanded placement rules (all profiles and local placement rules merged)
+
+                    API extension: instance_placement_rules
+                type: object
+                x-go-name: ExpandedPlacementRules
             expires_at:
                 description: When the snapshot expires (gets auto-deleted)
                 example: "2021-03-23T17:38:37.753398689-04:00"
@@ -2361,6 +2442,15 @@ definitions:
                 example: foo
                 type: string
                 x-go-name: Name
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    Placement rules
+
+                    API extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
             profiles:
                 description: List of profiles applied to the instance
                 example:
@@ -2910,6 +3000,15 @@ definitions:
                 example: foo
                 type: string
                 x-go-name: Name
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    PlacementRules are a map of rule name to InstancePlacementRule.
+
+                    API Extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
             profiles:
                 description: List of profiles applied to the instance
                 example:
@@ -4414,6 +4513,15 @@ definitions:
                 readOnly: true
                 type: string
                 x-go-name: Name
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    List of instance placement rules
+
+                    API extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
             project:
                 description: Project name
                 example: project1
@@ -4475,6 +4583,15 @@ definitions:
                         type: disk
                 type: object
                 x-go-name: Devices
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    List of instance placement rules
+
+                    API extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     ProfilesPost:
@@ -4516,6 +4633,15 @@ definitions:
                 example: foo
                 type: string
                 x-go-name: Name
+            placement_rules:
+                additionalProperties:
+                    $ref: '#/definitions/InstancePlacementRule'
+                description: |-
+                    List of instance placement rules
+
+                    API extension: instance_placement_rules
+                type: object
+                x-go-name: PlacementRules
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     Project:
@@ -5901,6 +6027,36 @@ definitions:
                 format: uint64
                 type: integer
                 x-go-name: SubClassID
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    Selector:
+        properties:
+            entity_type:
+                description: EntityType is the type of entity to perform the selection against.
+                type: string
+                x-go-name: EntityType
+            matchers:
+                description: Matchers are a list of matchers to use when performing the selection.
+                items:
+                    $ref: '#/definitions/SelectorMatcher'
+                type: array
+                x-go-name: Matchers
+        title: Selector represents a method of selecting one or more entities of a particular type.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    SelectorMatcher:
+        properties:
+            property:
+                description: Property is the property of the entity to perform the match against.
+                type: string
+                x-go-name: Property
+            values:
+                description: Values are a list of values to find in the property.
+                items:
+                    type: string
+                type: array
+                x-go-name: Values
+        title: SelectorMatcher contains the properties and values that a Selector selects against.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     Server:

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -37,6 +37,10 @@ func (c *cmdConfig) command() *cobra.Command {
 	configDeviceCmd := cmdConfigDevice{global: c.global, config: c}
 	cmd.AddCommand(configDeviceCmd.command())
 
+	// Placement rules
+	configPlacementCmd := cmdConfigPlacement{global: c.global, config: c}
+	cmd.AddCommand(configPlacementCmd.command())
+
 	// Edit
 	configEditCmd := cmdConfigEdit{global: c.global, config: c}
 	cmd.AddCommand(configEditCmd.command())
@@ -860,6 +864,7 @@ func (c *cmdConfigShow) run(cmd *cobra.Command, args []string) error {
 			if c.flagExpanded {
 				brief.(*api.InstanceSnapshot).Config = snap.ExpandedConfig
 				brief.(*api.InstanceSnapshot).Devices = snap.ExpandedDevices
+				brief.(*api.InstanceSnapshot).PlacementRules = snap.ExpandedPlacementRules
 			}
 		} else {
 			// Instance
@@ -874,6 +879,7 @@ func (c *cmdConfigShow) run(cmd *cobra.Command, args []string) error {
 			if c.flagExpanded {
 				brief.(*api.InstancePut).Config = inst.ExpandedConfig
 				brief.(*api.InstancePut).Devices = inst.ExpandedDevices
+				brief.(*api.InstancePut).PlacementRules = inst.ExpandedPlacementRules
 			}
 		}
 

--- a/lxc/config_placement.go
+++ b/lxc/config_placement.go
@@ -1,0 +1,482 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/canonical/lxd/shared/api"
+	cli "github.com/canonical/lxd/shared/cmd"
+	"github.com/canonical/lxd/shared/i18n"
+)
+
+type cmdConfigPlacement struct {
+	global       *cmdGlobal
+	config       *cmdConfig
+	profile      *cmdProfile
+	flagPriority int
+}
+
+func (c *cmdConfigPlacement) parseRule(args []string) (*api.InstancePlacementRule, error) {
+	if len(args) < 3 {
+		return nil, fmt.Errorf("Instance placement rule requires a kind, an entity type, and at least one key value pair")
+	}
+
+	required := c.flagPriority < 0
+	var priority int
+	if !required {
+		priority = c.flagPriority
+	}
+
+	rule := api.InstancePlacementRule{
+		Required: required,
+		Kind:     api.InstancePlacementRuleKind(args[0]),
+		Priority: priority,
+		Selector: api.Selector{
+			EntityType: args[1],
+			Matchers:   nil,
+		},
+	}
+
+	proprty, values, ok := strings.Cut(args[2], "=")
+	if !ok {
+		return nil, fmt.Errorf("Invalid selector matcher %q", args[2])
+	}
+
+	rule.Selector.Matchers = append(rule.Selector.Matchers, api.SelectorMatcher{
+		Property: proprty,
+		Values:   strings.Split(values, ","),
+	})
+
+	if len(args) > 3 {
+		for _, arg := range args[3:] {
+			proprty, values, ok := strings.Cut(arg, "=")
+			if !ok {
+				return nil, fmt.Errorf("Invalid selector matcher %q", arg)
+			}
+
+			rule.Selector.Matchers = append(rule.Selector.Matchers, api.SelectorMatcher{
+				Property: proprty,
+				Values:   strings.Split(values, ","),
+			})
+		}
+	}
+
+	return &rule, nil
+}
+
+func (c *cmdConfigPlacement) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("placement")
+	cmd.Short = i18n.G("Manage placement rules")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Manage placement rules`))
+
+	// Add
+	configPlacementAddCmd := cmdConfigPlacementAdd{global: c.global, config: c.config, profile: c.profile, configPlacement: c}
+	cmd.AddCommand(configPlacementAddCmd.command())
+
+	// Override
+	if c.config != nil {
+		configPlacementOverrideCmd := cmdConfigPlacementOverride{global: c.global, config: c.config, profile: c.profile, configPlacement: c}
+		cmd.AddCommand(configPlacementOverrideCmd.command())
+	}
+
+	// Remove
+	configPlacementRemoveCmd := cmdConfigPlacementRemove{global: c.global, config: c.config, profile: c.profile, configPlacement: c}
+	cmd.AddCommand(configPlacementRemoveCmd.command())
+
+	// Show
+	configPlacementShowCmd := cmdConfigPlacementShow{global: c.global, config: c.config, profile: c.profile}
+	cmd.AddCommand(configPlacementShowCmd.command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
+	return cmd
+}
+
+// Add.
+type cmdConfigPlacementAdd struct {
+	global          *cmdGlobal
+	config          *cmdConfig
+	configPlacement *cmdConfigPlacement
+	profile         *cmdProfile
+}
+
+func (c *cmdConfigPlacementAdd) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Short = i18n.G("Add instance placement rules")
+	cmd.Flags().IntVar(&c.configPlacement.flagPriority, "priority", -1, "The instance placement rule priority")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Add instance placement rules`))
+	if c.config != nil {
+		cmd.Use = usage("add", i18n.G("[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> [key=value...] [--priority <priority>]"))
+		cmd.Example = cli.FormatSection("", i18n.G(
+			`lxc config placement add [<remote>:]instance1 <rule-name> affinity cluster_group name=gpu
+    Will configure an affinity rule for the instance with name "instance1" for the cluster group with name "gpu".
+
+lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity instance config.user.foo=bar,baz
+	Will configure an anti-affinity rule for the instance with name "instance1" against other instances whose value for "config.user.foo" is "bar" or "baz".`))
+	} else if c.profile != nil {
+		cmd.Use = usage("add", i18n.G("[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> [key=value...] [--priority <priority>]"))
+		cmd.Example = cli.FormatSection("", i18n.G(
+			`lxc profile placement add [<remote>:]profile1 <rule-name> affinity cluster_group name=gpu
+    Will configure an affinity rule for the instances with profile "profile1" for the cluster group with name "gpu".
+
+lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity instance config.user.foo=bar,baz
+	Will configure an anti-affinity rule for instances with profile "profile1" against other instances whose value for "config.user.foo" is "bar" or "baz".`))
+	}
+
+	cmd.RunE = c.run
+	return cmd
+}
+
+func (c *cmdConfigPlacementAdd) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 5, -1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return errors.New(i18n.G("Missing name"))
+	}
+
+	// Add the rule
+	rulename := args[1]
+
+	rule, err := c.configPlacement.parseRule(args[2:])
+	if err != nil {
+		return err
+	}
+
+	if c.profile != nil {
+		profile, etag, err := resource.server.GetProfile(resource.name)
+		if err != nil {
+			return err
+		}
+
+		if profile.PlacementRules == nil {
+			profile.PlacementRules = make(map[string]api.InstancePlacementRule)
+		}
+
+		_, ok := profile.PlacementRules[rulename]
+		if ok {
+			return errors.New(i18n.G("The rule already exists"))
+		}
+
+		profile.PlacementRules[rulename] = *rule
+
+		err = resource.server.UpdateProfile(resource.name, profile.Writable(), etag)
+		if err != nil {
+			return err
+		}
+	} else {
+		inst, etag, err := resource.server.GetInstance(resource.name)
+		if err != nil {
+			return err
+		}
+
+		if inst.PlacementRules == nil {
+			inst.PlacementRules = make(map[string]api.InstancePlacementRule)
+		}
+
+		_, ok := inst.PlacementRules[rulename]
+		if ok {
+			return errors.New(i18n.G("The rule already exists"))
+		}
+
+		inst.PlacementRules[rulename] = *rule
+
+		op, err := resource.server.UpdateInstance(resource.name, inst.Writable(), etag)
+		if err != nil {
+			return err
+		}
+
+		err = op.Wait()
+		if err != nil {
+			return err
+		}
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf(i18n.G("Placement rule %s added to %s")+"\n", rulename, resource.name)
+	}
+
+	return nil
+}
+
+// Override.
+type cmdConfigPlacementOverride struct {
+	global          *cmdGlobal
+	config          *cmdConfig
+	configPlacement *cmdConfigPlacement
+	profile         *cmdProfile
+}
+
+func (c *cmdConfigPlacementOverride) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("override", i18n.G("[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--priority <priority>]"))
+	cmd.Short = i18n.G("Override profile inherited placement rules")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Override profile inherited placement rules`))
+	cmd.Flags().IntVar(&c.configPlacement.flagPriority, "priority", -1, "The instance placement rule priority")
+
+	cmd.RunE = c.run
+
+	return cmd
+}
+
+func (c *cmdConfigPlacementOverride) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return errors.New(i18n.G("Missing name"))
+	}
+
+	// Override the rule
+	inst, etag, err := resource.server.GetInstance(resource.name)
+	if err != nil {
+		return err
+	}
+
+	rulename := args[1]
+	_, ok := inst.PlacementRules[rulename]
+	if ok {
+		return errors.New(i18n.G("The rule already exists"))
+	}
+
+	_, ok = inst.ExpandedPlacementRules[rulename]
+	if !ok {
+		return errors.New(i18n.G("The profile placement doesn't exist"))
+	}
+
+	var rule api.InstancePlacementRule
+	kind := args[2]
+	if len(args) > 3 {
+		r, err := c.configPlacement.parseRule(args[3:])
+		if err != nil {
+			return err
+		}
+
+		rule = *r
+	} else {
+		rule = api.InstancePlacementRule{Kind: api.InstancePlacementRuleKind(kind)}
+	}
+
+	inst.PlacementRules[rulename] = rule
+
+	op, err := resource.server.UpdateInstance(resource.name, inst.Writable(), etag)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf(i18n.G("Placement %s overridden for %s")+"\n", rulename, resource.name)
+	}
+
+	return nil
+}
+
+// Remove.
+type cmdConfigPlacementRemove struct {
+	global          *cmdGlobal
+	config          *cmdConfig
+	configPlacement *cmdConfigPlacement
+	profile         *cmdProfile
+}
+
+func (c *cmdConfigPlacementRemove) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	if c.config != nil {
+		cmd.Use = usage("remove", i18n.G("[<remote>:]<instance> <name>..."))
+	} else if c.profile != nil {
+		cmd.Use = usage("remove", i18n.G("[<remote>:]<profile> <name>..."))
+	}
+
+	cmd.Aliases = []string{"rm"}
+	cmd.Short = i18n.G("Remove instance placement rules")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Remove instance placement rules`))
+
+	cmd.RunE = c.run
+
+	return cmd
+}
+
+func (c *cmdConfigPlacementRemove) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return errors.New(i18n.G("Missing name"))
+	}
+
+	// Remove the rule
+	if c.profile != nil {
+		profile, etag, err := resource.server.GetProfile(resource.name)
+		if err != nil {
+			return err
+		}
+
+		for _, rulename := range args[1:] {
+			_, ok := profile.PlacementRules[rulename]
+			if !ok {
+				return errors.New(i18n.G("Placement rule doesn't exist"))
+			}
+
+			delete(profile.PlacementRules, rulename)
+		}
+
+		err = resource.server.UpdateProfile(resource.name, profile.Writable(), etag)
+		if err != nil {
+			return err
+		}
+	} else {
+		inst, etag, err := resource.server.GetInstance(resource.name)
+		if err != nil {
+			return err
+		}
+
+		for _, rulename := range args[1:] {
+			_, ok := inst.PlacementRules[rulename]
+			if !ok {
+				_, ok := inst.PlacementRules[rulename]
+				if !ok {
+					return errors.New(i18n.G("Placement rule doesn't exist"))
+				}
+
+				return errors.New(i18n.G("Placement rule from profile(s) cannot be removed from individual instance. Override rule or modify profile instead"))
+			}
+
+			delete(inst.PlacementRules, rulename)
+		}
+
+		op, err := resource.server.UpdateInstance(resource.name, inst.Writable(), etag)
+		if err != nil {
+			return err
+		}
+
+		err = op.Wait()
+		if err != nil {
+			return err
+		}
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf(i18n.G("Placement %s removed from %s")+"\n", strings.Join(args[1:], ", "), resource.name)
+	}
+
+	return nil
+}
+
+// Show.
+type cmdConfigPlacementShow struct {
+	global  *cmdGlobal
+	config  *cmdConfig
+	profile *cmdProfile
+}
+
+func (c *cmdConfigPlacementShow) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	if c.config != nil {
+		cmd.Use = usage("show", i18n.G("[<remote>:]<instance>"))
+	} else if c.profile != nil {
+		cmd.Use = usage("show", i18n.G("[<remote>:]<profile>"))
+	}
+
+	cmd.Short = i18n.G("Show full placement rule configuration")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Show full placement rule configuration`))
+
+	cmd.RunE = c.run
+
+	return cmd
+}
+
+func (c *cmdConfigPlacementShow) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return errors.New(i18n.G("Missing name"))
+	}
+
+	// Show the placement rules
+	var placementRules map[string]api.InstancePlacementRule
+	if c.profile != nil {
+		profile, _, err := resource.server.GetProfile(resource.name)
+		if err != nil {
+			return err
+		}
+
+		placementRules = profile.PlacementRules
+	} else {
+		inst, _, err := resource.server.GetInstance(resource.name)
+		if err != nil {
+			return err
+		}
+
+		placementRules = inst.PlacementRules
+	}
+
+	data, err := yaml.Marshal(&placementRules)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(string(data))
+
+	return nil
+}

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -59,6 +59,10 @@ func (c *cmdProfile) command() *cobra.Command {
 	profileDeviceCmd := cmdConfigDevice{global: c.global, profile: c}
 	cmd.AddCommand(profileDeviceCmd.command())
 
+	// Placement
+	profilePlacementCmd := cmdConfigPlacement{global: c.global, profile: c}
+	cmd.AddCommand(profilePlacementCmd.command())
+
 	// Edit
 	profileEditCmd := cmdProfileEdit{global: c.global, profile: c}
 	cmd.AddCommand(profileEditCmd.command())

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3615,14 +3615,15 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 			delete(config, "volatile.evacuate.origin")
 
 			args := db.InstanceArgs{
-				Architecture: inst.Architecture(),
-				Config:       config,
-				Description:  inst.Description(),
-				Devices:      inst.LocalDevices(),
-				Ephemeral:    inst.IsEphemeral(),
-				Profiles:     inst.Profiles(),
-				Project:      inst.Project().Name,
-				ExpiryDate:   inst.ExpiryDate(),
+				Architecture:   inst.Architecture(),
+				Config:         config,
+				Description:    inst.Description(),
+				Devices:        inst.LocalDevices(),
+				Ephemeral:      inst.IsEphemeral(),
+				Profiles:       inst.Profiles(),
+				Project:        inst.Project().Name,
+				ExpiryDate:     inst.ExpiryDate(),
+				PlacementRules: inst.LocalPlacementRules(),
 			}
 
 			err = inst.Update(args, false)

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -217,6 +217,17 @@ func (e *EntityRef) getURL() (*api.URL, error) {
 	return u, nil
 }
 
+// RunSelector returns the entity IDs for the given Selector.
+func RunSelector(ctx context.Context, tx *sql.Tx, selector Selector) ([]int, error) {
+	entityType := entity.Type(selector.EntityType)
+	info, ok := entityTypes[entityType]
+	if !ok {
+		return nil, fmt.Errorf("Failed to run entity selector: Unknown entity type %q", entityType)
+	}
+
+	return info.runSelector(ctx, tx, selector)
+}
+
 // GetEntityURL returns the *api.URL of a single entity by its type and ID.
 func GetEntityURL(ctx context.Context, tx *sql.Tx, entityType entity.Type, entityID int) (*api.URL, error) {
 	if entityType == entity.TypeServer {

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -69,6 +69,9 @@ type entityTypeDBInfo interface {
 	// triggers are in place so that warnings and group permissions do not contain stale entries. The first return value
 	// must be the name of the trigger, the second return value must be the SQL for creating the trigger.
 	onDeleteTriggerSQL() (name string, sql string)
+
+	// runSelector must validate the given Selector for the entity type and return a slice of entity IDs that match.
+	runSelector(ctx context.Context, tx *sql.Tx, selector Selector) ([]int, error)
 }
 
 var entityTypes = map[entity.Type]entityTypeDBInfo{

--- a/lxd/db/cluster/entity_type_auth_group.go
+++ b/lxd/db/cluster/entity_type_auth_group.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeAuthGroup implements entityTypeDBInfo for an AuthGroup.
-type entityTypeAuthGroup struct{}
+type entityTypeAuthGroup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeAuthGroup) code() int64 {
 	return entityTypeCodeAuthGroup
@@ -13,10 +15,6 @@ func (e entityTypeAuthGroup) code() int64 {
 
 func (e entityTypeAuthGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, auth_groups.id, '', '', json_array(auth_groups.name) FROM auth_groups`, e.code())
-}
-
-func (e entityTypeAuthGroup) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeAuthGroup) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_certificate.go
+++ b/lxd/db/cluster/entity_type_certificate.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeCertificate implements entityTypeDBInfo for a Certificate.
-type entityTypeCertificate struct{}
+type entityTypeCertificate struct {
+	entityTypeCommon
+}
 
 func (e entityTypeCertificate) code() int64 {
 	return entityTypeCodeCertificate
@@ -22,10 +24,6 @@ func (e entityTypeCertificate) allURLsQuery() string {
 		identityTypeCertificateMetricsRestricted,
 		identityTypeCertificateMetricsUnrestricted,
 	)
-}
-
-func (e entityTypeCertificate) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeCertificate) urlByIDQuery() string {
@@ -48,8 +46,4 @@ WHERE '' = ?
 		identityTypeCertificateMetricsRestricted,
 		identityTypeCertificateMetricsUnrestricted,
 	)
-}
-
-func (e entityTypeCertificate) onDeleteTriggerSQL() (name string, sql string) {
-	return "", ""
 }

--- a/lxd/db/cluster/entity_type_cluster_group.go
+++ b/lxd/db/cluster/entity_type_cluster_group.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeClusterGroup implements entityTypeDBInfo for a ClusterGroup.
-type entityTypeClusterGroup struct{}
+type entityTypeClusterGroup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeClusterGroup) code() int64 {
 	return entityTypeCodeClusterGroup
@@ -13,10 +15,6 @@ func (e entityTypeClusterGroup) code() int64 {
 
 func (e entityTypeClusterGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, cluster_groups.id, '', '', json_array(cluster_groups.name) FROM cluster_groups`, e.code())
-}
-
-func (e entityTypeClusterGroup) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeClusterGroup) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_cluster_group.go
+++ b/lxd/db/cluster/entity_type_cluster_group.go
@@ -1,7 +1,12 @@
 package cluster
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
+	"github.com/canonical/lxd/shared/entity"
 )
 
 // entityTypeClusterGroup implements entityTypeDBInfo for a ClusterGroup.
@@ -44,4 +49,44 @@ CREATE TRIGGER %s
 		AND entity_id = OLD.id;
 	END
 `, name, e.code(), e.code())
+}
+
+// runSelector for entityTypeClusterGroup only accepts the "name" matcher key.
+func (e entityTypeClusterGroup) runSelector(ctx context.Context, tx *sql.Tx, selector Selector) ([]int, error) {
+	q, args, err := e.selectorQuery(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	return query.SelectIntegers(ctx, tx, q, args...)
+}
+
+func (e entityTypeClusterGroup) selectorQuery(selector Selector) (string, []any, error) {
+	if entity.Type(selector.EntityType) != entity.TypeClusterGroup {
+		return "", nil, fmt.Errorf("Invalid selector entity type %q (expected %q)", selector.EntityType, entity.TypeClusterGroup)
+	}
+
+	if len(selector.Matchers) == 0 {
+		return "", nil, fmt.Errorf("Selector for entity type %q has no matchers", entity.TypeClusterGroup)
+	}
+
+	if len(selector.Matchers) > 1 {
+		return "", nil, fmt.Errorf("Selectors for entity type %q may only have one matcher", entity.TypeClusterGroup)
+	}
+
+	if selector.Matchers[0].Property != "name" {
+		return "", nil, fmt.Errorf("Selectors for entity type %q may have only one matcher with property %q", entity.TypeClusterGroup, "name")
+	}
+
+	if len(selector.Matchers[0].Values) == 0 {
+		return "", nil, fmt.Errorf("Selector matcher for entity type %q requires at least one value", entity.TypeClusterGroup)
+	}
+
+	q := `SELECT id FROM cluster_groups WHERE name IN ` + query.Params(len(selector.Matchers[0].Values))
+	args := make([]any, 0, len(selector.Matchers[0].Values))
+	for _, v := range selector.Matchers[0].Values {
+		args = append(args, v)
+	}
+
+	return q, args, nil
 }

--- a/lxd/db/cluster/entity_type_cluster_member.go
+++ b/lxd/db/cluster/entity_type_cluster_member.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeClusterMember implements entityTypeDBInfo for a ClusterMember.
-type entityTypeClusterMember struct{}
+type entityTypeClusterMember struct {
+	entityTypeCommon
+}
 
 func (e entityTypeClusterMember) code() int64 {
 	return entityTypeCodeClusterMember
@@ -13,10 +15,6 @@ func (e entityTypeClusterMember) code() int64 {
 
 func (e entityTypeClusterMember) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, nodes.id, '', '', json_array(nodes.name) FROM nodes`, e.code())
-}
-
-func (e entityTypeClusterMember) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeClusterMember) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_common.go
+++ b/lxd/db/cluster/entity_type_common.go
@@ -1,0 +1,38 @@
+package cluster
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+type entityTypeCommon struct{}
+
+// allURLsQuery returns an empty string because there are no Server entities in the database.
+func (e entityTypeCommon) allURLsQuery() string {
+	return ""
+}
+
+func (e entityTypeCommon) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeCommon) urlByIDQuery() string {
+	return ""
+}
+
+// idFromURLQuery returns an empty string because there are no Server entities in the database.
+func (e entityTypeCommon) idFromURLQuery() string {
+	return ""
+}
+
+func (e entityTypeCommon) onDeleteTriggerSQL() (name string, sql string) {
+	return "", ""
+}
+
+// runSelector is not implemented for entityTypeServer.
+func (e entityTypeCommon) runSelector(_ context.Context, _ *sql.Tx, _ Selector) ([]int, error) {
+	return nil, api.NewGenericStatusError(http.StatusBadRequest)
+}

--- a/lxd/db/cluster/entity_type_container.go
+++ b/lxd/db/cluster/entity_type_container.go
@@ -7,7 +7,9 @@ import (
 )
 
 // entityTypeContainer implements entityTypeDBInfo for a Container.
-type entityTypeContainer struct{}
+type entityTypeContainer struct {
+	entityTypeCommon
+}
 
 func (e entityTypeContainer) code() int64 {
 	return entityTypeCodeContainer

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -7,7 +7,9 @@ import (
 )
 
 // entityTypeIdentity implements entityTypeDBInfo for an Identity.
-type entityTypeIdentity struct{}
+type entityTypeIdentity struct {
+	entityTypeCommon
+}
 
 func (e entityTypeIdentity) code() int64 {
 	return entityTypeCodeIdentity
@@ -35,10 +37,6 @@ WHERE type IN (%d, %d, %d)
 		authMethodOIDC, api.AuthenticationMethodOIDC,
 		identityTypeOIDCClient, identityTypeCertificateClient, identityTypeCertificateClientPending,
 	)
-}
-
-func (e entityTypeIdentity) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeIdentity) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_identity_provider_group.go
+++ b/lxd/db/cluster/entity_type_identity_provider_group.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeIdentityProviderGroup implements entityTypeDBInfo for an IdentityProviderGroup.
-type entityTypeIdentityProviderGroup struct{}
+type entityTypeIdentityProviderGroup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeIdentityProviderGroup) code() int64 {
 	return entityTypeCodeIdentityProviderGroup
@@ -13,10 +15,6 @@ func (e entityTypeIdentityProviderGroup) code() int64 {
 
 func (e entityTypeIdentityProviderGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, identity_provider_groups.id, '', '', json_array(identity_provider_groups.name) FROM identity_provider_groups`, e.code())
-}
-
-func (e entityTypeIdentityProviderGroup) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeIdentityProviderGroup) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_image.go
+++ b/lxd/db/cluster/entity_type_image.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeImage implements entityTypeDBInfo for an Image.
-type entityTypeImage struct{}
+type entityTypeImage struct {
+	entityTypeCommon
+}
 
 func (e entityTypeImage) code() int64 {
 	return entityTypeCodeImage

--- a/lxd/db/cluster/entity_type_image_alias.go
+++ b/lxd/db/cluster/entity_type_image_alias.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeImageAlias implements entityTypeDBInfo for an ImageAlias.
-type entityTypeImageAlias struct{}
+type entityTypeImageAlias struct {
+	entityTypeCommon
+}
 
 func (e entityTypeImageAlias) code() int64 {
 	return entityTypeCodeImageAlias

--- a/lxd/db/cluster/entity_type_instance.go
+++ b/lxd/db/cluster/entity_type_instance.go
@@ -1,7 +1,15 @@
 package cluster
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
+	"strings"
+
+	"github.com/canonical/lxd/lxd/db/query"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
 )
 
 // entityTypeInstance implements entityTypeDBInfo for an Instance.

--- a/lxd/db/cluster/entity_type_instance.go
+++ b/lxd/db/cluster/entity_type_instance.go
@@ -59,3 +59,187 @@ CREATE TRIGGER %s
 	END
 `, name, e.code(), e.code())
 }
+
+func (e entityTypeInstance) runSelector(ctx context.Context, tx *sql.Tx, selector Selector) ([]int, error) {
+	propertyQuery, propertyArgs, hasConfigMatcher, err := e.propertyQuery(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates, err := query.SelectIntegers(ctx, tx, propertyQuery, propertyArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hasConfigMatcher || len(candidates) == 0 {
+		return candidates, nil
+	}
+
+	type precedenceMapValue struct {
+		precedence int
+		value      string
+	}
+
+	configQuery, matcher, configQueryArgs, err := e.configQuery(selector, candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := tx.QueryContext(ctx, configQuery, configQueryArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	instances := make(map[int]precedenceMapValue)
+	for rows.Next() {
+		var instanceID int
+		var precedence int
+		var value string
+		err := rows.Scan(&instanceID, &precedence, &value)
+		if err != nil {
+			return nil, err
+		}
+
+		current, ok := instances[instanceID]
+		if ok && current.precedence > precedence {
+			continue
+		}
+
+		instances[instanceID] = precedenceMapValue{precedence: precedence, value: value}
+	}
+
+	candidates = make([]int, 0, len(candidates))
+	for instanceID, v := range instances {
+		if shared.ValueInSlice(v.value, matcher.Values) {
+			candidates = append(candidates, instanceID)
+		}
+	}
+
+	return candidates, nil
+}
+
+func (e entityTypeInstance) propertyQuery(selector Selector) (string, []any, bool, error) {
+	if entity.Type(selector.EntityType) != entity.TypeInstance {
+		return "", nil, false, fmt.Errorf("Invalid selector entity type %q (expected %q)", selector.EntityType, entity.TypeInstance)
+	}
+
+	if len(selector.Matchers) == 0 {
+		return "", nil, false, fmt.Errorf("Selector for entity type %q has no matchers", entity.TypeInstance)
+	}
+
+	var hasConfigMatcher bool
+	existingProperties := make([]string, 0, len(selector.Matchers))
+	for _, m := range selector.Matchers {
+		if shared.ValueInSlice(m.Property, existingProperties) {
+			return "", nil, false, fmt.Errorf("Repeated selector matcher property %q", m.Property)
+		}
+
+		existingProperties = append(existingProperties, m.Property)
+
+		isConfigMatcher := strings.HasPrefix(m.Property, "config.")
+		if isConfigMatcher {
+			if hasConfigMatcher {
+				return "", nil, false, fmt.Errorf("Multiple configuration matchers not supported")
+			}
+
+			hasConfigMatcher = true
+		}
+
+		if !shared.ValueInSlice(m.Property, []string{"name", "project"}) && !isConfigMatcher {
+			return "", nil, false, fmt.Errorf("Invalid selector property %q for entity type %q", m.Property, entity.TypeInstance)
+		}
+
+		if len(m.Values) == 0 {
+			return "", nil, false, fmt.Errorf("Selector matcher with property %q for entity type %q requires at least one value", m.Property, entity.TypeClusterGroup)
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(`SELECT instances.id FROM instances `)
+	for _, m := range selector.Matchers {
+		switch m.Property {
+		case "name":
+		case "project":
+			b.WriteString(`JOIN projects ON instances.project_id = projects.id `)
+		}
+	}
+
+	args := make([]any, 0, len(selector.Matchers))
+	for i, m := range selector.Matchers {
+		if !shared.ValueInSlice(m.Property, []string{"name", "project"}) {
+			continue
+		}
+
+		matcherArgs := make([]any, 0, len(m.Values))
+		for _, v := range m.Values {
+			matcherArgs = append(matcherArgs, v)
+		}
+
+		if i == 0 {
+			b.WriteString("WHERE ")
+		} else {
+			b.WriteString("AND ")
+		}
+
+		switch m.Property {
+		case "name":
+			b.WriteString("instances.name IN " + query.Params(len(matcherArgs)))
+		case "project":
+			b.WriteString("projects.name IN " + query.Params(len(matcherArgs)))
+		}
+
+		args = append(args, matcherArgs...)
+	}
+
+	return b.String(), args, hasConfigMatcher, nil
+}
+
+func (e entityTypeInstance) configQuery(selector Selector, instanceIDs []int) (string, api.SelectorMatcher, []any, error) {
+	var key string
+	var matcher api.SelectorMatcher
+	for _, m := range selector.Matchers {
+		var ok bool
+		key, ok = strings.CutPrefix(m.Property, "config.")
+		if !ok {
+			continue
+		}
+
+		matcher = m
+		break
+	}
+
+	args := make([]any, 0, 2*(len(instanceIDs)+1))
+	for i := 0; i < 2; i++ {
+		args = append(args, key)
+		for _, c := range instanceIDs {
+			args = append(args, c)
+		}
+	}
+
+	q := `
+SELECT 
+	instances.id AS instance_id, 
+	1000000 AS apply_order, 
+	instances_config.value 
+FROM instances 
+JOIN instances_config ON instances.id = instances_config.instance_id 
+WHERE instances_config.key = ? 
+	AND instances.id IN ` + query.Params(len(instanceIDs)) + `
+UNION 
+SELECT 
+	instances.id AS instance_id, 
+	instances_profiles.apply_order, 
+	profiles_config.value 
+FROM instances 
+JOIN instances_profiles ON instances.id = instances_profiles.instance_id 
+JOIN profiles ON instances_profiles.profile_id = profiles.id 
+JOIN profiles_config ON profiles.id = profiles_config.profile_id 
+WHERE profiles_config.key = ? 
+	AND instances.id IN ` + query.Params(len(instanceIDs))
+
+	return q, matcher, args, nil
+}

--- a/lxd/db/cluster/entity_type_instance_backup.go
+++ b/lxd/db/cluster/entity_type_instance_backup.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeInstanceBackup implements entityTypeDBInfo for an InstanceBackup.
-type entityTypeInstanceBackup struct{}
+type entityTypeInstanceBackup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeInstanceBackup) code() int64 {
 	return entityTypeCodeInstanceBackup

--- a/lxd/db/cluster/entity_type_instance_snapshot.go
+++ b/lxd/db/cluster/entity_type_instance_snapshot.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeInstanceSnapshot implements entityTypeDBInfo for an InstanceSnapshot.
-type entityTypeInstanceSnapshot struct{}
+type entityTypeInstanceSnapshot struct {
+	entityTypeCommon
+}
 
 func (e entityTypeInstanceSnapshot) code() int64 {
 	return entityTypeCodeInstanceSnapshot

--- a/lxd/db/cluster/entity_type_network.go
+++ b/lxd/db/cluster/entity_type_network.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeNetwork implements entityTypeDBInfo for a Network.
-type entityTypeNetwork struct{}
+type entityTypeNetwork struct {
+	entityTypeCommon
+}
 
 func (e entityTypeNetwork) code() int64 {
 	return entityTypeCodeNetwork

--- a/lxd/db/cluster/entity_type_network_acl.go
+++ b/lxd/db/cluster/entity_type_network_acl.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeNetworkACL implements entityTypeDBInfo for a NetworkACL.
-type entityTypeNetworkACL struct{}
+type entityTypeNetworkACL struct {
+	entityTypeCommon
+}
 
 func (e entityTypeNetworkACL) code() int64 {
 	return entityTypeCodeNetworkACL

--- a/lxd/db/cluster/entity_type_network_zone.go
+++ b/lxd/db/cluster/entity_type_network_zone.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeNetworkZone implements entityTypeDBInfo for a NetworkZone.
-type entityTypeNetworkZone struct{}
+type entityTypeNetworkZone struct {
+	entityTypeCommon
+}
 
 func (e entityTypeNetworkZone) code() int64 {
 	return entityTypeCodeNetworkZone

--- a/lxd/db/cluster/entity_type_operation.go
+++ b/lxd/db/cluster/entity_type_operation.go
@@ -6,7 +6,9 @@ import (
 )
 
 // entityTypeOperation implements entityTypeDBInfo for an Operation.
-type entityTypeOperation struct{}
+type entityTypeOperation struct {
+	entityTypeCommon
+}
 
 func (e entityTypeOperation) code() int64 {
 	return entityTypeCodeOperation

--- a/lxd/db/cluster/entity_type_profile.go
+++ b/lxd/db/cluster/entity_type_profile.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeProfile implements entityTypeDBInfo for a Profile.
-type entityTypeProfile struct{}
+type entityTypeProfile struct {
+	entityTypeCommon
+}
 
 func (e entityTypeProfile) code() int64 {
 	return entityTypeCodeProfile

--- a/lxd/db/cluster/entity_type_project.go
+++ b/lxd/db/cluster/entity_type_project.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeProject implements entityTypeDBInfo for a Project.
-type entityTypeProject struct{}
+type entityTypeProject struct {
+	entityTypeCommon
+}
 
 func (e entityTypeProject) code() int64 {
 	return entityTypeCodeProject
@@ -13,10 +15,6 @@ func (e entityTypeProject) code() int64 {
 
 func (e entityTypeProject) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, projects.id, projects.name, '', json_array(projects.name) FROM projects`, e.code())
-}
-
-func (e entityTypeProject) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeProject) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_server.go
+++ b/lxd/db/cluster/entity_type_server.go
@@ -1,30 +1,10 @@
 package cluster
 
 // entityTypeServer implements entityTypeDBInfo for a Server.
-type entityTypeServer struct{}
+type entityTypeServer struct {
+	entityTypeCommon
+}
 
 func (e entityTypeServer) code() int64 {
 	return entityTypeCodeServer
-}
-
-// allURLsQuery returns an empty string because there are no Server entities in the database.
-func (e entityTypeServer) allURLsQuery() string {
-	return ""
-}
-
-func (e entityTypeServer) urlsByProjectQuery() string {
-	return ""
-}
-
-func (e entityTypeServer) urlByIDQuery() string {
-	return ""
-}
-
-// idFromURLQuery returns an empty string because there are no Server entities in the database.
-func (e entityTypeServer) idFromURLQuery() string {
-	return ""
-}
-
-func (e entityTypeServer) onDeleteTriggerSQL() (name string, sql string) {
-	return "", ""
 }

--- a/lxd/db/cluster/entity_type_storage_bucket.go
+++ b/lxd/db/cluster/entity_type_storage_bucket.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageBucket implements entityTypeDBInfo for a StorageBucket.
-type entityTypeStorageBucket struct{}
+type entityTypeStorageBucket struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageBucket) code() int64 {
 	return entityTypeCodeStorageBucket

--- a/lxd/db/cluster/entity_type_storage_pool.go
+++ b/lxd/db/cluster/entity_type_storage_pool.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStoragePool implements entityTypeDBInfo for a StoragePool.
-type entityTypeStoragePool struct{}
+type entityTypeStoragePool struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStoragePool) code() int64 {
 	return entityTypeCodeStoragePool
@@ -13,10 +15,6 @@ func (e entityTypeStoragePool) code() int64 {
 
 func (e entityTypeStoragePool) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, storage_pools.id, '', '', json_array(storage_pools.name) FROM storage_pools`, e.code())
-}
-
-func (e entityTypeStoragePool) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeStoragePool) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_storage_volume.go
+++ b/lxd/db/cluster/entity_type_storage_volume.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageVolume implements entityTypeDBInfo for a StorageVolume.
-type entityTypeStorageVolume struct{}
+type entityTypeStorageVolume struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageVolume) code() int64 {
 	return entityTypeCodeStorageVolume

--- a/lxd/db/cluster/entity_type_storage_volume_backup.go
+++ b/lxd/db/cluster/entity_type_storage_volume_backup.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageVolumeBackup implements entityTypeDBInfo for a StorageVolumeBackup.
-type entityTypeStorageVolumeBackup struct{}
+type entityTypeStorageVolumeBackup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageVolumeBackup) code() int64 {
 	return entityTypeCodeStorageVolumeBackup

--- a/lxd/db/cluster/entity_type_storage_volume_snapshot.go
+++ b/lxd/db/cluster/entity_type_storage_volume_snapshot.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageVolumeSnapshot implements entityTypeDBInfo for a StorageVolumeSnapshot.
-type entityTypeStorageVolumeSnapshot struct{}
+type entityTypeStorageVolumeSnapshot struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageVolumeSnapshot) code() int64 {
 	return entityTypeCodeStorageVolumeSnapshot

--- a/lxd/db/cluster/entity_type_test.go
+++ b/lxd/db/cluster/entity_type_test.go
@@ -1,0 +1,184 @@
+package cluster
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+type selectorSuite struct {
+	suite.Suite
+	db *sql.DB
+}
+
+func TestSelectorSuite(t *testing.T) {
+	suite.Run(t, new(selectorSuite))
+}
+
+func (s *selectorSuite) SetupTest() {
+	s.db = newDB(s.T())
+}
+
+func (s *selectorSuite) Test_entityTypeClusterGroup_selectorQuery() {
+	tests := []struct {
+		name          string
+		selector      Selector
+		expectedQuery string
+		expectedArgs  []any
+		expectedErr   error
+	}{
+		{
+			selector: Selector{
+				ID:         0,
+				EntityType: EntityType("cluster_group"),
+				Matchers: SelectorMatchers{
+					{
+						Property: "name",
+						Values:   []string{"g1", "g2"},
+					},
+				},
+			},
+			expectedQuery: `SELECT id FROM cluster_groups WHERE name IN (?, ?)`,
+			expectedArgs:  []any{"g1", "g2"},
+		},
+	}
+
+	for _, tt := range tests {
+		query, args, err := entityTypeClusterGroup{}.selectorQuery(tt.selector)
+		if tt.expectedErr != nil {
+			s.Equal(tt.expectedErr, err)
+			return
+		}
+
+		s.Require().NoError(err)
+
+		_, err = s.db.Prepare(query)
+		s.Require().NoError(err)
+
+		s.Equal(tt.expectedQuery, query)
+		s.ElementsMatch(tt.expectedArgs, args)
+	}
+}
+
+func (s *selectorSuite) Test_entityTypeInstance_propertyQuery() {
+	tests := []struct {
+		name                      string
+		selector                  Selector
+		expectedHasConfigProperty bool
+		expectedQuery             string
+		expectedArgs              []any
+		expectedErr               error
+	}{
+		{
+			selector: Selector{
+				ID:         0,
+				EntityType: EntityType("instance"),
+				Matchers: SelectorMatchers{
+					{
+						Property: "project",
+						Values:   []string{"p1"},
+					},
+					{
+						Property: "config.user.deployment",
+						Values:   []string{"ha1", "ha2"},
+					},
+				},
+			},
+			expectedHasConfigProperty: true,
+			expectedQuery:             `SELECT instances.id FROM instances JOIN projects ON instances.project_id = projects.id WHERE projects.name IN (?)`,
+			expectedArgs:              []any{"p1"},
+		},
+	}
+
+	for _, tt := range tests {
+		query, args, hasConfigProperty, err := entityTypeInstance{}.propertyQuery(tt.selector)
+		if tt.expectedErr != nil {
+			s.Equal(tt.expectedErr, err)
+			return
+		}
+
+		s.Require().NoError(err)
+
+		_, err = s.db.Prepare(query)
+		s.Require().NoError(err)
+
+		s.Equal(tt.expectedHasConfigProperty, hasConfigProperty)
+		s.Equal(tt.expectedQuery, query)
+		s.ElementsMatch(tt.expectedArgs, args)
+	}
+}
+
+func (s *selectorSuite) Test_entityTypeInstance_configQuery() {
+	tests := []struct {
+		name            string
+		selector        Selector
+		instanceIDs     []int
+		expectedMatcher api.SelectorMatcher
+		expectedQuery   string
+		expectedArgs    []any
+		expectedErr     error
+	}{
+		{
+			selector: Selector{
+				ID:         0,
+				EntityType: EntityType("instance"),
+				Matchers: SelectorMatchers{
+					{
+						Property: "project",
+						Values:   []string{"p1"},
+					},
+					{
+						Property: "config.user.deployment",
+						Values:   []string{"ha1", "ha2"},
+					},
+				},
+			},
+			instanceIDs: []int{1, 2, 3},
+			expectedQuery: `
+SELECT 
+	instances.id AS instance_id, 
+	1000000 AS apply_order, 
+	instances_config.value 
+FROM instances 
+JOIN instances_config ON instances.id = instances_config.instance_id 
+WHERE instances_config.key = ? 
+	AND instances.id IN (?, ?, ?)
+UNION 
+SELECT 
+	instances.id AS instance_id, 
+	instances_profiles.apply_order, 
+	profiles_config.value 
+FROM instances 
+JOIN instances_profiles ON instances.id = instances_profiles.instance_id 
+JOIN profiles ON instances_profiles.profile_id = profiles.id 
+JOIN profiles_config ON profiles.id = profiles_config.profile_id 
+WHERE profiles_config.key = ? 
+	AND instances.id IN (?, ?, ?)`,
+			expectedArgs: []any{"user.deployment", 1, 2, 3, "user.deployment", 1, 2, 3},
+			expectedMatcher: api.SelectorMatcher{
+				Property: "config.user.deployment",
+				Values:   []string{"ha1", "ha2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		query, matcher, args, err := entityTypeInstance{}.configQuery(tt.selector, tt.instanceIDs)
+		if tt.expectedErr != nil {
+			s.Equal(tt.expectedErr, err)
+			return
+		}
+
+		s.Require().NoError(err)
+
+		_, err = s.db.Prepare(query)
+		s.Require().NoError(err)
+
+		s.Equal(tt.expectedMatcher, matcher)
+		s.Equal(tt.expectedQuery, query)
+		s.ElementsMatch(tt.expectedArgs, args)
+	}
+}

--- a/lxd/db/cluster/entity_type_warning.go
+++ b/lxd/db/cluster/entity_type_warning.go
@@ -6,7 +6,9 @@ import (
 )
 
 // entityTypeWarning implements entityTypeDBInfo for a Warning.
-type entityTypeWarning struct{}
+type entityTypeWarning struct {
+	entityTypeCommon
+}
 
 func (e entityTypeWarning) code() int64 {
 	return entityTypeCodeWarning

--- a/lxd/db/cluster/instance_placement.go
+++ b/lxd/db/cluster/instance_placement.go
@@ -1,0 +1,335 @@
+package cluster
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/canonical/lxd/lxd/db/query"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
+	"github.com/canonical/lxd/shared/validate"
+)
+
+// InstancePlacementRuleKind is the database enum for the api.InstancePlacementRuleKind constants.
+type InstancePlacementRuleKind api.InstancePlacementRuleKind
+
+const (
+	instancePlacementRuleKindCodeAffinity     int64 = 1
+	instancePlacementRuleKindCodeAntiAffinity int64 = 2
+	instancePlacementRuleKindCodeNone         int64 = 3
+)
+
+// Scan implements sql.Scanner for InstancePlacementRuleKind. This converts the integer value back into the correct API constant or
+// returns an error.
+func (a *InstancePlacementRuleKind) Scan(value any) error {
+	if value == nil {
+		return fmt.Errorf("Instance placement rule kind cannot be null")
+	}
+
+	intValue, err := driver.Int32.ConvertValue(value)
+	if err != nil {
+		return fmt.Errorf("Invalid instance placement rule kind type: %w", err)
+	}
+
+	ruleInt, ok := intValue.(int64)
+	if !ok {
+		return fmt.Errorf("Instance placement rule kind should be an integer, got `%v` (%T)", intValue, intValue)
+	}
+
+	switch ruleInt {
+	case instancePlacementRuleKindCodeAffinity:
+		*a = InstancePlacementRuleKind(api.InstancePlacementRuleKindAffinity)
+	case instancePlacementRuleKindCodeAntiAffinity:
+		*a = InstancePlacementRuleKind(api.InstancePlacementRuleKindAntiAffinity)
+	case instancePlacementRuleKindCodeNone:
+		*a = InstancePlacementRuleKind(api.InstancePlacementRuleKindNone)
+	default:
+		return fmt.Errorf("Unknown instance placement rule kind `%d`", ruleInt)
+	}
+
+	return nil
+}
+
+// Value implements driver.Valuer for InstancePlacementRuleKind. This converts the API constant into an integer or throws an error.
+func (a InstancePlacementRuleKind) Value() (driver.Value, error) {
+	switch api.InstancePlacementRuleKind(a) {
+	case api.InstancePlacementRuleKindAffinity:
+		return instancePlacementRuleKindCodeAffinity, nil
+	case api.InstancePlacementRuleKindAntiAffinity:
+		return instancePlacementRuleKindCodeAntiAffinity, nil
+	case api.InstancePlacementRuleKindNone:
+		return instancePlacementRuleKindCodeNone, nil
+	}
+
+	return nil, fmt.Errorf("Invalid instance placement rule kind %q", a)
+}
+
+// InstancePlacementRule is the database representation of an api.InstancePlacementRule.
+type InstancePlacementRule struct {
+	ID       int
+	Name     string
+	Kind     InstancePlacementRuleKind
+	Priority int
+	Required bool
+	Selector Selector
+}
+
+// ToAPI converts an InstancePlacementRule into an api.InstancePlacementRule.
+func (i InstancePlacementRule) ToAPI() (string, api.InstancePlacementRule) {
+	return i.Name, api.InstancePlacementRule{
+		Required: i.Required,
+		Kind:     api.InstancePlacementRuleKind(i.Kind),
+		Priority: i.Priority,
+		Selector: api.Selector{
+			EntityType: string(i.Selector.EntityType),
+			Matchers:   i.Selector.Matchers,
+		},
+	}
+}
+
+// InstancePlacementRulesToAPI converts a slice of InstancePlacementRule to a map of api.InstancePlacementRule.
+func InstancePlacementRulesToAPI(rules []InstancePlacementRule) map[string]api.InstancePlacementRule {
+	apiRules := make(map[string]api.InstancePlacementRule, len(rules))
+	for _, rule := range rules {
+		name, apiRule := rule.ToAPI()
+		apiRules[name] = apiRule
+	}
+
+	return apiRules
+}
+
+// InstancePlacementRulesFromAPI parses and validates the given map of api.InstancePlacementRule, returning a slice of
+// InstancePlacementRule or an error.
+func InstancePlacementRulesFromAPI(rules map[string]api.InstancePlacementRule) ([]InstancePlacementRule, error) {
+	dbRules := make([]InstancePlacementRule, 0, len(rules))
+	for name, rule := range rules {
+		i, err := InstancePlacementRuleFromAPI(name, rule)
+		if err != nil {
+			return nil, err
+		}
+
+		dbRules = append(dbRules, *i)
+	}
+
+	return dbRules, nil
+}
+
+// InstancePlacementRuleFromAPI parses and validates the given rulename and api.InstancePlacementRule, returning an
+// InstancePlacementRule or an error.
+func InstancePlacementRuleFromAPI(rulename string, rule api.InstancePlacementRule) (*InstancePlacementRule, error) {
+	err := validate.IsDeviceName(rulename)
+	if err != nil {
+		return nil, err
+	}
+
+	if rule.Priority < 0 || rule.Priority > 255 {
+		return nil, fmt.Errorf("Instance placement rule priority must be in the range 0-255")
+	}
+
+	kind := InstancePlacementRuleKind(rule.Kind)
+	_, err = kind.Value()
+	if err != nil {
+		return nil, err
+	}
+
+	selectorEntityType := entity.Type(rule.Selector.EntityType)
+	if !shared.ValueInSlice(selectorEntityType, []entity.Type{entity.TypeInstance, entity.TypeClusterMember, entity.TypeClusterGroup}) {
+		return nil, fmt.Errorf("Instance placement rule selector entity type must be one of %q, %q, or %q", entity.TypeInstance, entity.TypeClusterMember, entity.TypeClusterGroup)
+	}
+
+	existingProperties := make([]string, 0, len(rule.Selector.Matchers))
+	for _, matcher := range rule.Selector.Matchers {
+		if shared.ValueInSlice(matcher.Property, existingProperties) {
+			return nil, fmt.Errorf("Duplicate selector matcher property %q found in instance placement rule %q", matcher.Property, rulename)
+		}
+
+		switch selectorEntityType {
+		case entity.TypeInstance:
+			if matcher.Property != "name" && !strings.HasPrefix(matcher.Property, "config.") {
+				return nil, fmt.Errorf("Matcher property %q not allowed for entity type %q", matcher.Property, entity.TypeInstance)
+			}
+
+		case entity.TypeClusterMember:
+			if matcher.Property != "name" && !strings.HasPrefix(matcher.Property, "config.") {
+				return nil, fmt.Errorf("Matcher property %q not allowed for entity type %q", matcher.Property, entity.TypeClusterMember)
+			}
+
+		case entity.TypeClusterGroup:
+			if matcher.Property != "name" {
+				return nil, fmt.Errorf("Matcher property %q not allowed for entity type %q", matcher.Property, entity.TypeClusterGroup)
+			}
+		}
+
+		existingProperties = append(existingProperties, matcher.Property)
+	}
+
+	i := &InstancePlacementRule{
+		Name:     rulename,
+		Kind:     kind,
+		Priority: rule.Priority,
+		Required: rule.Required,
+		Selector: Selector{
+			EntityType: EntityType(selectorEntityType),
+			Matchers:   rule.Selector.Matchers,
+		},
+	}
+
+	return i, nil
+}
+
+// Selector is the database representation of an api.Selector.
+type Selector struct {
+	ID         int
+	EntityType EntityType
+	Matchers   SelectorMatchers
+}
+
+// SelectorMatchers is a database representation of an array of api.SelectorMatcher.
+// This is used to automatically write selector matchers as JSON to the database.
+type SelectorMatchers []api.SelectorMatcher
+
+// Scan implements sql.Scanner. This unmarshals the matchers as JSON.
+func (v *SelectorMatchers) Scan(value any) error {
+	if value == nil {
+		*v = []api.SelectorMatcher{}
+		return nil
+	}
+
+	strValue, err := driver.String.ConvertValue(value)
+	if err != nil {
+		return fmt.Errorf("Invalid selector matcher type: %w", err)
+	}
+
+	valueStr, ok := strValue.(string)
+	if !ok {
+		return fmt.Errorf("Selector matcher should be a string, got `%v` (%T)", strValue, strValue)
+	}
+
+	if valueStr == "" {
+		*v = []api.SelectorMatcher{}
+		return nil
+	}
+
+	return json.Unmarshal([]byte(valueStr), v)
+}
+
+// Value implements driver.Valuer for SelectorMatchers. This returns the matchers as marshalled JSON.
+func (v SelectorMatchers) Value() (driver.Value, error) {
+	if len(v) == 0 {
+		return "", nil
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return string(b), nil
+}
+
+// UpsertInstancePlacementRules deletes any existing rules for the given entity type and ID and creates the given rules.
+// Rules can only be created for instances and profiles.
+// This takes advantage of the identical structure of the tables for instance and profile placement rules.
+func UpsertInstancePlacementRules(ctx context.Context, tx *sql.Tx, entityType entity.Type, entityID int, rules []InstancePlacementRule) error {
+	if !shared.ValueInSlice(entityType, []entity.Type{entity.TypeInstance, entity.TypeProfile}) {
+		return fmt.Errorf("Cannot set instance placement rules for type %q: Instance placement rules may only be set on instances and profiles", entityType)
+	}
+
+	q1 := `DELETE FROM selectors WHERE id = (
+	SELECT selector_id FROM placements_selectors
+	    JOIN placements ON placements_selectors.placement_id = placements.id
+	    JOIN instances_placements ON placements.id = instances_placements.placement_id
+	    WHERE instances_placements.instance_id = ?
+)`
+
+	q2 := `DELETE FROM placements WHERE id = (
+    SELECT placement_id FROM instances_placements WHERE instance_id = ?
+)`
+
+	tblPrefix := "instance"
+	if entityType == entity.TypeProfile {
+		tblPrefix = "profile"
+		q1 = strings.ReplaceAll(q1, "instance", tblPrefix)
+		q2 = strings.ReplaceAll(q2, "instance", tblPrefix)
+	}
+
+	_, err := tx.ExecContext(ctx, q1, entityID)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, q2, entityID)
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range rules {
+		ruleID, err := query.UpsertObject(tx, "placements", []string{"kind", "required", "priority"}, []any{rule.Kind, rule.Required, rule.Priority})
+		if err != nil {
+			return err
+		}
+
+		rule.ID = int(ruleID)
+		_, err = query.UpsertObject(tx, tblPrefix+"s_placements", []string{tblPrefix + "_id", "name", "placement_id"}, []any{entityID, rule.Name, rule.ID})
+		if err != nil {
+			return err
+		}
+
+		selectorID, err := query.UpsertObject(tx, "selectors", []string{"entity_type", "matchers"}, []any{rule.Selector.EntityType, rule.Selector.Matchers})
+		if err != nil {
+			return err
+		}
+
+		rule.Selector.ID = int(selectorID)
+		_, err = query.UpsertObject(tx, "placements_selectors", []string{"placement_id", "selector_id"}, []any{rule.ID, rule.Selector.ID})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetInstancePlacementRulesForEntity gets the instance placement rules for the given entity type and ID.
+func GetInstancePlacementRulesForEntity(ctx context.Context, tx *sql.Tx, entityType entity.Type, entityID int) ([]InstancePlacementRule, error) {
+	if !shared.ValueInSlice(entityType, []entity.Type{entity.TypeInstance, entity.TypeProfile}) {
+		return nil, fmt.Errorf("Cannot set instance placement rules for type %q: Instance placement rules may only be set on instances and profiles", entityType)
+	}
+
+	q := `
+SELECT placements.id AS placement_id, instances_placements.name, placements.kind, placements.required, placements.priority, selectors.id AS selector_id, selectors.entity_type, selectors.matchers FROM placements
+	JOIN instances_placements ON placements.id = instances_placements.placement_id 
+	JOIN instances ON instances.id = instances_placements.instance_id
+	JOIN placements_selectors ON placements.id = placements_selectors.placement_id
+	JOIN selectors ON placements_selectors.selector_id = selectors.id
+	WHERE instances.id = ?
+	ORDER BY placements.id, selectors.id
+`
+	if entityType == entity.TypeProfile {
+		q = strings.ReplaceAll(q, "instance", "profile")
+	}
+
+	var placements []InstancePlacementRule
+	err := query.Scan(ctx, tx, q, func(scan func(dest ...any) error) error {
+		var placement InstancePlacementRule
+		var selector Selector
+		err := scan(&placement.ID, &placement.Name, &placement.Kind, &placement.Required, &placement.Priority, &selector.ID, &selector.EntityType, &selector.Matchers)
+		if err != nil {
+			return err
+		}
+
+		placement.Selector = selector
+		placements = append(placements, placement)
+		return nil
+	}, entityID)
+	if err != nil {
+		return nil, err
+	}
+
+	return placements, nil
+}

--- a/lxd/db/cluster/profiles.go
+++ b/lxd/db/cluster/profiles.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
 )
 
 // Code generation directives.
@@ -83,12 +84,18 @@ func (p *Profile) ToAPI(ctx context.Context, tx *sql.Tx, profileConfigs map[int]
 		}
 	}
 
+	placementRules, err := GetInstancePlacementRulesForEntity(ctx, tx, entity.TypeProfile, p.ID)
+	if err != nil {
+		return nil, err
+	}
+
 	profile := &api.Profile{
-		Name:        p.Name,
-		Description: p.Description,
-		Config:      dbConfig,
-		Devices:     DevicesToAPI(dbDevices),
-		Project:     p.Project,
+		Name:           p.Name,
+		Description:    p.Description,
+		Config:         dbConfig,
+		Devices:        DevicesToAPI(dbDevices),
+		Project:        p.Project,
+		PlacementRules: InstancePlacementRulesToAPI(placementRules),
 	}
 
 	return profile, nil

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -190,6 +190,16 @@ CREATE TABLE "instances_devices_config" (
     UNIQUE (instance_device_id, key)
 );
 CREATE INDEX instances_node_id_idx ON instances (node_id);
+CREATE TABLE instances_placements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name TEXT NOT NULL,
+    instance_id INTEGER NOT NULL,
+    placement_id INTEGER NOT NULL,
+    FOREIGN KEY (instance_id) REFERENCES instances (id) ON DELETE CASCADE,
+    FOREIGN KEY (placement_id) REFERENCES placements (id) ON DELETE CASCADE,
+    UNIQUE (instance_id, placement_id),
+    UNIQUE (instance_id, name)
+);
 CREATE TABLE "instances_profiles" (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     instance_id INTEGER NOT NULL,
@@ -434,6 +444,20 @@ CREATE TABLE "operations" (
     FOREIGN KEY (node_id) REFERENCES "nodes" (id) ON DELETE CASCADE,
     FOREIGN KEY (project_id) REFERENCES "projects" (id) ON DELETE CASCADE
 );
+CREATE TABLE placements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    kind TEXT NOT NULL,
+    required INTEGER NOT NULL,
+    priority INTEGER NOT NULL
+);
+CREATE TABLE placements_selectors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    placement_id INTEGER NOT NULL,
+    selector_id INTEGER NOT NULL,
+    FOREIGN KEY (placement_id) REFERENCES placements (id) ON DELETE CASCADE,
+    FOREIGN KEY (selector_id) REFERENCES selectors (id) ON DELETE CASCADE,
+    UNIQUE (placement_id, selector_id)
+);
 CREATE TABLE "profiles" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name TEXT NOT NULL,
@@ -466,6 +490,16 @@ CREATE TABLE "profiles_devices_config" (
     UNIQUE (profile_device_id, key),
     FOREIGN KEY (profile_device_id) REFERENCES "profiles_devices" (id) ON DELETE CASCADE
 );
+CREATE TABLE profiles_placements (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	name TEXT NOT NULL,
+    profile_id INTEGER NOT NULL,
+    placement_id INTEGER NOT NULL,
+    FOREIGN KEY (profile_id) REFERENCES profiles (id) ON DELETE CASCADE,
+    FOREIGN KEY (placement_id) REFERENCES placements (id) ON DELETE CASCADE,
+    UNIQUE (profile_id, placement_id),
+    UNIQUE (profile_id, name)
+);
 CREATE INDEX profiles_project_id_idx ON profiles (project_id);
 CREATE TABLE "projects" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -480,6 +514,11 @@ CREATE TABLE "projects_config" (
     value TEXT NOT NULL,
     FOREIGN KEY (project_id) REFERENCES "projects" (id) ON DELETE CASCADE,
     UNIQUE (project_id, key)
+);
+CREATE TABLE selectors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    entity_type INTEGER NOT NULL,
+    matchers TEXT NOT NULL
 );
 CREATE TABLE "storage_buckets" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -662,5 +701,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (73, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (74, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -114,6 +114,52 @@ var updates = map[int]schema.Update{
 	71: updateFromV70,
 	72: updateFromV71,
 	73: updateFromV72,
+	74: updateFromV73,
+}
+
+func updateFromV73(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+CREATE TABLE selectors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    entity_type INTEGER NOT NULL,
+    matchers TEXT NOT NULL
+);
+CREATE TABLE placements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    kind TEXT NOT NULL,
+    required INTEGER NOT NULL,
+    priority INTEGER NOT NULL
+);
+CREATE TABLE placements_selectors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    placement_id INTEGER NOT NULL,
+    selector_id INTEGER NOT NULL,
+    FOREIGN KEY (placement_id) REFERENCES placements (id) ON DELETE CASCADE,
+    FOREIGN KEY (selector_id) REFERENCES selectors (id) ON DELETE CASCADE,
+    UNIQUE (placement_id, selector_id)
+);
+CREATE TABLE instances_placements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name TEXT NOT NULL,
+    instance_id INTEGER NOT NULL,
+    placement_id INTEGER NOT NULL,
+    FOREIGN KEY (instance_id) REFERENCES instances (id) ON DELETE CASCADE,
+    FOREIGN KEY (placement_id) REFERENCES placements (id) ON DELETE CASCADE,
+    UNIQUE (instance_id, placement_id),
+    UNIQUE (instance_id, name)
+);
+CREATE TABLE profiles_placements (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	name TEXT NOT NULL,
+    profile_id INTEGER NOT NULL,
+    placement_id INTEGER NOT NULL,
+    FOREIGN KEY (profile_id) REFERENCES profiles (id) ON DELETE CASCADE,
+    FOREIGN KEY (placement_id) REFERENCES placements (id) ON DELETE CASCADE,
+    UNIQUE (profile_id, placement_id),
+    UNIQUE (profile_id, name)
+);
+`)
+	return err
 }
 
 func updateFromV72(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -34,16 +34,17 @@ type InstanceArgs struct {
 	BaseImage    string
 	CreationDate time.Time
 
-	Architecture int
-	Config       map[string]string
-	Description  string
-	Devices      deviceConfig.Devices
-	Ephemeral    bool
-	LastUsedDate time.Time
-	Name         string
-	Profiles     []api.Profile
-	Stateful     bool
-	ExpiryDate   time.Time
+	Architecture   int
+	Config         map[string]string
+	Description    string
+	Devices        deviceConfig.Devices
+	PlacementRules map[string]api.InstancePlacementRule
+	Ephemeral      bool
+	LastUsedDate   time.Time
+	Name           string
+	Profiles       []api.Profile
+	Stateful       bool
+	ExpiryDate     time.Time
 }
 
 // ToAPI converts InstanceArgs to api.Instance.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -140,23 +140,24 @@ func qemuInstantiate(s *state.State, args db.InstanceArgs, expandedDevices devic
 		common: common{
 			state: s,
 
-			architecture: args.Architecture,
-			creationDate: args.CreationDate,
-			dbType:       args.Type,
-			description:  args.Description,
-			ephemeral:    args.Ephemeral,
-			expiryDate:   args.ExpiryDate,
-			id:           args.ID,
-			lastUsedDate: args.LastUsedDate,
-			localConfig:  args.Config,
-			localDevices: args.Devices,
-			logger:       logger.AddContext(logger.Ctx{"instanceType": args.Type, "instance": args.Name, "project": args.Project}),
-			name:         args.Name,
-			node:         args.Node,
-			profiles:     args.Profiles,
-			project:      p,
-			isSnapshot:   args.Snapshot,
-			stateful:     args.Stateful,
+			architecture:        args.Architecture,
+			creationDate:        args.CreationDate,
+			dbType:              args.Type,
+			description:         args.Description,
+			ephemeral:           args.Ephemeral,
+			expiryDate:          args.ExpiryDate,
+			id:                  args.ID,
+			lastUsedDate:        args.LastUsedDate,
+			localConfig:         args.Config,
+			localDevices:        args.Devices,
+			localPlacementRules: args.PlacementRules,
+			logger:              logger.AddContext(logger.Ctx{"instanceType": args.Type, "instance": args.Name, "project": args.Project}),
+			name:                args.Name,
+			node:                args.Node,
+			profiles:            args.Profiles,
+			project:             p,
+			isSnapshot:          args.Snapshot,
+			stateful:            args.Stateful,
 		},
 	}
 
@@ -198,23 +199,24 @@ func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.I
 		common: common{
 			state: s,
 
-			architecture: args.Architecture,
-			creationDate: args.CreationDate,
-			dbType:       args.Type,
-			description:  args.Description,
-			ephemeral:    args.Ephemeral,
-			expiryDate:   args.ExpiryDate,
-			id:           args.ID,
-			lastUsedDate: args.LastUsedDate,
-			localConfig:  args.Config,
-			localDevices: args.Devices,
-			logger:       logger.AddContext(logger.Ctx{"instanceType": args.Type, "instance": args.Name, "project": args.Project}),
-			name:         args.Name,
-			node:         args.Node,
-			profiles:     args.Profiles,
-			project:      p,
-			isSnapshot:   args.Snapshot,
-			stateful:     args.Stateful,
+			architecture:        args.Architecture,
+			creationDate:        args.CreationDate,
+			dbType:              args.Type,
+			description:         args.Description,
+			ephemeral:           args.Ephemeral,
+			expiryDate:          args.ExpiryDate,
+			id:                  args.ID,
+			lastUsedDate:        args.LastUsedDate,
+			localConfig:         args.Config,
+			localDevices:        args.Devices,
+			localPlacementRules: args.PlacementRules,
+			logger:              logger.AddContext(logger.Ctx{"instanceType": args.Type, "instance": args.Name, "project": args.Project}),
+			name:                args.Name,
+			node:                args.Node,
+			profiles:            args.Profiles,
+			project:             p,
+			isSnapshot:          args.Snapshot,
+			stateful:            args.Stateful,
 		},
 	}
 
@@ -5451,6 +5453,10 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		args.Profiles = []api.Profile{}
 	}
 
+	if args.PlacementRules == nil {
+		args.PlacementRules = make(map[string]api.InstancePlacementRule)
+	}
+
 	if userRequested {
 		// Validate the new config.
 		err := instance.ValidConfig(d.state.OS, args.Config, false, d.dbType)
@@ -5463,6 +5469,11 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		if err != nil {
 			return fmt.Errorf("Invalid devices: %w", err)
 		}
+	}
+
+	dbPlacementRules, err := dbCluster.InstancePlacementRulesFromAPI(args.PlacementRules)
+	if err != nil {
+		return fmt.Errorf("Invalid placement rules: %w", err)
 	}
 
 	var profiles []string
@@ -5542,6 +5553,12 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		return err
 	}
 
+	oldLocalPlacementRules := make(map[string]api.InstancePlacementRule)
+	err = shared.DeepCopy(&d.localPlacementRules, &oldLocalPlacementRules)
+	if err != nil {
+		return err
+	}
+
 	oldExpiryDate := d.expiryDate
 
 	// Revert local changes if update fails.
@@ -5555,6 +5572,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		d.localDevices = oldLocalDevices
 		d.profiles = oldProfiles
 		d.expiryDate = oldExpiryDate
+		d.localPlacementRules = oldLocalPlacementRules
 	})
 
 	// Apply the various changes to local vars.
@@ -5563,6 +5581,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	d.ephemeral = args.Ephemeral
 	d.localConfig = args.Config
 	d.localDevices = args.Devices
+	d.localPlacementRules = args.PlacementRules
 	d.profiles = args.Profiles
 	d.expiryDate = args.ExpiryDate
 
@@ -5871,6 +5890,11 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		err = dbCluster.UpdateInstanceDevices(ctx, tx.Tx(), int64(object.ID), devices)
+		if err != nil {
+			return err
+		}
+
+		err = dbCluster.UpsertInstancePlacementRules(ctx, tx.Tx(), entity.TypeInstance, object.ID, dbPlacementRules)
 		if err != nil {
 			return err
 		}
@@ -7855,18 +7879,20 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 		etag := []any{d.expiryDate}
 
 		snapState := api.InstanceSnapshot{
-			Name:            strings.SplitN(d.name, "/", 2)[1],
-			Architecture:    d.architectureName,
-			Profiles:        profileNames,
-			Config:          d.localConfig,
-			ExpandedConfig:  d.expandedConfig,
-			Devices:         d.localDevices.CloneNative(),
-			ExpandedDevices: d.expandedDevices.CloneNative(),
-			CreatedAt:       d.creationDate,
-			LastUsedAt:      d.lastUsedDate,
-			ExpiresAt:       d.expiryDate,
-			Ephemeral:       d.ephemeral,
-			Stateful:        d.stateful,
+			Name:                   strings.SplitN(d.name, "/", 2)[1],
+			Architecture:           d.architectureName,
+			Profiles:               profileNames,
+			Config:                 d.localConfig,
+			ExpandedConfig:         d.expandedConfig,
+			Devices:                d.localDevices.CloneNative(),
+			ExpandedDevices:        d.expandedDevices.CloneNative(),
+			PlacementRules:         d.localPlacementRules,
+			ExpandedPlacementRules: d.expandedPlacementRules,
+			CreatedAt:              d.creationDate,
+			LastUsedAt:             d.lastUsedDate,
+			ExpiresAt:              d.expiryDate,
+			Ephemeral:              d.ephemeral,
+			Stateful:               d.stateful,
 
 			// Default to uninitialised/error state (0 means no CoW usage).
 			// The size can then be populated optionally via the options argument.
@@ -7884,25 +7910,27 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 	}
 
 	// Prepare the ETag
-	etag = []any{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
+	etag = []any{d.architecture, d.localConfig, d.localDevices, d.localPlacementRules, d.ephemeral, d.profiles}
 
 	instState := api.Instance{
-		Name:            d.name,
-		Description:     d.description,
-		Architecture:    d.architectureName,
-		Profiles:        profileNames,
-		Config:          d.localConfig,
-		ExpandedConfig:  d.expandedConfig,
-		Devices:         d.localDevices.CloneNative(),
-		ExpandedDevices: d.expandedDevices.CloneNative(),
-		CreatedAt:       d.creationDate,
-		LastUsedAt:      d.lastUsedDate,
-		Ephemeral:       d.ephemeral,
-		Stateful:        d.stateful,
-		Project:         d.project.Name,
-		Location:        d.node,
-		Type:            d.Type().String(),
-		StatusCode:      api.Error, // Default to error status for remote instances that are unreachable.
+		Name:                   d.name,
+		Description:            d.description,
+		Architecture:           d.architectureName,
+		Profiles:               profileNames,
+		Config:                 d.localConfig,
+		ExpandedConfig:         d.expandedConfig,
+		Devices:                d.localDevices.CloneNative(),
+		ExpandedDevices:        d.expandedDevices.CloneNative(),
+		PlacementRules:         d.localPlacementRules,
+		ExpandedPlacementRules: d.expandedPlacementRules,
+		CreatedAt:              d.creationDate,
+		LastUsedAt:             d.lastUsedDate,
+		Ephemeral:              d.ephemeral,
+		Stateful:               d.stateful,
+		Project:                d.project.Name,
+		Location:               d.node,
+		Type:                   d.Type().String(),
+		StatusCode:             api.Error, // Default to error status for remote instances that are unreachable.
 	}
 
 	// If instance is local then request status.

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -70,8 +70,10 @@ type ConfigReader interface {
 
 	ExpandedConfig() map[string]string
 	ExpandedDevices() deviceConfig.Devices
+	ExpandedPlacementRules() map[string]api.InstancePlacementRule
 	LocalConfig() map[string]string
 	LocalDevices() deviceConfig.Devices
+	LocalPlacementRules() map[string]api.InstancePlacementRule
 }
 
 // Instance interface.

--- a/lxd/instance/instancetype/instance_utils.go
+++ b/lxd/instance/instancetype/instance_utils.go
@@ -65,3 +65,24 @@ func ExpandInstanceDevices(devices deviceConfig.Devices, profiles []api.Profile)
 
 	return expandedDevices
 }
+
+// ExpandInstancePlacementRules expands the given instance placement rules with the placement rules defined in the given profiles.
+func ExpandInstancePlacementRules(localRules map[string]api.InstancePlacementRule, profiles []api.Profile) map[string]api.InstancePlacementRule {
+	if localRules == nil {
+		localRules = make(map[string]api.InstancePlacementRule)
+	}
+
+	expandedRules := make(map[string]api.InstancePlacementRule)
+	for _, profile := range profiles {
+		for name, rule := range profile.PlacementRules {
+			expandedRules[name] = rule
+		}
+	}
+
+	// Stick the given devices on top.
+	for k, v := range localRules {
+		expandedRules[k] = v
+	}
+
+	return expandedRules
+}

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -101,7 +101,7 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag
-	etag := []any{c.Architecture(), c.LocalConfig(), c.LocalDevices(), c.IsEphemeral(), c.Profiles()}
+	etag := []any{c.Architecture(), c.LocalConfig(), c.LocalDevices(), c.LocalPlacementRules(), c.IsEphemeral(), c.Profiles()}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -111,7 +111,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag
-	etag := []any{inst.Architecture(), inst.LocalConfig(), inst.LocalDevices(), inst.IsEphemeral(), inst.Profiles()}
+	etag := []any{inst.Architecture(), inst.LocalConfig(), inst.LocalDevices(), inst.LocalPlacementRules(), inst.IsEphemeral(), inst.Profiles()}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -169,13 +169,14 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 			defer unlock()
 
 			args := db.InstanceArgs{
-				Architecture: architecture,
-				Config:       configRaw.Config,
-				Description:  configRaw.Description,
-				Devices:      deviceConfig.NewDevices(configRaw.Devices),
-				Ephemeral:    configRaw.Ephemeral,
-				Profiles:     apiProfiles,
-				Project:      projectName,
+				Architecture:   architecture,
+				Config:         configRaw.Config,
+				Description:    configRaw.Description,
+				Devices:        deviceConfig.NewDevices(configRaw.Devices),
+				Ephemeral:      configRaw.Ephemeral,
+				Profiles:       apiProfiles,
+				Project:        projectName,
+				PlacementRules: configRaw.PlacementRules,
 			}
 
 			err = inst.Update(args, true)

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -534,16 +534,17 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 		// Update instance configuration
 		do = func(_ *operations.Operation) error {
 			args := db.InstanceArgs{
-				Architecture: snapInst.Architecture(),
-				Config:       snapInst.LocalConfig(),
-				Description:  snapInst.Description(),
-				Devices:      snapInst.LocalDevices(),
-				Ephemeral:    snapInst.IsEphemeral(),
-				Profiles:     snapInst.Profiles(),
-				Project:      snapInst.Project().Name,
-				ExpiryDate:   configRaw.ExpiresAt,
-				Type:         snapInst.Type(),
-				Snapshot:     snapInst.IsSnapshot(),
+				Architecture:   snapInst.Architecture(),
+				Config:         snapInst.LocalConfig(),
+				Description:    snapInst.Description(),
+				Devices:        snapInst.LocalDevices(),
+				Ephemeral:      snapInst.IsEphemeral(),
+				Profiles:       snapInst.Profiles(),
+				Project:        snapInst.Project().Name,
+				ExpiryDate:     configRaw.ExpiresAt,
+				Type:           snapInst.Type(),
+				Snapshot:       snapInst.IsSnapshot(),
+				PlacementRules: snapInst.LocalPlacementRules(),
 			}
 
 			err = snapInst.Update(args, false)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -97,14 +97,15 @@ func createFromImage(s *state.State, r *http.Request, p api.Project, profiles []
 		devices := deviceConfig.NewDevices(req.Devices)
 
 		args := db.InstanceArgs{
-			Project:     p.Name,
-			Config:      req.Config,
-			Type:        dbType,
-			Description: req.Description,
-			Devices:     deviceConfig.ApplyDeviceInitialValues(devices, profiles),
-			Ephemeral:   req.Ephemeral,
-			Name:        req.Name,
-			Profiles:    profiles,
+			Project:        p.Name,
+			Config:         req.Config,
+			Type:           dbType,
+			Description:    req.Description,
+			Devices:        deviceConfig.ApplyDeviceInitialValues(devices, profiles),
+			Ephemeral:      req.Ephemeral,
+			Name:           req.Name,
+			Profiles:       profiles,
+			PlacementRules: req.PlacementRules,
 		}
 
 		if req.Source.Server != "" {
@@ -163,14 +164,15 @@ func createFromNone(s *state.State, r *http.Request, projectName string, profile
 	devices := deviceConfig.NewDevices(req.Devices)
 
 	args := db.InstanceArgs{
-		Project:     projectName,
-		Config:      req.Config,
-		Type:        dbType,
-		Description: req.Description,
-		Devices:     deviceConfig.ApplyDeviceInitialValues(devices, profiles),
-		Ephemeral:   req.Ephemeral,
-		Name:        req.Name,
-		Profiles:    profiles,
+		Project:        projectName,
+		Config:         req.Config,
+		Type:           dbType,
+		Description:    req.Description,
+		Devices:        deviceConfig.ApplyDeviceInitialValues(devices, profiles),
+		Ephemeral:      req.Ephemeral,
+		Name:           req.Name,
+		Profiles:       profiles,
+		PlacementRules: req.PlacementRules,
 	}
 
 	if req.Architecture != "" {
@@ -602,17 +604,18 @@ func createFromCopy(s *state.State, r *http.Request, projectName string, profile
 	}
 
 	args := db.InstanceArgs{
-		Project:      targetProject,
-		Architecture: source.Architecture(),
-		BaseImage:    req.Source.BaseImage,
-		Config:       req.Config,
-		Type:         source.Type(),
-		Description:  req.Description,
-		Devices:      deviceConfig.NewDevices(req.Devices),
-		Ephemeral:    req.Ephemeral,
-		Name:         req.Name,
-		Profiles:     profiles,
-		Stateful:     req.Stateful,
+		Project:        targetProject,
+		Architecture:   source.Architecture(),
+		BaseImage:      req.Source.BaseImage,
+		Config:         req.Config,
+		Type:           source.Type(),
+		Description:    req.Description,
+		Devices:        deviceConfig.NewDevices(req.Devices),
+		Ephemeral:      req.Ephemeral,
+		Name:           req.Name,
+		Profiles:       profiles,
+		Stateful:       req.Stateful,
+		PlacementRules: req.PlacementRules,
 	}
 
 	run := func(op *operations.Operation) error {
@@ -897,17 +900,18 @@ func setupInstanceArgs(s *state.State, instType instancetype.Type, projectName s
 
 	// Prepare the instance creation request.
 	args := db.InstanceArgs{
-		Project:      projectName,
-		Architecture: architecture,
-		BaseImage:    req.Source.BaseImage,
-		Config:       req.Config,
-		Type:         instType,
-		Devices:      deviceConfig.NewDevices(req.Devices),
-		Description:  req.Description,
-		Ephemeral:    req.Ephemeral,
-		Name:         req.Name,
-		Profiles:     profiles,
-		Stateful:     req.Stateful,
+		Project:        projectName,
+		Architecture:   architecture,
+		BaseImage:      req.Source.BaseImage,
+		Config:         req.Config,
+		Type:           instType,
+		Devices:        deviceConfig.NewDevices(req.Devices),
+		Description:    req.Description,
+		Ephemeral:      req.Ephemeral,
+		Name:           req.Name,
+		Profiles:       profiles,
+		Stateful:       req.Stateful,
+		PlacementRules: req.PlacementRules,
 	}
 
 	storagePool, storagePoolProfile, localRootDiskDeviceKey, localRootDiskDevice, resp := instanceFindStoragePool(s, projectName, req)

--- a/lxd/instances_post_test.go
+++ b/lxd/instances_post_test.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/lxd/instance/instancetype"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
 )
@@ -189,6 +194,186 @@ func (s *placementSuite) Test_getSortedPlacementRules() {
 		s.Require().Len(got, len(tt.want))
 		for i := range tt.want {
 			s.Require().Equal(tt.want[i], got[i])
+		}
+	}
+}
+
+func (s *placementSuite) Test_applyPlacementRules() {
+	cluster, cleanup := db.NewTestCluster(s.T())
+	defer cleanup()
+
+	nodeNames := []string{"member01", "member02", "member03", "member04", "member05"}
+	candidates := make([]db.NodeInfo, 0, len(nodeNames))
+	for i, nodeName := range nodeNames {
+		candidates = append(candidates, db.NodeInfo{Name: nodeName, Address: fmt.Sprintf("192.0.2.%d", i)})
+	}
+
+	candidatesWithout := func(members ...string) []db.NodeInfo {
+		filteredCandidates := make([]db.NodeInfo, 0, len(candidates))
+		for _, candidate := range candidates {
+			if !shared.ValueInSlice(candidate.Name, members) {
+				filteredCandidates = append(filteredCandidates, candidate)
+			}
+		}
+
+		return filteredCandidates
+	}
+
+	err := cluster.Transaction(context.Background(), func(_ context.Context, tx *db.ClusterTx) error {
+		for i, node := range candidates {
+			id, err := tx.CreateNode(node.Name, node.Address)
+			candidates[i].ID = id
+			s.Require().NoError(err)
+		}
+
+		return nil
+	})
+	s.Require().NoError(err)
+
+	type args struct {
+		candidates             []db.NodeInfo
+		project                string
+		expandedConfig         map[string]string
+		expandedPlacementRules map[string]api.InstancePlacementRule
+	}
+
+	tests := []struct {
+		name         string
+		args         args
+		caseSetup    func()
+		caseTearDown func()
+		want         []db.NodeInfo
+		wantErr      error
+	}{
+		{
+			name: "cluster group affinity",
+			caseSetup: func() {
+				_ = cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+					_, err := dbCluster.CreateClusterGroup(ctx, tx.Tx(), dbCluster.ClusterGroup{Name: "g1"})
+					s.Require().NoError(err)
+
+					for _, node := range candidatesWithout("member01", "member02") {
+						err = tx.AddNodeToClusterGroup(ctx, "g1", node.Name)
+						s.Require().NoError(err)
+					}
+
+					return nil
+				})
+			},
+			args: args{
+				candidates:     candidates,
+				project:        "default",
+				expandedConfig: map[string]string{},
+				expandedPlacementRules: map[string]api.InstancePlacementRule{
+					"cluster_group_affinity": {
+						Required: true,
+						Kind:     api.InstancePlacementRuleKindAffinity,
+						Priority: 0,
+						Selector: api.Selector{
+							EntityType: "cluster_group",
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "name",
+									Values:   []string{"g1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: candidatesWithout("member01", "member02"),
+		},
+		{
+			name: "instance anti-affinity (first)",
+			args: args{
+				candidates: candidates,
+				project:    "default",
+				expandedConfig: map[string]string{
+					"user.deployment": "ha",
+				},
+				expandedPlacementRules: map[string]api.InstancePlacementRule{
+					"instance_anti_affinity": {
+						Required: true,
+						Kind:     api.InstancePlacementRuleKindAntiAffinity,
+						Priority: 0,
+						Selector: api.Selector{
+							EntityType: "instance",
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "config.user.deployment",
+									Values:   []string{"ha"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: candidates,
+		},
+		{
+			name: "instance anti-affinity (second)",
+			caseSetup: func() {
+				_ = cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+					instanceID, err := dbCluster.CreateInstance(ctx, tx.Tx(), dbCluster.Instance{
+						Name:    "c1",
+						Node:    "member01",
+						Project: "default",
+						Type:    instancetype.Container,
+					})
+					s.Require().NoError(err)
+					err = dbCluster.CreateInstanceConfig(ctx, tx.Tx(), instanceID, map[string]string{
+						"user.deployment": "ha",
+					})
+					s.Require().NoError(err)
+					return nil
+				})
+			},
+			args: args{
+				candidates: candidates,
+				project:    "default",
+				expandedConfig: map[string]string{
+					"user.deployment": "ha",
+				},
+				expandedPlacementRules: map[string]api.InstancePlacementRule{
+					"instance_anti_affinity": {
+						Required: true,
+						Kind:     api.InstancePlacementRuleKindAntiAffinity,
+						Priority: 0,
+						Selector: api.Selector{
+							EntityType: "instance",
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "config.user.deployment",
+									Values:   []string{"ha"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: candidatesWithout("member01"),
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.caseSetup != nil {
+			tt.caseSetup()
+		}
+
+		_ = cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+			got, err := applyPlacementRules(ctx, tx.Tx(), tt.args.candidates, tt.args.project, tt.args.expandedConfig, tt.args.expandedPlacementRules)
+			if tt.wantErr != nil {
+				s.Equal(tt.wantErr, err)
+				return nil
+			}
+
+			s.Require().NoError(err)
+			s.ElementsMatch(tt.want, got)
+			return nil
+		})
+
+		if tt.caseTearDown != nil {
+			tt.caseTearDown()
 		}
 	}
 }

--- a/lxd/instances_post_test.go
+++ b/lxd/instances_post_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
+)
+
+type placementSuite struct {
+	suite.Suite
+}
+
+func TestPlacementSuite(t *testing.T) {
+	suite.Run(t, new(placementSuite))
+}
+
+func (s *placementSuite) Test_getSortedPlacementRules() {
+	type args struct {
+		rules map[string]api.InstancePlacementRule
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []dbCluster.InstancePlacementRule
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Valid rules",
+			args: args{
+				rules: map[string]api.InstancePlacementRule{
+					"2": {
+						Required: true,
+						Kind:     api.InstancePlacementRuleKindAffinity,
+						Selector: api.Selector{
+							EntityType: string(entity.TypeClusterGroup),
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "name",
+									Values:   []string{"g1"},
+								},
+							},
+						},
+					},
+					"1": {
+						Required: false,
+						Kind:     api.InstancePlacementRuleKindAffinity,
+						Priority: 0,
+						Selector: api.Selector{
+							EntityType: string(entity.TypeClusterGroup),
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "name",
+									Values:   []string{"g1"},
+								},
+							},
+						},
+					},
+					"3": {
+						Required: false,
+						Kind:     api.InstancePlacementRuleKindAffinity,
+						Priority: 1,
+						Selector: api.Selector{
+							EntityType: string(entity.TypeClusterGroup),
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "name",
+									Values:   []string{"g1"},
+								},
+							},
+						},
+					},
+					"4": {
+						Required: true,
+						Kind:     api.InstancePlacementRuleKindAffinity,
+						Selector: api.Selector{
+							EntityType: string(entity.TypeInstance),
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "name",
+									Values:   []string{"g1"},
+								},
+							},
+						},
+					},
+					"5": {
+						Required: false,
+						Kind:     api.InstancePlacementRuleKindAffinity,
+						Priority: 1,
+						Selector: api.Selector{
+							EntityType: string(entity.TypeInstance),
+							Matchers: []api.SelectorMatcher{
+								{
+									Property: "name",
+									Values:   []string{"g1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []dbCluster.InstancePlacementRule{
+				{
+					Name:     "2",
+					Kind:     dbCluster.InstancePlacementRuleKind(api.InstancePlacementRuleKindAffinity),
+					Required: true,
+					Selector: dbCluster.Selector{
+						EntityType: dbCluster.EntityType("cluster_group"),
+						Matchers: dbCluster.SelectorMatchers{
+							{
+								Property: "name",
+								Values:   []string{"g1"},
+							},
+						},
+					},
+				},
+				{
+					Name:     "4",
+					Kind:     dbCluster.InstancePlacementRuleKind(api.InstancePlacementRuleKindAffinity),
+					Required: true,
+					Selector: dbCluster.Selector{
+						EntityType: dbCluster.EntityType("instance"),
+						Matchers: dbCluster.SelectorMatchers{
+							{
+								Property: "name",
+								Values:   []string{"g1"},
+							},
+						},
+					},
+				},
+				{
+					Name:     "3",
+					Kind:     dbCluster.InstancePlacementRuleKind(api.InstancePlacementRuleKindAffinity),
+					Priority: 1,
+					Selector: dbCluster.Selector{
+						EntityType: dbCluster.EntityType("cluster_group"),
+						Matchers: dbCluster.SelectorMatchers{
+							{
+								Property: "name",
+								Values:   []string{"g1"},
+							},
+						},
+					},
+				},
+				{
+					Name:     "5",
+					Kind:     dbCluster.InstancePlacementRuleKind(api.InstancePlacementRuleKindAffinity),
+					Priority: 1,
+					Selector: dbCluster.Selector{
+						EntityType: dbCluster.EntityType("instance"),
+						Matchers: dbCluster.SelectorMatchers{
+							{
+								Property: "name",
+								Values:   []string{"g1"},
+							},
+						},
+					},
+				},
+				{
+					Name:     "1",
+					Kind:     dbCluster.InstancePlacementRuleKind(api.InstancePlacementRuleKindAffinity),
+					Priority: 0,
+					Selector: dbCluster.Selector{
+						EntityType: dbCluster.EntityType("cluster_group"),
+						Matchers: dbCluster.SelectorMatchers{
+							{
+								Property: "name",
+								Values:   []string{"g1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		s.T().Logf("%s (case %d)", tt.name, i)
+		got, err := getSortedPlacementRules(tt.args.rules)
+		if tt.wantErr != nil {
+			tt.wantErr(s.T(), err)
+		}
+
+		s.Require().Len(got, len(tt.want))
+		for i := range tt.want {
+			s.Require().Equal(tt.want[i], got[i])
+		}
+	}
+}

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -232,15 +232,16 @@ func doProfileUpdateInstance(s *state.State, args db.InstanceArgs, p api.Project
 
 	// Update will internally load the new profile configs and detect the changes to apply.
 	return inst.Update(db.InstanceArgs{
-		Architecture: inst.Architecture(),
-		Config:       inst.LocalConfig(),
-		Description:  inst.Description(),
-		Devices:      inst.LocalDevices(),
-		Ephemeral:    inst.IsEphemeral(),
-		Profiles:     profiles, // Supply with new profile config.
-		Project:      inst.Project().Name,
-		Type:         inst.Type(),
-		Snapshot:     inst.IsSnapshot(),
+		Architecture:   inst.Architecture(),
+		Config:         inst.LocalConfig(),
+		Description:    inst.Description(),
+		Devices:        inst.LocalDevices(),
+		Ephemeral:      inst.IsEphemeral(),
+		Profiles:       profiles, // Supply with new profile config.
+		Project:        inst.Project().Name,
+		Type:           inst.Type(),
+		Snapshot:       inst.IsSnapshot(),
+		PlacementRules: inst.LocalPlacementRules(),
 	}, true)
 }
 

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -43,15 +43,16 @@ func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolNam
 		}
 
 		args := db.InstanceArgs{
-			Architecture: inst.Architecture(),
-			Description:  inst.Description(),
-			Config:       inst.LocalConfig(),
-			Devices:      newDevices,
-			Ephemeral:    inst.IsEphemeral(),
-			Profiles:     inst.Profiles(),
-			Project:      inst.Project().Name,
-			Type:         inst.Type(),
-			Snapshot:     inst.IsSnapshot(),
+			Architecture:   inst.Architecture(),
+			Description:    inst.Description(),
+			Config:         inst.LocalConfig(),
+			Devices:        newDevices,
+			Ephemeral:      inst.IsEphemeral(),
+			Profiles:       inst.Profiles(),
+			Project:        inst.Project().Name,
+			Type:           inst.Type(),
+			Snapshot:       inst.IsSnapshot(),
+			PlacementRules: inst.LocalPlacementRules(),
 		}
 
 		err = inst.Update(args, false)

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -109,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -627,6 +627,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -686,7 +690,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -737,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -780,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -840,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1226,12 +1230,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1261,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1301,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1502,7 +1506,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,11 +1551,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1609,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1653,7 +1657,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1696,39 +1700,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1754,10 +1761,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1864,7 +1871,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1912,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1917,7 +1924,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1984,11 +1991,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2000,7 +2007,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2039,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2060,7 +2067,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,17 +2120,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2131,7 +2138,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2180,20 +2187,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2221,7 +2228,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2241,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2295,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2349,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2384,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2413,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,11 +2481,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2541,7 +2548,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2556,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2589,7 +2596,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2609,7 +2616,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2621,7 +2628,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2653,7 +2660,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2827,11 +2834,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2846,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2884,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2894,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2943,7 +2950,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3077,7 +3084,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3128,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3251,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3388,11 +3395,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3560,7 +3567,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3629,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3652,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3707,6 +3714,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3815,12 +3826,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3875,8 +3886,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3898,7 +3909,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3962,18 +3975,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4081,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4093,7 +4106,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4278,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4363,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4382,6 +4395,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4426,7 +4443,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4452,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4462,6 +4479,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4494,12 +4536,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4537,37 +4579,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4579,16 +4621,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4653,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4751,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4824,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4896,6 +4938,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4912,7 +4958,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4965,7 +5011,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -4999,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5133,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5309,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5434,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5454,7 +5500,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5498,6 +5544,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5515,11 +5565,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5577,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5579,7 +5629,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5621,7 +5671,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5699,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5711,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5743,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5909,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5953,17 +6003,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6003,7 +6057,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6039,11 +6093,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6123,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6155,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6177,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6201,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6217,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6263,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6278,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6232,7 +6291,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6265,7 +6324,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6350,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6366,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6355,7 +6414,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6407,7 +6466,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6427,7 +6486,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6454,11 +6513,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6590,7 +6649,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6613,7 +6672,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6634,7 +6693,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6812,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,17 +6836,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6807,24 +6867,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7129,8 +7201,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7146,23 +7219,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7215,7 +7294,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7302,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7334,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7342,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7349,13 +7428,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7457,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7505,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7570,7 +7663,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7582,7 +7675,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7601,10 +7694,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7739,7 +7846,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7747,7 +7854,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7784,7 +7891,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -159,7 +159,7 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -264,7 +264,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -578,7 +578,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -689,7 +689,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(kein Wert)"
 
@@ -727,7 +727,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -751,7 +751,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -792,7 +792,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -805,15 +805,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -838,7 +838,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
@@ -902,6 +902,11 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+#, fuzzy
+msgid "Add instance placement rules"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
 #: lxc/cluster_group.go:724
 msgid "Add member to group"
 msgstr ""
@@ -960,7 +965,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1014,7 +1019,7 @@ msgstr "Aliasname fehlt"
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
@@ -1033,7 +1038,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1061,7 +1066,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1126,11 +1131,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
@@ -1179,7 +1184,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1189,7 +1194,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
@@ -1272,7 +1277,7 @@ msgstr "ERSTELLT AM"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1294,7 +1299,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1331,7 +1336,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1452,8 +1457,8 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1494,7 +1499,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1534,12 +1539,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1570,15 +1575,15 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1611,7 +1616,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1630,16 +1635,16 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1834,7 +1839,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1854,7 +1859,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1884,11 +1889,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1948,7 +1953,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1998,7 +2003,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -2044,39 +2049,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2102,10 +2110,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2222,7 +2230,7 @@ msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2267,7 +2275,7 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2282,7 +2290,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display network zones from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2355,11 +2363,11 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2374,7 +2382,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2413,7 +2421,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2443,7 +2451,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2497,17 +2505,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2515,7 +2523,7 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2573,20 +2581,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2618,7 +2626,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2631,7 +2639,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2685,12 +2693,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2739,7 +2747,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2774,7 +2782,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2806,7 +2814,7 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -2875,11 +2883,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2943,7 +2951,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2952,7 +2960,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2997,7 +3005,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3020,7 +3028,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -3034,7 +3042,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3073,7 +3081,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3253,11 +3261,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3265,25 +3273,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3305,7 +3313,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3315,7 +3323,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3373,7 +3381,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3515,7 +3523,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3559,12 +3567,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3691,11 +3699,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3854,11 +3862,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "List permissions"
 msgstr "Aliasse:\n"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -4037,7 +4045,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
@@ -4107,12 +4115,12 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 #, fuzzy
 msgid "Manage images"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4131,7 +4139,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4209,6 +4217,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Fehlerhafte Profil URL %s"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
+msgstr "Kein Zertifikat für diese Verbindung"
 
 #: lxc/profile.go:34 lxc/profile.go:35
 #, fuzzy
@@ -4327,12 +4340,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4395,8 +4408,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4421,7 +4434,9 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 #, fuzzy
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
@@ -4491,19 +4506,19 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4619,7 +4634,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4632,7 +4647,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4819,7 +4834,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4909,7 +4924,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4928,6 +4943,10 @@ msgstr "Profil %s gelöscht\n"
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4972,7 +4991,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4981,7 +5000,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -5009,6 +5028,32 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, fuzzy, c-format
+msgid "Placement %s overridden for %s"
+msgstr "Gerät %s wurde von %s entfernt\n"
+
+#: lxc/config_placement.go:407
+#, fuzzy, c-format
+msgid "Placement %s removed from %s"
+msgstr "Gerät %s wurde von %s entfernt\n"
+
+#: lxc/config_placement.go:215
+#, fuzzy, c-format
+msgid "Placement rule %s added to %s"
+msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+#, fuzzy
+msgid "Placement rule doesn't exist"
+msgstr "entfernte Instanz %s existiert nicht"
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -5044,12 +5089,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -5087,37 +5132,37 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5132,17 +5177,17 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
@@ -5166,12 +5211,12 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5265,7 +5310,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -5304,7 +5349,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5344,16 +5389,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5467,6 +5512,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+#, fuzzy
+msgid "Remove instance placement rules"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5486,7 +5536,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5545,7 +5595,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5583,7 +5633,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5679,7 +5729,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5770,7 +5820,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5807,16 +5857,16 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5913,11 +5963,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6050,7 +6100,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -6073,7 +6123,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6120,6 +6170,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "Geräte zu Containern oder Profilen hinzufügen"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -6138,11 +6193,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6152,7 +6207,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -6214,7 +6269,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6260,7 +6315,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6291,7 +6346,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6303,7 +6358,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
@@ -6336,7 +6391,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6510,7 +6565,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6610,17 +6665,22 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
+#: lxc/config_placement.go:275
+#, fuzzy
+msgid "The profile placement doesn't exist"
+msgstr "entfernte Instanz %s existiert nicht"
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6660,7 +6720,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6696,11 +6756,17 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+#, fuzzy
+msgid "The rule already exists"
+msgstr "entfernte Instanz %s existiert bereits"
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6723,7 +6789,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6757,7 +6823,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
@@ -6780,7 +6846,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6804,7 +6870,7 @@ msgstr "unbekannter entfernter Instanz Name: %q"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6820,12 +6886,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6868,7 +6934,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6883,7 +6949,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6896,7 +6962,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6930,7 +6996,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6956,7 +7022,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -6976,11 +7042,11 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7034,7 +7100,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -7095,7 +7161,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -7118,7 +7184,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7146,11 +7212,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7294,7 +7360,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7327,7 +7393,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7370,7 +7436,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7591,7 +7657,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7600,7 +7666,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7609,7 +7675,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7617,7 +7683,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7641,7 +7707,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7649,7 +7715,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7657,9 +7723,10 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7700,7 +7767,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7708,7 +7775,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7716,7 +7783,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7724,7 +7791,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7733,7 +7800,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7741,6 +7808,26 @@ msgstr ""
 "\n"
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
+
+#: lxc/config_placement.go:117
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
+#: lxc/config_placement.go:231
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
 
 #: lxc/restore.go:20
 #, fuzzy
@@ -8339,8 +8426,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8372,7 +8460,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8380,7 +8468,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8388,7 +8476,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8396,7 +8484,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8404,7 +8492,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8511,7 +8605,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8529,7 +8623,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8537,7 +8631,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8587,7 +8681,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -8595,7 +8689,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -8681,13 +8775,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8696,13 +8804,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8744,7 +8852,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8906,7 +9014,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8918,7 +9026,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8937,10 +9045,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -9075,7 +9197,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -9083,7 +9205,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -9120,8 +9242,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -634,6 +634,10 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:724
 msgid "Add member to group"
 msgstr ""
@@ -691,7 +695,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -743,7 +747,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -759,7 +763,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -786,7 +790,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -846,11 +850,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -897,7 +901,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -907,7 +911,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -989,7 +993,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1002,7 +1006,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1039,7 +1043,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1154,8 +1158,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1196,7 +1200,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1233,12 +1237,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1268,15 +1272,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1308,7 +1312,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1324,16 +1328,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1528,7 +1532,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1557,11 +1561,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1620,7 +1624,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1667,7 +1671,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1711,39 +1715,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1769,10 +1776,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1880,7 +1887,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1925,7 +1932,7 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1937,7 +1944,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2005,11 +2012,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2021,7 +2028,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2057,7 +2064,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit network zone record configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2086,7 +2093,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2139,17 +2146,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2157,7 +2164,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2206,20 +2213,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2247,7 +2254,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2260,7 +2267,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2314,12 +2321,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2368,7 +2375,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2403,7 +2410,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2432,7 +2439,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2500,11 +2507,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2567,7 +2574,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2575,7 +2582,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2620,7 +2627,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2641,7 +2648,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2654,7 +2661,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2691,7 +2698,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2866,11 +2873,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2878,25 +2885,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2916,7 +2923,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2926,7 +2933,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2982,7 +2989,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3116,7 +3123,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3160,12 +3167,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3285,11 +3292,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3429,11 +3436,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3601,7 +3608,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3665,11 +3672,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3688,7 +3695,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "  Χρήση δικτύου:"
@@ -3758,6 +3765,11 @@ msgstr "  Χρήση δικτύου:"
 #: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
+msgstr "  Χρήση δικτύου:"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
 msgstr "  Χρήση δικτύου:"
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3872,12 +3884,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3938,8 +3950,8 @@ msgstr "  Χρήση δικτύου:"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3962,7 +3974,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4027,18 +4041,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4147,7 +4161,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4159,7 +4173,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4346,7 +4360,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4431,7 +4445,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4450,6 +4464,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4494,7 +4512,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4503,7 +4521,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4530,6 +4548,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4563,12 +4606,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4606,37 +4649,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4648,16 +4691,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4680,11 +4723,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4778,7 +4821,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4814,7 +4857,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4851,16 +4894,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4968,6 +5011,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4985,7 +5032,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5039,7 +5086,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5073,7 +5120,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5162,7 +5209,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5251,7 +5298,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5286,15 +5333,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5390,11 +5437,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5521,7 +5568,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5542,7 +5589,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5587,6 +5634,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "  Χρήση δικτύου:"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -5605,11 +5657,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5617,7 +5669,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5675,7 +5727,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show network zone record configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5719,7 +5771,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5748,7 +5800,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5760,7 +5812,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5792,7 +5844,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5958,7 +6010,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6052,17 +6104,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6102,7 +6158,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6138,11 +6194,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6163,7 +6224,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
@@ -6196,7 +6257,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6218,7 +6279,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6242,7 +6303,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6258,12 +6319,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6304,7 +6365,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6319,7 +6380,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6332,7 +6393,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6365,7 +6426,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6391,7 +6452,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6408,11 +6469,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6464,7 +6525,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6523,7 +6584,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6544,7 +6605,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6571,11 +6632,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6707,7 +6768,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6730,7 +6791,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6751,7 +6812,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6870,19 +6931,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6894,17 +6955,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6924,24 +6986,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7246,8 +7320,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7263,23 +7338,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7332,7 +7413,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7340,11 +7421,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7372,7 +7453,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7380,7 +7461,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7466,13 +7547,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7481,13 +7576,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7529,7 +7624,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7687,7 +7782,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7699,7 +7794,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7718,10 +7813,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7856,7 +7965,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7864,7 +7973,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7901,8 +8010,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -163,7 +163,7 @@ msgstr ""
 "### Esta es una representación YAML del grupo de clústeres.\n"
 "### Cualquier línea que empiece con un '#' será ignorada."
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -266,7 +266,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -574,7 +574,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -657,7 +657,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
@@ -677,7 +677,7 @@ msgstr "%s no es un directorio"
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -714,7 +714,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -771,7 +771,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -784,15 +784,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -877,6 +877,11 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+#, fuzzy
+msgid "Add instance placement rules"
+msgstr "Nombre del contenedor es: %s"
+
 #: lxc/cluster_group.go:724
 msgid "Add member to group"
 msgstr ""
@@ -935,7 +940,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -987,7 +992,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -1004,7 +1009,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1032,7 +1037,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1092,11 +1097,11 @@ msgstr "Tipo de autenticación %s no está soportada por el servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
@@ -1143,7 +1148,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1153,7 +1158,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
@@ -1235,7 +1240,7 @@ msgstr "CREADO EN"
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
@@ -1251,7 +1256,7 @@ msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
 "local"
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
@@ -1289,7 +1294,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1406,8 +1411,8 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1448,7 +1453,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1487,12 +1492,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1522,15 +1527,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1562,7 +1567,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1578,17 +1583,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
@@ -1774,7 +1779,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1790,7 +1795,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1820,11 +1825,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1883,7 +1888,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr "Eliminar imágenes"
 
@@ -1931,7 +1936,7 @@ msgstr "Perfil %s creado"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1975,39 +1980,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2033,10 +2041,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2145,7 +2153,7 @@ msgstr "Dispositivo: %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
@@ -2187,7 +2195,7 @@ msgstr "Disco:"
 msgid "Disks:"
 msgstr "Discos:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2202,7 +2210,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display network zones from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2272,11 +2280,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2288,7 +2296,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2324,7 +2332,7 @@ msgstr "Perfil %s creado"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2353,7 +2361,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2406,17 +2414,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2424,7 +2432,7 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2475,20 +2483,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2518,7 +2526,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
@@ -2531,7 +2539,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2585,12 +2593,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2639,7 +2647,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2674,7 +2682,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2703,7 +2711,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
@@ -2772,11 +2780,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2839,7 +2847,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
@@ -2848,7 +2856,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2893,7 +2901,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2914,7 +2922,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2927,7 +2935,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2964,7 +2972,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3142,11 +3150,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3154,25 +3162,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3192,7 +3200,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3202,7 +3210,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3261,7 +3269,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
@@ -3398,7 +3406,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "IsSM: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3442,12 +3450,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3574,11 +3582,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3721,11 +3729,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "List permissions"
 msgstr "Aliases:"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3896,7 +3904,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3960,11 +3968,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3983,7 +3991,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Nombre del Miembro del Cluster"
@@ -4054,6 +4062,11 @@ msgstr "Nombre del contenedor es: %s"
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Nombre del contenedor es: %s"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
+msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/profile.go:34 lxc/profile.go:35
 msgid "Manage profiles"
@@ -4166,12 +4179,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4234,8 +4247,8 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
@@ -4260,7 +4273,9 @@ msgstr "Nombre del contenedor es: %s"
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4328,19 +4343,19 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4452,7 +4467,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4464,7 +4479,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4649,7 +4664,7 @@ msgstr "Perfil %s eliminado"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4734,7 +4749,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4753,6 +4768,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4797,7 +4816,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4806,7 +4825,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4833,6 +4852,32 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, fuzzy, c-format
+msgid "Placement %s overridden for %s"
+msgstr "Perfil %s eliminado de %s"
+
+#: lxc/config_placement.go:407
+#, fuzzy, c-format
+msgid "Placement %s removed from %s"
+msgstr "Perfil %s eliminado de %s"
+
+#: lxc/config_placement.go:215
+#, fuzzy, c-format
+msgid "Placement rule %s added to %s"
+msgstr "Perfil %s añadido a %s"
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+#, fuzzy
+msgid "Placement rule doesn't exist"
+msgstr "El dispostivo ya existe: %s"
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4866,12 +4911,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4909,37 +4954,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -4954,16 +4999,16 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
@@ -4987,11 +5032,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5085,7 +5130,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
@@ -5121,7 +5166,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5160,16 +5205,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5279,6 +5324,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5296,7 +5345,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5351,7 +5400,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5385,7 +5434,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5479,7 +5528,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5568,7 +5617,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
@@ -5604,15 +5653,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5708,11 +5757,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5839,7 +5888,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5860,7 +5909,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5905,6 +5954,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "Perfil %s creado"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -5923,11 +5977,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Dispositivo %s añadido a %s"
@@ -5936,7 +5990,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5994,7 +6048,7 @@ msgstr "Perfil %s creado"
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6038,7 +6092,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6067,7 +6121,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6079,7 +6133,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
@@ -6111,7 +6165,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6278,7 +6332,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6374,17 +6428,22 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+#, fuzzy
+msgid "The profile placement doesn't exist"
+msgstr "El dispostivo ya existe: %s"
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6424,7 +6483,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6460,11 +6519,17 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+#, fuzzy
+msgid "The rule already exists"
+msgstr "El dispostivo ya existe: %s"
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6485,7 +6550,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
@@ -6519,7 +6584,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6541,7 +6606,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6565,7 +6630,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6581,12 +6646,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6629,7 +6694,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -6644,7 +6709,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6657,7 +6722,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6690,7 +6755,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6716,7 +6781,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
@@ -6734,11 +6799,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6790,7 +6855,7 @@ msgstr "Perfil %s creado"
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6849,7 +6914,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6870,7 +6935,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6898,11 +6963,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7034,7 +7099,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7059,7 +7124,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7085,7 +7150,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7228,22 +7293,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7258,19 +7323,20 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7295,29 +7361,43 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/config_placement.go:117
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/config_placement.go:231
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/restore.go:20
@@ -7689,8 +7769,9 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7710,27 +7791,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7796,7 +7883,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7806,12 +7893,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7844,7 +7931,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7852,7 +7939,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7938,13 +8025,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7953,13 +8054,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8001,7 +8102,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8159,7 +8260,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8171,7 +8272,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8190,10 +8291,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -8328,7 +8443,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8336,7 +8451,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -8373,8 +8488,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -265,7 +265,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -577,7 +577,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -666,7 +666,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -686,7 +686,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -722,7 +722,7 @@ msgstr "--console fonctionne seulement avec une instance seule"
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -742,7 +742,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -787,7 +787,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -801,16 +801,16 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
@@ -896,6 +896,11 @@ msgstr ""
 #: lxc/config_device.go:78 lxc/config_device.go:79
 #, fuzzy
 msgid "Add instance devices"
+msgstr "Création du conteneur"
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+#, fuzzy
+msgid "Add instance placement rules"
 msgstr "Création du conteneur"
 
 #: lxc/cluster_group.go:724
@@ -965,7 +970,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Création du conteneur"
@@ -1019,7 +1024,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Alias :"
 
@@ -1037,7 +1042,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1065,7 +1070,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Création du conteneur"
@@ -1129,11 +1134,11 @@ msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
@@ -1182,7 +1187,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1192,7 +1197,7 @@ msgstr "Clé de configuration invalide"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
@@ -1274,7 +1279,7 @@ msgstr "CRÉÉ À"
 msgid "CUDA Version: %v"
 msgstr "Afficher la version du client"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr "Créé : %s"
@@ -1288,7 +1293,7 @@ msgstr "Créé : %s"
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1328,7 +1333,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1446,8 +1451,8 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1488,7 +1493,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1536,12 +1541,12 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1572,15 +1577,15 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1613,7 +1618,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1632,17 +1637,17 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
@@ -1854,7 +1859,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
@@ -1874,7 +1879,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1904,11 +1909,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1971,7 +1976,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 #, fuzzy
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
@@ -2023,7 +2028,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -2070,39 +2075,42 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2128,10 +2136,10 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2242,7 +2250,7 @@ msgstr "Serveur distant : %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
@@ -2287,7 +2295,7 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2302,7 +2310,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display network zones from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2376,11 +2384,11 @@ msgstr "Clé de configuration invalide"
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2395,7 +2403,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2434,7 +2442,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2465,7 +2473,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2519,17 +2527,17 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2537,7 +2545,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2604,21 +2612,21 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 #, fuzzy
 msgid "Export and download images"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2650,7 +2658,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
@@ -2664,7 +2672,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2718,12 +2726,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2773,7 +2781,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2808,7 +2816,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2838,7 +2846,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -2910,11 +2918,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2977,7 +2985,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -2986,7 +2994,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3031,7 +3039,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3054,7 +3062,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -3068,7 +3076,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3108,7 +3116,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3294,11 +3302,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
@@ -3306,26 +3314,26 @@ msgstr "Image copiée avec succès !"
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3348,7 +3356,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3358,7 +3366,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
@@ -3419,7 +3427,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
@@ -3557,7 +3565,7 @@ msgstr "Cible invalide %s"
 msgid "IsSM: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
@@ -3602,12 +3610,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
@@ -3734,11 +3742,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3943,11 +3951,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "List permissions"
 msgstr "Alias :"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -4122,7 +4130,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
@@ -4191,12 +4199,12 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr "Rendre l'image publique"
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 #, fuzzy
 msgid "Manage images"
 msgstr "Rendre l'image publique"
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4215,7 +4223,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -4294,6 +4302,11 @@ msgstr "Nom du réseau"
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Rendre l'image publique"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
+msgstr "Copie de l'image : %s"
 
 #: lxc/profile.go:34 lxc/profile.go:35
 msgid "Manage profiles"
@@ -4413,12 +4426,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -4481,8 +4494,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4507,7 +4520,9 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 #, fuzzy
 msgid "Missing name"
 msgstr "Résumé manquant."
@@ -4578,19 +4593,19 @@ msgstr "Résumé manquant."
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4709,7 +4724,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4722,7 +4737,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4910,7 +4925,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 #, fuzzy
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
@@ -5006,7 +5021,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 #, fuzzy
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
@@ -5029,6 +5044,10 @@ msgstr "Le réseau %s a été supprimé"
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -5074,7 +5093,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5083,7 +5102,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5112,6 +5131,32 @@ msgstr "Création du conteneur"
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, fuzzy, c-format
+msgid "Placement %s overridden for %s"
+msgstr "Périphérique %s retiré de %s"
+
+#: lxc/config_placement.go:407
+#, fuzzy, c-format
+msgid "Placement %s removed from %s"
+msgstr "Profil %s supprimé de %s"
+
+#: lxc/config_placement.go:215
+#, fuzzy, c-format
+msgid "Placement rule %s added to %s"
+msgstr "Profil %s ajouté à %s"
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+#, fuzzy
+msgid "Placement rule doesn't exist"
+msgstr "le serveur distant %s n'existe pas"
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -5147,12 +5192,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -5191,37 +5236,37 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -5236,17 +5281,17 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
@@ -5270,11 +5315,11 @@ msgstr "Profil %s ajouté à %s"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5368,7 +5413,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -5407,7 +5452,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5449,17 +5494,17 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5574,6 +5619,11 @@ msgstr "Création du conteneur"
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+#, fuzzy
+msgid "Remove instance placement rules"
+msgstr "L'arrêt du conteneur a échoué !"
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5593,7 +5643,7 @@ msgstr "Création du conteneur"
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
@@ -5653,7 +5703,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5690,7 +5740,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5803,7 +5853,7 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -5897,7 +5947,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -5934,16 +5984,16 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6041,12 +6091,12 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6179,7 +6229,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -6202,7 +6252,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6249,6 +6299,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "Afficher la configuration étendue"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -6267,11 +6322,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6281,7 +6336,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -6346,7 +6401,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
@@ -6395,7 +6450,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -6426,7 +6481,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6438,7 +6493,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
@@ -6471,7 +6526,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr "Source :"
 
@@ -6648,7 +6703,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6752,17 +6807,22 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
+#: lxc/config_placement.go:275
+#, fuzzy
+msgid "The profile placement doesn't exist"
+msgstr "Le périphérique indiqué n'existe pas"
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6802,7 +6862,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6838,11 +6898,17 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+#, fuzzy
+msgid "The rule already exists"
+msgstr "Le périphérique n'existe pas"
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6863,7 +6929,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6898,7 +6964,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
@@ -6923,7 +6989,7 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6947,7 +7013,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6963,12 +7029,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -7012,7 +7078,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -7027,7 +7093,7 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -7040,7 +7106,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -7074,7 +7140,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7100,7 +7166,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -7120,11 +7186,11 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7179,7 +7245,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7242,7 +7308,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -7265,7 +7331,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7293,11 +7359,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -7439,7 +7505,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7472,7 +7538,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7518,7 +7584,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7754,7 +7820,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7766,7 +7832,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7778,7 +7844,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7786,7 +7852,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7810,7 +7876,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7818,7 +7884,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7826,9 +7892,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7872,7 +7939,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7880,7 +7947,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7888,7 +7955,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7896,7 +7963,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7908,7 +7975,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7919,6 +7986,26 @@ msgstr ""
 "\n"
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
+
+#: lxc/config_placement.go:117
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/config_placement.go:231
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/restore.go:20
 #, fuzzy
@@ -8583,8 +8670,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8616,7 +8704,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8624,7 +8712,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8632,7 +8720,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8640,7 +8728,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8648,7 +8736,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8761,7 +8855,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8785,7 +8879,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8793,7 +8887,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8850,7 +8944,7 @@ msgstr "Swap (courant)"
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr "désactivé"
 
@@ -8858,7 +8952,7 @@ msgstr "désactivé"
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr "activé"
 
@@ -8944,13 +9038,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8959,13 +9067,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -9007,7 +9115,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9187,7 +9295,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9199,7 +9307,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -9218,10 +9326,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -9357,7 +9479,7 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr "non"
 
@@ -9365,7 +9487,7 @@ msgstr "non"
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr "s'il vous plaît utilisez  `lxc profile`"
 
@@ -9402,8 +9524,8 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "oui"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -113,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -631,6 +631,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -690,7 +694,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +761,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -784,7 +788,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -844,11 +848,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +909,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +990,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +1003,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1040,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1155,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1230,12 +1234,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1265,15 +1269,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1305,7 +1309,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,16 +1325,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1506,7 +1510,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1526,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,11 +1555,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1613,7 +1617,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1657,7 +1661,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1700,39 +1704,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1758,10 +1765,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1868,7 +1875,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1916,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1921,7 +1928,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1988,11 +1995,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2004,7 +2011,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2043,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2071,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,17 +2124,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2135,7 +2142,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2184,20 +2191,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2225,7 +2232,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2245,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2299,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2353,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2388,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2417,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,11 +2485,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2545,7 +2552,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2560,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2593,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2613,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2625,7 +2632,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2657,7 +2664,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2831,11 +2838,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2850,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2888,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2898,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2947,7 +2954,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3081,7 +3088,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3132,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3255,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3392,11 +3399,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3564,7 +3571,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3633,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3656,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3711,6 +3718,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3819,12 +3830,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3879,8 +3890,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3902,7 +3913,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3966,18 +3979,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4085,7 +4098,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4097,7 +4110,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4282,7 +4295,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4367,7 +4380,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4386,6 +4399,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4430,7 +4447,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4456,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4466,6 +4483,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4498,12 +4540,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4541,37 +4583,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4583,16 +4625,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4657,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4755,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4828,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4900,6 +4942,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4916,7 +4962,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4969,7 +5015,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,7 +5049,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5137,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5226,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5260,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5313,11 +5359,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5438,7 +5484,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5458,7 +5504,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5502,6 +5548,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5519,11 +5569,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5581,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5583,7 +5633,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,7 +5675,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5703,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5715,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5747,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5913,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5957,17 +6007,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6007,7 +6061,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6043,11 +6097,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6127,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6159,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6181,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6205,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6221,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6267,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6282,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6236,7 +6295,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6269,7 +6328,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6354,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6370,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6359,7 +6418,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6411,7 +6470,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6431,7 +6490,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,11 +6517,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6594,7 +6653,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6617,7 +6676,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6638,7 +6697,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6816,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,17 +6840,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6811,24 +6871,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7133,8 +7205,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7150,23 +7223,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7219,7 +7298,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7306,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7338,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7346,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7353,13 +7432,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7461,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7416,7 +7509,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7574,7 +7667,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7586,7 +7679,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7605,10 +7698,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7743,7 +7850,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7751,7 +7858,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7788,7 +7895,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -173,7 +173,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -276,7 +276,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -579,7 +579,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -662,7 +662,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -682,7 +682,7 @@ msgstr "%s non è una directory"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -718,7 +718,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -773,7 +773,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -786,15 +786,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -819,7 +819,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -880,6 +880,11 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+#, fuzzy
+msgid "Add instance placement rules"
+msgstr "Creazione del container in corso"
+
 #: lxc/cluster_group.go:724
 msgid "Add member to group"
 msgstr ""
@@ -937,7 +942,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -989,7 +994,7 @@ msgstr "Nome dell'alias mancante"
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Alias:"
 
@@ -1006,7 +1011,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1034,7 +1039,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1094,11 +1099,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1145,7 +1150,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1155,7 +1160,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
@@ -1237,7 +1242,7 @@ msgstr "CREATO IL"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1250,7 +1255,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1287,7 +1292,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1404,8 +1409,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1446,7 +1451,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1483,12 +1488,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1519,15 +1524,15 @@ msgstr "Creazione del container in corso"
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1559,7 +1564,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1575,16 +1580,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1771,7 +1776,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1787,7 +1792,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1817,11 +1822,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1880,7 +1885,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1927,7 +1932,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1971,39 +1976,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2029,10 +2037,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2141,7 +2149,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -2185,7 +2193,7 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Creazione del container in corso"
@@ -2200,7 +2208,7 @@ msgstr "Creazione del container in corso"
 msgid "Display network zones from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
@@ -2270,11 +2278,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -2287,7 +2295,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2322,7 +2330,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2351,7 +2359,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2404,17 +2412,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2422,7 +2430,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2472,20 +2480,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2515,7 +2523,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2528,7 +2536,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2582,12 +2590,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
@@ -2636,7 +2644,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -2671,7 +2679,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2701,7 +2709,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2770,11 +2778,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2837,7 +2845,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -2846,7 +2854,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2889,7 +2897,7 @@ msgstr "Creazione del container in corso"
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2910,7 +2918,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2923,7 +2931,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2959,7 +2967,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3136,11 +3144,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3148,25 +3156,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3186,7 +3194,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3196,7 +3204,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3254,7 +3262,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
@@ -3392,7 +3400,7 @@ msgstr "Proprietà errata: %s"
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3436,12 +3444,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3568,11 +3576,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3716,11 +3724,11 @@ msgstr "Creazione del container in corso"
 msgid "List permissions"
 msgstr "Alias:"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3892,7 +3900,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3959,11 +3967,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3982,7 +3990,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -4055,6 +4063,11 @@ msgstr "Creazione del container in corso"
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Creazione del container in corso"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
+msgstr "Il nome del container è: %s"
 
 #: lxc/profile.go:34 lxc/profile.go:35
 msgid "Manage profiles"
@@ -4167,12 +4180,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4234,8 +4247,8 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
@@ -4260,7 +4273,9 @@ msgstr "Il nome del container è: %s"
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4328,19 +4343,19 @@ msgstr "Il nome del container è: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4451,7 +4466,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4463,7 +4478,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4648,7 +4663,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4735,7 +4750,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4754,6 +4769,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4798,7 +4817,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4807,7 +4826,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4835,6 +4854,32 @@ msgstr "Creazione del container in corso"
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, fuzzy, c-format
+msgid "Placement rule %s added to %s"
+msgstr "Il nome del container è: %s"
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+#, fuzzy
+msgid "Placement rule doesn't exist"
+msgstr "il remote %s non esiste"
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4868,12 +4913,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4911,37 +4956,37 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -4955,16 +5000,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4987,11 +5032,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5085,7 +5130,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5122,7 +5167,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5161,16 +5206,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5281,6 +5326,11 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+#, fuzzy
+msgid "Remove instance placement rules"
+msgstr "Creazione del container in corso"
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5298,7 +5348,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5353,7 +5403,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5387,7 +5437,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5481,7 +5531,7 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5570,7 +5620,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -5606,15 +5656,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5708,11 +5758,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5837,7 +5887,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5858,7 +5908,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5903,6 +5953,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "Il nome del container è: %s"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -5921,11 +5976,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "errore di processamento degli alias %s\n"
@@ -5934,7 +5989,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5992,7 +6047,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6036,7 +6091,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6066,7 +6121,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6078,7 +6133,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
@@ -6110,7 +6165,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6279,7 +6334,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6375,17 +6430,22 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
+#: lxc/config_placement.go:275
+#, fuzzy
+msgid "The profile placement doesn't exist"
+msgstr "il remote %s non esiste"
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
@@ -6425,7 +6485,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6461,11 +6521,17 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+#, fuzzy
+msgid "The rule already exists"
+msgstr "La periferica esiste già"
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6486,7 +6552,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
@@ -6520,7 +6586,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6542,7 +6608,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6566,7 +6632,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6582,12 +6648,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6629,7 +6695,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6644,7 +6710,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6657,7 +6723,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6691,7 +6757,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6717,7 +6783,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6736,11 +6802,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6789,7 +6855,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6845,7 +6911,7 @@ msgstr "Creazione del container in corso"
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6866,7 +6932,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6894,11 +6960,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7032,7 +7098,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -7059,7 +7125,7 @@ msgstr "Creazione del container in corso"
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7085,7 +7151,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7228,22 +7294,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "Creazione del container in corso"
@@ -7258,19 +7324,20 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
@@ -7295,29 +7362,43 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
+msgstr "Creazione del container in corso"
+
+#: lxc/config_placement.go:117
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr "Creazione del container in corso"
+
+#: lxc/config_placement.go:231
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/restore.go:20
@@ -7689,8 +7770,9 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -7710,27 +7792,33 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -7796,7 +7884,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7806,12 +7894,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7844,7 +7932,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7852,7 +7940,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7938,13 +8026,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7953,13 +8055,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8001,7 +8103,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8159,7 +8261,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8171,7 +8273,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8190,10 +8292,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -8329,7 +8445,7 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr "no"
 
@@ -8337,7 +8453,7 @@ msgstr "no"
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -8374,8 +8490,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -150,7 +150,7 @@ msgstr ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -568,7 +568,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -654,7 +654,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
@@ -674,7 +674,7 @@ msgstr "%s はディレクトリではありません"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(none)"
 
@@ -709,7 +709,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -729,7 +729,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -762,7 +762,7 @@ msgstr "<remote> <new-name>"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -777,15 +777,15 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -810,7 +810,7 @@ msgstr "アクセスキー（空白の場合自動生成）"
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -867,6 +867,11 @@ msgstr "ネットワークゾーンレコードにエントリを追加します
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr "インスタンスにデバイスを追加します"
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+#, fuzzy
+msgid "Add instance placement rules"
 msgstr "インスタンスにデバイスを追加します"
 
 #: lxc/cluster_group.go:724
@@ -946,7 +951,7 @@ msgstr "フォワードにポートを追加します"
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
@@ -997,7 +1002,7 @@ msgstr "エイリアスを指定してください"
 msgid "Aliases already exists: %s"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "エイリアス:"
 
@@ -1013,7 +1018,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1041,7 +1046,7 @@ msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
@@ -1105,11 +1110,11 @@ msgstr "認証タイプ '%s' はサーバではサポートされていません
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
@@ -1158,7 +1163,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1168,7 +1173,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
@@ -1249,7 +1254,7 @@ msgstr "CREATED AT"
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
@@ -1262,7 +1267,7 @@ msgstr "キャッシュ:"
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
@@ -1300,7 +1305,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1420,8 +1425,8 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1462,7 +1467,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1503,12 +1508,12 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1539,15 +1544,15 @@ msgstr "ステートフルなインスタンスをステートレスにコピー
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr "サーバ間でイメージをコピーします"
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1594,7 +1599,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
@@ -1610,16 +1615,16 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr "仮想マシンイメージをコピーします"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
@@ -1804,7 +1809,7 @@ msgstr "新たにネットワークゾーンを作成します"
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
@@ -1820,7 +1825,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1849,11 +1854,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1914,7 +1919,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr "イメージを削除します"
 
@@ -1958,7 +1963,7 @@ msgstr "ネットワークゾーンを削除します"
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
@@ -2001,39 +2006,42 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2059,10 +2067,10 @@ msgstr "警告を削除します"
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2175,7 +2183,7 @@ msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
 "でした"
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -2217,7 +2225,7 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2231,7 +2239,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display network zones from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2304,11 +2312,11 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを編集します"
@@ -2321,7 +2329,7 @@ msgstr "インスタンスのファイルテンプレートを編集します"
 msgid "Edit instance metadata files"
 msgstr "インスタンスのメタデータファイルを編集します"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
@@ -2353,7 +2361,7 @@ msgstr "ネットワークゾーン設定をYAMLで編集します"
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
@@ -2381,7 +2389,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2446,17 +2454,17 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
@@ -2464,7 +2472,7 @@ msgstr "イメージのプロパティを削除します"
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2524,20 +2532,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "失効日時"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr "イメージをエクスポートしてダウンロードします"
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2569,7 +2577,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
@@ -2582,7 +2590,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2636,12 +2644,12 @@ msgstr "クライアント %q に対する SFTP インスタンスの接続に�
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2690,7 +2698,7 @@ msgstr "リモートの追加に失敗しました"
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
@@ -2725,7 +2733,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
@@ -2754,7 +2762,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -2838,11 +2846,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2905,7 +2913,7 @@ msgstr "すべてのコマンドに対する man ページを作成します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -2914,7 +2922,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -2960,7 +2968,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2983,7 +2991,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2995,7 +3003,7 @@ msgstr "クラスターメンバーの設定値を取得します"
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
@@ -3027,7 +3035,7 @@ msgstr "ネットワークゾーンの設定値を取得します"
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
@@ -3207,11 +3215,11 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
@@ -3219,25 +3227,25 @@ msgstr "イメージのコピーが成功しました!"
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3260,7 +3268,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 #, fuzzy
 msgid ""
 "Import image into the image store\n"
@@ -3275,7 +3283,7 @@ msgstr ""
 "ディレクトリのインポートは Linux 上でのみ可能で、root で実行する必要がありま"
 "す。"
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
@@ -3331,7 +3339,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
@@ -3474,7 +3482,7 @@ msgstr "不正な送り先 %s"
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
@@ -3520,12 +3528,12 @@ msgstr "LXD サーバはクラスタの一部ではありません"
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
@@ -3650,11 +3658,11 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 #, fuzzy
 msgid ""
 "List images\n"
@@ -3899,11 +3907,11 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 #, fuzzy
 msgid ""
 "List profiles\n"
@@ -4123,7 +4131,7 @@ msgstr "MTU"
 msgid "MTU: %d"
 msgstr "MTU: %d"
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr "イメージを public にする"
 
@@ -4188,11 +4196,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr "イメージのエイリアスを管理します"
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr "イメージを管理します"
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4224,7 +4232,7 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを管理します"
@@ -4289,6 +4297,11 @@ msgstr "ネットワークゾーンを管理します"
 #, fuzzy
 msgid "Manage permissions"
 msgstr "プロファイルを管理します"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
+msgstr "クラスタロールを管理します"
 
 #: lxc/profile.go:34 lxc/profile.go:35
 msgid "Manage profiles"
@@ -4401,12 +4414,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -4465,8 +4478,8 @@ msgstr "クラスターグループ名がありません"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -4488,7 +4501,9 @@ msgstr "リッスンアドレスを指定する必要があります"
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
@@ -4552,18 +4567,18 @@ msgstr "ピア名を指定する必要があります"
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
@@ -4689,7 +4704,7 @@ msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
@@ -4701,7 +4716,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4889,7 +4904,7 @@ msgstr "ネットワークゾーンレコード %s を削除しました"
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
@@ -4978,7 +4993,7 @@ msgstr "\"カスタム\" のボリュームのみがスナップショットを�
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
@@ -4998,6 +5013,10 @@ msgstr "バックグラウンド操作 %s を削除しました"
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
+msgstr ""
 
 #: lxc/main.go:96
 msgid "Override the source project"
@@ -5041,7 +5060,7 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
@@ -5050,7 +5069,7 @@ msgstr "PROJECT"
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5078,6 +5097,35 @@ msgstr "インスタンスを一時停止します"
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
+
+#: lxc/config_placement.go:304
+#, fuzzy, c-format
+msgid "Placement %s overridden for %s"
+msgstr "デバイス %s が %s で上書きされました"
+
+#: lxc/config_placement.go:407
+#, fuzzy, c-format
+msgid "Placement %s removed from %s"
+msgstr "プロファイル %s が %s から削除されました"
+
+#: lxc/config_placement.go:215
+#, fuzzy, c-format
+msgid "Placement rule %s added to %s"
+msgstr "プロファイル %s が %s に追加されました"
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+#, fuzzy
+msgid "Placement rule doesn't exist"
+msgstr "リモート %s は存在しません"
+
+#: lxc/config_placement.go:389
+#, fuzzy
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
+msgstr ""
+"プロファイルのデバイスは個々のインスタンスでは削除できません。デバイスを上書"
+"きするかプロファイルを変更してください"
 
 #: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
@@ -5110,12 +5158,12 @@ msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -5155,37 +5203,37 @@ msgstr "エイリアスの処理が失敗しました: %s"
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
@@ -5197,16 +5245,16 @@ msgstr "新しいインスタンスに適用するプロファイル"
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr "プロファイル: "
 
@@ -5229,11 +5277,11 @@ msgstr "プロジェクト名 %s を %s に変更しました"
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5333,7 +5381,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -5369,7 +5417,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5408,16 +5456,16 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5525,6 +5573,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+#, fuzzy
+msgid "Remove instance placement rules"
+msgstr "インスタンスのデバイスを削除します"
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
@@ -5542,7 +5595,7 @@ msgstr "フォワードからポートを削除します"
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
@@ -5597,7 +5650,7 @@ msgstr "ネットワーク ACL 名を変更します"
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
@@ -5632,7 +5685,7 @@ msgstr "レンダー: %s (%s)"
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5728,7 +5781,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr "SIZE"
 
@@ -5818,7 +5871,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -5861,15 +5914,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5988,11 +6041,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6143,7 +6196,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -6166,7 +6219,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6211,6 +6264,11 @@ msgstr "すべてのプロジェクトのイベントを表示します"
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "デバイスの設定をすべて表示します"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -6229,11 +6287,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを表示します"
@@ -6242,7 +6300,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -6294,7 +6352,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
@@ -6336,7 +6394,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -6365,7 +6423,7 @@ msgstr "信頼済みクライアントの設定を表示します"
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
@@ -6377,7 +6435,7 @@ msgstr "ストレージプールの情報を表示します"
 msgid "Show warning"
 msgstr "警告を表示します"
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
@@ -6409,7 +6467,7 @@ msgstr "ソケット %d:"
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr "取得元:"
 
@@ -6575,7 +6633,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6675,17 +6733,22 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
+#: lxc/config_placement.go:275
+#, fuzzy
+msgid "The profile placement doesn't exist"
+msgstr "プロファイルのデバイスが存在しません"
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6725,7 +6788,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6763,11 +6826,17 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+#, fuzzy
+msgid "The rule already exists"
+msgstr "デバイスはすでに存在します"
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
@@ -6790,7 +6859,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6832,7 +6901,7 @@ msgstr "スレッド:"
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
@@ -6861,7 +6930,7 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6887,7 +6956,7 @@ msgstr "トランシーバータイプ: %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6903,12 +6972,12 @@ msgstr "転送モード。pull, push, relay のいずれか"
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6952,7 +7021,7 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6967,7 +7036,7 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
@@ -6980,7 +7049,7 @@ msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr "USED BY"
@@ -7013,7 +7082,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7039,7 +7108,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
@@ -7056,11 +7125,11 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -7104,7 +7173,7 @@ msgstr "ネットワークゾーンの設定を削除します"
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
@@ -7162,7 +7231,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -7185,7 +7254,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7213,12 +7282,12 @@ msgid ""
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 #, fuzzy
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -7358,7 +7427,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -7385,7 +7454,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -7406,7 +7475,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7530,19 +7599,19 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr "[<remote>:]<image> <remote>:"
 
@@ -7555,17 +7624,18 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
@@ -7585,27 +7655,41 @@ msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
+
+#: lxc/config_placement.go:117
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
+
+#: lxc/config_placement.go:231
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
+msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 
 #: lxc/restore.go:20
 msgid "[<remote>:]<instance> <snapshot>"
@@ -7931,8 +8015,9 @@ msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
@@ -7948,24 +8033,30 @@ msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
@@ -8019,7 +8110,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -8027,11 +8118,11 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
@@ -8061,7 +8152,7 @@ msgstr "現在値"
 msgid "description"
 msgstr "説明"
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr "無効"
 
@@ -8069,7 +8160,7 @@ msgstr "無効"
 msgid "driver"
 msgstr "ドライバ"
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr "有効"
 
@@ -8190,7 +8281,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンス内の /opt にマウントし"
 "ます。"
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
@@ -8198,7 +8289,21 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 #, fuzzy
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
@@ -8216,7 +8321,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 #, fuzzy
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
@@ -8225,7 +8330,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8278,7 +8383,7 @@ msgstr ""
 "   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
 "ます。"
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8520,7 +8625,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8541,7 +8646,7 @@ msgstr ""
 "lxc profile assign foo ''\n"
 "    \"foo\" からすべてのプロファイルを削除します。"
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 #, fuzzy
 msgid ""
 "lxc profile create p1\n"
@@ -8573,13 +8678,27 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
 
 #: lxc/project.go:99
 #, fuzzy
@@ -8760,7 +8879,7 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr "no"
 
@@ -8768,7 +8887,7 @@ msgstr "no"
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr "`lxc profile` コマンドを使ってください"
 
@@ -8807,8 +8926,8 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "yes"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -109,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -627,6 +627,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -686,7 +690,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -737,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -780,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -840,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1226,12 +1230,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1261,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1301,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1502,7 +1506,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,11 +1551,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1609,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1653,7 +1657,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1696,39 +1700,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1754,10 +1761,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1864,7 +1871,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1912,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1917,7 +1924,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1984,11 +1991,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2000,7 +2007,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2039,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2060,7 +2067,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,17 +2120,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2131,7 +2138,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2180,20 +2187,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2221,7 +2228,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2241,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2295,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2349,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2384,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2413,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,11 +2481,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2541,7 +2548,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2556,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2589,7 +2596,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2609,7 +2616,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2621,7 +2628,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2653,7 +2660,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2827,11 +2834,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2846,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2884,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2894,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2943,7 +2950,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3077,7 +3084,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3128,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3251,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3388,11 +3395,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3560,7 +3567,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3629,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3652,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3707,6 +3714,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3815,12 +3826,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3875,8 +3886,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3898,7 +3909,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3962,18 +3975,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4081,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4093,7 +4106,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4278,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4363,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4382,6 +4395,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4426,7 +4443,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4452,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4462,6 +4479,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4494,12 +4536,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4537,37 +4579,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4579,16 +4621,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4653,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4751,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4824,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4896,6 +4938,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4912,7 +4958,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4965,7 +5011,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -4999,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5133,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5309,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5434,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5454,7 +5500,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5498,6 +5544,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5515,11 +5565,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5577,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5579,7 +5629,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5621,7 +5671,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5699,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5711,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5743,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5909,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5953,17 +6003,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6003,7 +6057,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6039,11 +6093,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6123,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6155,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6177,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6201,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6217,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6263,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6278,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6232,7 +6291,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6265,7 +6324,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6350,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6366,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6355,7 +6414,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6407,7 +6466,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6427,7 +6486,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6454,11 +6513,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6590,7 +6649,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6613,7 +6672,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6634,7 +6693,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6812,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,17 +6836,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6807,24 +6867,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7129,8 +7201,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7146,23 +7219,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7215,7 +7294,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7302,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7334,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7342,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7349,13 +7428,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7457,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7505,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7570,7 +7663,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7582,7 +7675,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7601,10 +7694,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7739,7 +7846,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7747,7 +7854,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7784,7 +7891,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-03-03 09:58-0600\n"
+        "POT-Creation-Date: 2025-03-31 08:57+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -102,7 +102,7 @@ msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid   "### This is a YAML representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -176,7 +176,7 @@ msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Note that the name is shown but cannot be modified"
 msgstr  ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid   "### This is a YAML representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -338,7 +338,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -388,7 +388,7 @@ msgstr  ""
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -408,7 +408,7 @@ msgstr  ""
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid   "(none)"
 msgstr  ""
 
@@ -443,7 +443,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -463,7 +463,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843 lxc/info.go:461
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847 lxc/info.go:461
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -495,7 +495,7 @@ msgstr  ""
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid   "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr  ""
 
@@ -507,15 +507,15 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -540,7 +540,7 @@ msgstr  ""
 msgid   "Access key: %s"
 msgstr  ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid   "Access the expanded configuration"
 msgstr  ""
 
@@ -597,6 +597,10 @@ msgstr  ""
 msgid   "Add instance devices"
 msgstr  ""
 
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid   "Add instance placement rules"
+msgstr  ""
+
 #: lxc/cluster_group.go:724
 msgid   "Add member to group"
 msgstr  ""
@@ -647,7 +651,7 @@ msgstr  ""
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid   "Add profiles to instances"
 msgstr  ""
 
@@ -698,7 +702,7 @@ msgstr  ""
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid   "Aliases:"
 msgstr  ""
 
@@ -714,7 +718,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -741,7 +745,7 @@ msgstr  ""
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
@@ -798,11 +802,11 @@ msgstr  ""
 msgid   "Auto negotiation: %v"
 msgstr  ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
@@ -847,7 +851,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -857,7 +861,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %s"
 msgstr  ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
@@ -938,7 +942,7 @@ msgstr  ""
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
@@ -951,7 +955,7 @@ msgstr  ""
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
@@ -988,7 +992,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -1101,7 +1105,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:389 lxc/storage_volume.go:613 lxc/storage_volume.go:718 lxc/storage_volume.go:1020 lxc/storage_volume.go:1246 lxc/storage_volume.go:1375 lxc/storage_volume.go:1866 lxc/storage_volume.go:1964 lxc/storage_volume.go:2103 lxc/storage_volume.go:2263 lxc/storage_volume.go:2379 lxc/storage_volume.go:2440 lxc/storage_volume.go:2567 lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780 lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:389 lxc/storage_volume.go:613 lxc/storage_volume.go:718 lxc/storage_volume.go:1020 lxc/storage_volume.go:1246 lxc/storage_volume.go:1375 lxc/storage_volume.go:1866 lxc/storage_volume.go:1964 lxc/storage_volume.go:2103 lxc/storage_volume.go:2263 lxc/storage_volume.go:2379 lxc/storage_volume.go:2440 lxc/storage_volume.go:2567 lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1117,7 +1121,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728 lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1152,7 +1156,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165 lxc/storage_volume.go:1197
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285 lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165 lxc/storage_volume.go:1197
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1179,15 +1183,15 @@ msgstr  ""
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid   "Copy images between servers"
 msgstr  ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid   "Copy images between servers\n"
         "\n"
         "The auto-update flag instructs the server to keep this image up to date.\n"
@@ -1213,7 +1217,7 @@ msgstr  ""
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid   "Copy profiles"
 msgstr  ""
 
@@ -1229,15 +1233,15 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282 lxc/storage_volume.go:392
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid   "Copy virtual machine images"
 msgstr  ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
@@ -1412,7 +1416,7 @@ msgstr  ""
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid   "Create profiles"
 msgstr  ""
 
@@ -1428,7 +1432,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1456,7 +1460,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1750
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1750
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1512,7 +1516,7 @@ msgstr  ""
 msgid   "Delete image aliases"
 msgstr  ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid   "Delete images"
 msgstr  ""
 
@@ -1556,7 +1560,7 @@ msgstr  ""
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid   "Delete profiles"
 msgstr  ""
 
@@ -1580,7 +1584,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608 lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:309 lxc/storage_volume.go:385 lxc/storage_volume.go:606 lxc/storage_volume.go:715 lxc/storage_volume.go:802 lxc/storage_volume.go:907 lxc/storage_volume.go:1011 lxc/storage_volume.go:1232 lxc/storage_volume.go:1363 lxc/storage_volume.go:1525 lxc/storage_volume.go:1609 lxc/storage_volume.go:1862 lxc/storage_volume.go:1961 lxc/storage_volume.go:2088 lxc/storage_volume.go:2246 lxc/storage_volume.go:2367 lxc/storage_volume.go:2429 lxc/storage_volume.go:2565 lxc/storage_volume.go:2648 lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397 lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963 lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180 lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_placement.go:75 lxc/config_placement.go:114 lxc/config_placement.go:233 lxc/config_placement.go:328 lxc/config_placement.go:429 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280 lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638 lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019 lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:309 lxc/storage_volume.go:385 lxc/storage_volume.go:606 lxc/storage_volume.go:715 lxc/storage_volume.go:802 lxc/storage_volume.go:907 lxc/storage_volume.go:1011 lxc/storage_volume.go:1232 lxc/storage_volume.go:1363 lxc/storage_volume.go:1525 lxc/storage_volume.go:1609 lxc/storage_volume.go:1862 lxc/storage_volume.go:1961 lxc/storage_volume.go:2088 lxc/storage_volume.go:2246 lxc/storage_volume.go:2367 lxc/storage_volume.go:2429 lxc/storage_volume.go:2565 lxc/storage_volume.go:2648 lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1654,7 +1658,7 @@ msgstr  ""
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -1695,7 +1699,7 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid   "Display images from all projects"
 msgstr  ""
 
@@ -1707,7 +1711,7 @@ msgstr  ""
 msgid   "Display network zones from all projects"
 msgstr  ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid   "Display profiles from all projects"
 msgstr  ""
 
@@ -1772,11 +1776,11 @@ msgstr  ""
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid   "Edit instance UEFI variables"
 msgstr  ""
 
@@ -1788,7 +1792,7 @@ msgstr  ""
 msgid   "Edit instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
@@ -1820,7 +1824,7 @@ msgstr  ""
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
@@ -1848,7 +1852,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770 lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1896,17 +1900,17 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2173 lxc/storage_volume.go:2211
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2173 lxc/storage_volume.go:2211
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1950,20 +1954,20 @@ msgstr  ""
 msgid   "Expires at"
 msgstr  ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid   "Export and download images"
 msgstr  ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid   "Export and download images\n"
         "\n"
         "The output target is optional and defaults to the working directory."
@@ -1990,7 +1994,7 @@ msgstr  ""
 msgid   "Exporting the backup: %s"
 msgstr  ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
@@ -2003,7 +2007,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142 lxc/image_alias.go:268
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143 lxc/image_alias.go:268
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2056,12 +2060,12 @@ msgstr  ""
 msgid   "Failed deleting instance snapshot %q in project %q: %w"
 msgstr  ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid   "Failed fetching fingerprint %q for alias %q: %w"
 msgstr  ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
@@ -2110,7 +2114,7 @@ msgstr  ""
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -2145,7 +2149,7 @@ msgstr  ""
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
@@ -2173,7 +2177,7 @@ msgstr  ""
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -2233,7 +2237,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2293,7 +2297,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
@@ -2301,7 +2305,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2341,7 +2345,7 @@ msgstr  ""
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid   "Get the key as a profile property"
 msgstr  ""
 
@@ -2361,7 +2365,7 @@ msgstr  ""
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid   "Get the key as an instance property"
 msgstr  ""
 
@@ -2373,7 +2377,7 @@ msgstr  ""
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
@@ -2405,7 +2409,7 @@ msgstr  ""
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
@@ -2577,11 +2581,11 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid   "Image already up to date."
 msgstr  ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid   "Image copied successfully!"
 msgstr  ""
 
@@ -2589,25 +2593,25 @@ msgstr  ""
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2627,7 +2631,7 @@ msgstr  ""
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid   "Import image into the image store\n"
         "\n"
         "Directory import is only available on Linux and must be performed as root.\n"
@@ -2635,7 +2639,7 @@ msgid   "Import image into the image store\n"
         "Descriptive properties can be set by providing key=value pairs. Example: os=Ubuntu release=noble variant=cloud."
 msgstr  ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid   "Import images into the image store"
 msgstr  ""
 
@@ -2691,7 +2695,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid   "Instance name must be specified"
 msgstr  ""
 
@@ -2822,7 +2826,7 @@ msgstr  ""
 msgid   "IsSM: %s (%s)"
 msgstr  ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
@@ -2863,12 +2867,12 @@ msgstr  ""
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid   "Last used: never"
 msgstr  ""
 
@@ -2985,11 +2989,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -3119,11 +3123,11 @@ msgstr  ""
 msgid   "List permissions"
 msgstr  ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid   "List profiles\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3288,7 +3292,7 @@ msgstr  ""
 msgid   "MTU: %d"
 msgstr  ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid   "Make image public"
 msgstr  ""
 
@@ -3348,11 +3352,11 @@ msgstr  ""
 msgid   "Manage image aliases"
 msgstr  ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid   "Manage images"
 msgstr  ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid   "Manage images\n"
         "\n"
         "In LXD instances are created from images. Those images were themselves\n"
@@ -3370,7 +3374,7 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid   "Manage instance UEFI variables"
 msgstr  ""
 
@@ -3432,6 +3436,10 @@ msgstr  ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid   "Manage permissions"
+msgstr  ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid   "Manage placement rules"
 msgstr  ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3538,12 +3546,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3584,7 +3592,7 @@ msgstr  ""
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
-#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227 lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231 lxc/profile.go:907 lxc/rebuild.go:61
 msgid   "Missing instance name"
 msgstr  ""
 
@@ -3596,7 +3604,7 @@ msgstr  ""
 msgid   "Missing listen address"
 msgstr  ""
 
-#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368 lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683 lxc/config_device.go:804
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368 lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683 lxc/config_device.go:804 lxc/config_placement.go:154 lxc/config_placement.go:258 lxc/config_placement.go:352 lxc/config_placement.go:453
 msgid   "Missing name"
 msgstr  ""
 
@@ -3624,15 +3632,15 @@ msgstr  ""
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987 lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991 lxc/profile.go:1059 lxc/profile.go:1140
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324 lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827 lxc/project.go:956
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324 lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827 lxc/project.go:956
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid   "Missing source profile name"
 msgstr  ""
 
@@ -3733,7 +3741,7 @@ msgstr  ""
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -3741,7 +3749,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid   "NAME"
 msgstr  ""
 
@@ -3920,7 +3928,7 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid   "New aliases to add to the image"
 msgstr  ""
 
@@ -4004,7 +4012,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
@@ -4023,6 +4031,10 @@ msgstr  ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid   "Optimized Storage"
+msgstr  ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid   "Override profile inherited placement rules"
 msgstr  ""
 
 #: lxc/main.go:96
@@ -4067,7 +4079,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753 lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4075,7 +4087,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4102,6 +4114,29 @@ msgstr  ""
 
 #: lxc/copy.go:65
 msgid   "Perform an incremental copy"
+msgstr  ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid   "Placement %s overridden for %s"
+msgstr  ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid   "Placement %s removed from %s"
+msgstr  ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid   "Placement rule %s added to %s"
+msgstr  ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid   "Placement rule doesn't exist"
+msgstr  ""
+
+#: lxc/config_placement.go:389
+msgid   "Placement rule from profile(s) cannot be removed from individual instance. Override rule or modify profile instead"
 msgstr  ""
 
 #: lxc/remote.go:195
@@ -4133,7 +4168,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166 lxc/storage_volume.go:1198
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361 lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166 lxc/storage_volume.go:1198
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4168,37 +4203,37 @@ msgstr  ""
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
@@ -4210,16 +4245,16 @@ msgstr  ""
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid   "Profiles:"
 msgstr  ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid   "Profiles: "
 msgstr  ""
 
@@ -4242,11 +4277,11 @@ msgstr  ""
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid   "Property not found"
 msgstr  ""
 
@@ -4324,7 +4359,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -4360,7 +4395,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4397,16 +4432,16 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4510,6 +4545,10 @@ msgstr  ""
 msgid   "Remove instance devices"
 msgstr  ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid   "Remove instance placement rules"
+msgstr  ""
+
 #: lxc/cluster_group.go:521
 msgid   "Remove member from group"
 msgstr  ""
@@ -4526,7 +4565,7 @@ msgstr  ""
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid   "Remove profiles from instances"
 msgstr  ""
 
@@ -4578,7 +4617,7 @@ msgstr  ""
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid   "Rename profiles"
 msgstr  ""
 
@@ -4612,7 +4651,7 @@ msgstr  ""
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
@@ -4698,7 +4737,7 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid   "SIZE"
 msgstr  ""
 
@@ -4786,7 +4825,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
@@ -4816,15 +4855,15 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid   "Set image properties"
 msgstr  ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4901,11 +4940,11 @@ msgstr  ""
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5016,7 +5055,7 @@ msgstr  ""
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid   "Set the key as a profile property"
 msgstr  ""
 
@@ -5036,7 +5075,7 @@ msgstr  ""
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid   "Set the key as an instance property"
 msgstr  ""
 
@@ -5080,6 +5119,10 @@ msgstr  ""
 msgid   "Show full device configuration"
 msgstr  ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid   "Show full placement rule configuration"
+msgstr  ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid   "Show group configurations"
 msgstr  ""
@@ -5093,11 +5136,11 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid   "Show instance UEFI variables"
 msgstr  ""
 
@@ -5105,7 +5148,7 @@ msgstr  ""
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -5157,7 +5200,7 @@ msgstr  ""
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid   "Show profile configurations"
 msgstr  ""
 
@@ -5197,7 +5240,7 @@ msgstr  ""
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -5225,7 +5268,7 @@ msgstr  ""
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid   "Show useful information about images"
 msgstr  ""
 
@@ -5237,7 +5280,7 @@ msgstr  ""
 msgid   "Show warning"
 msgstr  ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid   "Size: %.2fMiB"
 msgstr  ""
@@ -5269,7 +5312,7 @@ msgstr  ""
 msgid   "Some instances failed to %s"
 msgstr  ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid   "Source:"
 msgstr  ""
 
@@ -5435,7 +5478,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5522,17 +5565,21 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
+#: lxc/config_placement.go:275
+msgid   "The profile placement doesn't exist"
+msgstr  ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid   "The property %q does not exist on the cluster member %q: %v"
 msgstr  ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid   "The property %q does not exist on the instance %q: %v"
 msgstr  ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
@@ -5572,7 +5619,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
@@ -5606,11 +5653,15 @@ msgstr  ""
 msgid   "The provided fingerprint does not match the server certificate fingerprint"
 msgstr  ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198 lxc/config_placement.go:270
+msgid   "The rule already exists"
+msgstr  ""
+
 #: lxc/info.go:354
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
@@ -5630,7 +5681,7 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
@@ -5658,7 +5709,7 @@ msgstr  ""
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -5679,7 +5730,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5702,7 +5753,7 @@ msgstr  ""
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
@@ -5718,12 +5769,12 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5762,7 +5813,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1470
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5776,7 +5827,7 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -5788,7 +5839,7 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1752
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid   "USED BY"
 msgstr  ""
 
@@ -5820,7 +5871,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776 lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5845,7 +5896,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
@@ -5861,11 +5912,11 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -5909,7 +5960,7 @@ msgstr  ""
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
@@ -5961,7 +6012,7 @@ msgstr  ""
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
@@ -5981,7 +6032,7 @@ msgstr  ""
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
@@ -6006,11 +6057,11 @@ msgstr  ""
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -6134,7 +6185,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -6150,7 +6201,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6170,7 +6221,7 @@ msgstr  ""
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6282,19 +6333,19 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid   "[<remote>:]<image> <remote>:"
 msgstr  ""
 
@@ -6306,15 +6357,15 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330 lxc/config_device.go:762 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330 lxc/config_device.go:762 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_placement.go:423 lxc/config_template.go:271 lxc/console.go:38
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6334,24 +6385,32 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid   "[<remote>:]<instance> <key>"
 msgstr  ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid   "[<remote>:]<instance> <profiles>"
+msgstr  ""
+
+#: lxc/config_placement.go:117
+msgid   "[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> [key=value...] [--priority <priority>]"
+msgstr  ""
+
+#: lxc/config_placement.go:231
+msgid   "[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--priority <priority>]"
 msgstr  ""
 
 #: lxc/restore.go:20
@@ -6630,7 +6689,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356 lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441 lxc/profile.go:500 lxc/profile.go:1106
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
@@ -6646,23 +6705,27 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid   "[<remote>:]<profile> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid   "[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> [key=value...] [--priority <priority>]"
+msgstr  ""
+
+#: lxc/profile.go:277
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
@@ -6714,7 +6777,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6722,11 +6785,11 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
@@ -6754,7 +6817,7 @@ msgstr  ""
 msgid   "description"
 msgstr  ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid   "disabled"
 msgstr  ""
 
@@ -6762,7 +6825,7 @@ msgstr  ""
 msgid   "driver"
 msgstr  ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid   "enabled"
 msgstr  ""
 
@@ -6833,12 +6896,20 @@ msgid   "lxc config device add [<remote>:]instance1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid   "lxc config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid   "lxc config placement add [<remote>:]instance1 <rule-name> affinity cluster_group name=gpu\n"
+        "    Will configure an affinity rule for the instance with name \"instance1\" for the cluster group with name \"gpu\".\n"
+        "\n"
+        "lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity instance config.user.foo=bar,baz\n"
+        "	Will configure an anti-affinity rule for the instance with name \"instance1\" against other instances whose value for \"config.user.foo\" is \"bar\" or \"baz\"."
+msgstr  ""
+
+#: lxc/config.go:551
 msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
@@ -6846,12 +6917,12 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
         "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr  ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
         "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""
@@ -6883,7 +6954,7 @@ msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid   "lxc image edit <image>\n"
         "    Launch a text editor to edit the properties\n"
         "\n"
@@ -7015,7 +7086,7 @@ msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid   "lxc profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -7026,7 +7097,7 @@ msgid   "lxc profile assign foo default,bar\n"
         "    Remove all profile from \"foo\""
 msgstr  ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid   "lxc profile create p1\n"
         "\n"
         "lxc profile create p1 < config.yaml\n"
@@ -7041,9 +7112,17 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
+msgstr  ""
+
+#: lxc/config_placement.go:126
+msgid   "lxc profile placement add [<remote>:]profile1 <rule-name> affinity cluster_group name=gpu\n"
+        "    Will configure an affinity rule for the instances with profile \"profile1\" for the cluster group with name \"gpu\".\n"
+        "\n"
+        "lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity instance config.user.foo=bar,baz\n"
+        "	Will configure an anti-affinity rule for instances with profile \"profile1\" against other instances whose value for \"config.user.foo\" is \"bar\" or \"baz\"."
 msgstr  ""
 
 #: lxc/project.go:99
@@ -7156,7 +7235,7 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid   "no"
 msgstr  ""
 
@@ -7164,7 +7243,7 @@ msgstr  ""
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid   "please use `lxc profile`"
 msgstr  ""
 
@@ -7201,7 +7280,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002 lxc/image.go:1207
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -162,7 +162,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -267,7 +267,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -559,7 +559,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -644,7 +644,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
@@ -664,7 +664,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(geen)"
 
@@ -699,7 +699,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -752,7 +752,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -765,15 +765,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -854,6 +854,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -913,7 +917,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -964,7 +968,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1007,7 +1011,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1067,11 +1071,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1118,7 +1122,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1132,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1209,7 +1213,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1222,7 +1226,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1259,7 +1263,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1374,8 +1378,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1416,7 +1420,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1453,12 +1457,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1488,15 +1492,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1528,7 +1532,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1544,16 +1548,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1729,7 +1733,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1745,7 +1749,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1774,11 +1778,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1880,7 +1884,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1923,39 +1927,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1981,10 +1988,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2091,7 +2098,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2132,7 +2139,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -2144,7 +2151,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2227,7 +2234,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2259,7 +2266,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2287,7 +2294,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2340,17 +2347,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2358,7 +2365,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2407,20 +2414,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2448,7 +2455,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2461,7 +2468,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2515,12 +2522,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2569,7 +2576,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2604,7 +2611,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2633,7 +2640,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2701,11 +2708,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2768,7 +2775,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2776,7 +2783,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2816,7 +2823,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2836,7 +2843,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2848,7 +2855,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3054,11 +3061,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3066,25 +3073,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3104,7 +3111,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3114,7 +3121,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3170,7 +3177,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3304,7 +3311,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3348,12 +3355,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3471,11 +3478,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3615,11 +3622,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3787,7 +3794,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3849,11 +3856,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3872,7 +3879,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3934,6 +3941,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -4042,12 +4053,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4102,8 +4113,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4125,7 +4136,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4189,18 +4202,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4308,7 +4321,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4320,7 +4333,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4505,7 +4518,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4590,7 +4603,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4609,6 +4622,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4653,7 +4670,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4662,7 +4679,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4689,6 +4706,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4721,12 +4763,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4764,37 +4806,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4806,16 +4848,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4838,11 +4880,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4936,7 +4978,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4972,7 +5014,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5009,16 +5051,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5123,6 +5165,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5139,7 +5185,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5192,7 +5238,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5226,7 +5272,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5314,7 +5360,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5403,7 +5449,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5437,15 +5483,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5536,11 +5582,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5661,7 +5707,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5681,7 +5727,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5725,6 +5771,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5742,11 +5792,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5754,7 +5804,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5806,7 +5856,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5848,7 +5898,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5876,7 +5926,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5888,7 +5938,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5920,7 +5970,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6086,7 +6136,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6180,17 +6230,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6230,7 +6284,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6266,11 +6320,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6291,7 +6350,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6323,7 +6382,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6345,7 +6404,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6369,7 +6428,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6385,12 +6444,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6431,7 +6490,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6446,7 +6505,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6459,7 +6518,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6492,7 +6551,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6518,7 +6577,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6534,11 +6593,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6582,7 +6641,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6634,7 +6693,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6654,7 +6713,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6681,11 +6740,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6817,7 +6876,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6840,7 +6899,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6861,7 +6920,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6980,19 +7039,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -7004,17 +7063,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7034,24 +7094,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7356,8 +7428,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7373,23 +7446,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7442,7 +7521,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7450,11 +7529,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7482,7 +7561,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7490,7 +7569,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7576,13 +7655,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7591,13 +7684,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7639,7 +7732,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7797,7 +7890,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7809,7 +7902,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7828,10 +7921,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7966,7 +8073,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7974,7 +8081,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -8011,8 +8118,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -168,7 +168,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -593,7 +593,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -682,7 +682,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -803,15 +803,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -892,6 +892,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -951,7 +955,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -1002,7 +1006,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -1018,7 +1022,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1045,7 +1049,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1105,11 +1109,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1156,7 +1160,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1166,7 +1170,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1247,7 +1251,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1260,7 +1264,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1297,7 +1301,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1412,8 +1416,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1454,7 +1458,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1491,12 +1495,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1526,15 +1530,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1566,7 +1570,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1582,16 +1586,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1767,7 +1771,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1783,7 +1787,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1812,11 +1816,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1874,7 +1878,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1918,7 +1922,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1961,39 +1965,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2019,10 +2026,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2129,7 +2136,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2170,7 +2177,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -2182,7 +2189,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2249,11 +2256,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2265,7 +2272,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2297,7 +2304,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2325,7 +2332,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2378,17 +2385,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2396,7 +2403,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2445,20 +2452,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2486,7 +2493,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2499,7 +2506,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2553,12 +2560,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2607,7 +2614,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2642,7 +2649,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2671,7 +2678,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2739,11 +2746,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2806,7 +2813,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2814,7 +2821,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2854,7 +2861,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2874,7 +2881,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2886,7 +2893,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2918,7 +2925,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3092,11 +3099,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3104,25 +3111,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3142,7 +3149,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3152,7 +3159,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3208,7 +3215,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3342,7 +3349,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3386,12 +3393,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3509,11 +3516,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3653,11 +3660,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3825,7 +3832,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3887,11 +3894,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3910,7 +3917,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3972,6 +3979,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -4080,12 +4091,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4140,8 +4151,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4163,7 +4174,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4227,18 +4240,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4346,7 +4359,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4358,7 +4371,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4543,7 +4556,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4628,7 +4641,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4647,6 +4660,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4691,7 +4708,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4700,7 +4717,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4727,6 +4744,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4759,12 +4801,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4802,37 +4844,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4844,16 +4886,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4876,11 +4918,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4974,7 +5016,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5010,7 +5052,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5047,16 +5089,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5161,6 +5203,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5177,7 +5223,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5230,7 +5276,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5264,7 +5310,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5352,7 +5398,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5441,7 +5487,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5475,15 +5521,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5574,11 +5620,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5699,7 +5745,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5719,7 +5765,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5763,6 +5809,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5780,11 +5830,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5792,7 +5842,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5844,7 +5894,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5886,7 +5936,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5914,7 +5964,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5926,7 +5976,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5958,7 +6008,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6124,7 +6174,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6218,17 +6268,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6268,7 +6322,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6304,11 +6358,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6329,7 +6388,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6361,7 +6420,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6383,7 +6442,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6407,7 +6466,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6423,12 +6482,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6469,7 +6528,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6484,7 +6543,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6497,7 +6556,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6530,7 +6589,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6556,7 +6615,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6572,11 +6631,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6620,7 +6679,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6672,7 +6731,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6692,7 +6751,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6719,11 +6778,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6855,7 +6914,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6878,7 +6937,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6899,7 +6958,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7018,19 +7077,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -7042,17 +7101,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7072,24 +7132,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7394,8 +7466,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7411,23 +7484,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7480,7 +7559,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7488,11 +7567,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7520,7 +7599,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7528,7 +7607,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7614,13 +7693,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7629,13 +7722,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7677,7 +7770,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7835,7 +7928,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7847,7 +7940,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7866,10 +7959,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -8004,7 +8111,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8012,7 +8119,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -8049,8 +8156,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -109,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -627,6 +627,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -686,7 +690,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -737,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -780,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -840,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1226,12 +1230,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1261,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1301,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1502,7 +1506,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,11 +1551,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1609,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1653,7 +1657,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1696,39 +1700,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1754,10 +1761,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1864,7 +1871,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1912,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1917,7 +1924,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1984,11 +1991,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2000,7 +2007,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2039,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2060,7 +2067,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,17 +2120,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2131,7 +2138,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2180,20 +2187,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2221,7 +2228,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2241,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2295,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2349,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2384,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2413,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,11 +2481,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2541,7 +2548,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2556,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2589,7 +2596,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2609,7 +2616,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2621,7 +2628,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2653,7 +2660,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2827,11 +2834,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2846,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2884,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2894,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2943,7 +2950,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3077,7 +3084,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3128,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3251,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3388,11 +3395,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3560,7 +3567,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3629,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3652,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3707,6 +3714,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3815,12 +3826,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3875,8 +3886,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3898,7 +3909,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3962,18 +3975,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4081,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4093,7 +4106,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4278,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4363,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4382,6 +4395,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4426,7 +4443,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4452,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4462,6 +4479,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4494,12 +4536,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4537,37 +4579,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4579,16 +4621,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4653,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4751,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4824,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4896,6 +4938,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4912,7 +4958,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4965,7 +5011,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -4999,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5133,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5309,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5434,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5454,7 +5500,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5498,6 +5544,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5515,11 +5565,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5577,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5579,7 +5629,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5621,7 +5671,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5699,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5711,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5743,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5909,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5953,17 +6003,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6003,7 +6057,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6039,11 +6093,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6123,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6155,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6177,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6201,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6217,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6263,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6278,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6232,7 +6291,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6265,7 +6324,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6350,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6366,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6355,7 +6414,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6407,7 +6466,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6427,7 +6486,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6454,11 +6513,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6590,7 +6649,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6613,7 +6672,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6634,7 +6693,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6812,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,17 +6836,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6807,24 +6867,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7129,8 +7201,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7146,23 +7219,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7215,7 +7294,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7302,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7334,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7342,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7349,13 +7428,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7457,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7505,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7570,7 +7663,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7582,7 +7675,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7601,10 +7694,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7739,7 +7846,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7747,7 +7854,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7784,7 +7891,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -165,7 +165,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -270,7 +270,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -580,7 +580,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -668,7 +668,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
@@ -688,7 +688,7 @@ msgstr "%s não é um diretório"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -727,7 +727,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -752,7 +752,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -787,7 +787,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -800,15 +800,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
@@ -895,6 +895,11 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+#, fuzzy
+msgid "Add instance placement rules"
+msgstr "Editar arquivos de metadados do container"
+
 #: lxc/cluster_group.go:724
 msgid "Add member to group"
 msgstr ""
@@ -953,7 +958,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
@@ -1007,7 +1012,7 @@ msgstr "Nome do alias ausente"
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1053,7 +1058,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
@@ -1118,11 +1123,11 @@ msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
@@ -1170,7 +1175,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1180,7 +1185,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
@@ -1261,7 +1266,7 @@ msgstr "CRIADO EM"
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
@@ -1275,7 +1280,7 @@ msgstr "Em cache: %s"
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
@@ -1313,7 +1318,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1430,8 +1435,8 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1472,7 +1477,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1518,12 +1523,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1554,15 +1559,15 @@ msgstr "Ignorar o estado do container"
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1595,7 +1600,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
@@ -1611,17 +1616,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
@@ -1816,7 +1821,7 @@ msgstr "Criar novas redes"
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr "Criar perfis"
 
@@ -1832,7 +1837,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1862,11 +1867,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1929,7 +1934,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1981,7 +1986,7 @@ msgstr "Criar novas redes"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -2025,39 +2030,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2083,10 +2091,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2197,7 +2205,7 @@ msgstr "Em cache: %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
@@ -2241,7 +2249,7 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Criar projetos"
@@ -2255,7 +2263,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr "Criar projetos"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
@@ -2329,11 +2337,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -2348,7 +2356,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Edit instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -2387,7 +2395,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
@@ -2418,7 +2426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2471,17 +2479,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2489,7 +2497,7 @@ msgstr "Editar propriedades da imagem"
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2539,20 +2547,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2580,7 +2588,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2593,7 +2601,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2647,12 +2655,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
@@ -2701,7 +2709,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -2736,7 +2744,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2765,7 +2773,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2834,11 +2842,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2901,7 +2909,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -2910,7 +2918,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -2956,7 +2964,7 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2978,7 +2986,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2992,7 +3000,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3031,7 +3039,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3208,11 +3216,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3220,25 +3228,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3259,7 +3267,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3269,7 +3277,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3325,7 +3333,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3461,7 +3469,7 @@ msgstr "Editar arquivos no container"
 msgid "IsSM: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3505,12 +3513,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3634,11 +3642,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3781,11 +3789,11 @@ msgstr "Criar projetos"
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3955,7 +3963,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -4022,11 +4030,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4045,7 +4053,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -4123,6 +4131,11 @@ msgstr "Criar novas redes"
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Editar arquivos no container"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
+msgstr "Nome de membro do cluster"
 
 #: lxc/profile.go:34 lxc/profile.go:35
 msgid "Manage profiles"
@@ -4236,12 +4249,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4304,8 +4317,8 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4329,7 +4342,9 @@ msgstr "Nome de membro do cluster"
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4397,18 +4412,18 @@ msgstr "Nome de membro do cluster"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4519,7 +4534,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4531,7 +4546,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4716,7 +4731,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4801,7 +4816,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4820,6 +4835,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4864,7 +4883,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4873,7 +4892,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4900,6 +4919,32 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, fuzzy, c-format
+msgid "Placement %s overridden for %s"
+msgstr "Dispositivo %s sobreposto em %s"
+
+#: lxc/config_placement.go:407
+#, fuzzy, c-format
+msgid "Placement %s removed from %s"
+msgstr "Dispositivo %s removido de %s"
+
+#: lxc/config_placement.go:215
+#, fuzzy, c-format
+msgid "Placement rule %s added to %s"
+msgstr "Dispositivo %s adicionado a %s"
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+#, fuzzy
+msgid "Placement rule doesn't exist"
+msgstr "Alias %s não existe"
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4933,12 +4978,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4976,37 +5021,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -5021,17 +5066,17 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
@@ -5055,11 +5100,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5153,7 +5198,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5190,7 +5235,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5229,16 +5274,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5352,6 +5397,11 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+#, fuzzy
+msgid "Remove instance placement rules"
+msgstr "Editar arquivos de metadados do container"
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5371,7 +5421,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
@@ -5429,7 +5479,7 @@ msgstr "Criar novas redes"
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5463,7 +5513,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5561,7 +5611,7 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5650,7 +5700,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -5687,17 +5737,17 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5794,11 +5844,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5926,7 +5976,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5948,7 +5998,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5995,6 +6045,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "Adicionar dispositivos aos containers ou perfis"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -6013,11 +6068,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -6027,7 +6082,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6089,7 +6144,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6134,7 +6189,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6165,7 +6220,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6177,7 +6232,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -6209,7 +6264,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6376,7 +6431,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6474,17 +6529,22 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+#, fuzzy
+msgid "The profile placement doesn't exist"
+msgstr "Alias %s não existe"
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
@@ -6524,7 +6584,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6560,11 +6620,17 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+#, fuzzy
+msgid "The rule already exists"
+msgstr "O dispositivo já existe: %s"
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6585,7 +6651,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
@@ -6619,7 +6685,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6641,7 +6707,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6665,7 +6731,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6681,12 +6747,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6729,7 +6795,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6744,7 +6810,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6757,7 +6823,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6791,7 +6857,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6817,7 +6883,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6837,12 +6903,12 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6896,7 +6962,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6956,7 +7022,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6977,7 +7043,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7005,11 +7071,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7142,7 +7208,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7167,7 +7233,7 @@ msgstr "Criar perfis"
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7191,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7328,21 +7394,21 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -7355,17 +7421,18 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7385,26 +7452,38 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7744,8 +7823,9 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
@@ -7762,24 +7842,30 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7841,7 +7927,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7849,11 +7935,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7885,7 +7971,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7893,7 +7979,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7979,13 +8065,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7994,13 +8094,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8042,7 +8142,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8200,7 +8300,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8212,7 +8312,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8231,10 +8331,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -8369,7 +8483,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8377,7 +8491,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -8414,8 +8528,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -169,7 +169,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -274,7 +274,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -588,7 +588,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -677,7 +677,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -697,7 +697,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr "(пусто)"
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -803,16 +803,16 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -898,6 +898,11 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+#, fuzzy
+msgid "Add instance placement rules"
+msgstr "Копирование образа: %s"
+
 #: lxc/cluster_group.go:724
 msgid "Add member to group"
 msgstr ""
@@ -956,7 +961,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -1008,7 +1013,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
@@ -1026,7 +1031,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1054,7 +1059,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1115,11 +1120,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
@@ -1167,7 +1172,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1177,7 +1182,7 @@ msgstr "Имя контейнера: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1260,7 +1265,7 @@ msgstr "СОЗДАН"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1273,7 +1278,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1310,7 +1315,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1430,8 +1435,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1472,7 +1477,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1509,12 +1514,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1545,15 +1550,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1585,7 +1590,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1602,17 +1607,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
@@ -1805,7 +1810,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1823,7 +1828,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1853,11 +1858,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1917,7 +1922,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1967,7 +1972,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -2012,39 +2017,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -2070,10 +2078,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2182,7 +2190,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2227,7 +2235,7 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Копирование образа: %s"
@@ -2242,7 +2250,7 @@ msgstr "Копирование образа: %s"
 msgid "Display network zones from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
@@ -2311,11 +2319,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2330,7 +2338,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2366,7 +2374,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2395,7 +2403,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2448,17 +2456,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2466,7 +2474,7 @@ msgstr "Копирование образа: %s"
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2519,21 +2527,21 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 #, fuzzy
 msgid "Export and download images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2565,7 +2573,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
@@ -2578,7 +2586,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2632,12 +2640,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
@@ -2686,7 +2694,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -2721,7 +2729,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2750,7 +2758,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2819,11 +2827,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2886,7 +2894,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2895,7 +2903,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2940,7 +2948,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2963,7 +2971,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2976,7 +2984,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3013,7 +3021,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3190,11 +3198,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3202,25 +3210,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3241,7 +3249,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3251,7 +3259,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
@@ -3311,7 +3319,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
@@ -3448,7 +3456,7 @@ msgstr "Имя контейнера: %s"
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3492,12 +3500,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3624,11 +3632,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3773,11 +3781,11 @@ msgstr "Копирование образа: %s"
 msgid "List permissions"
 msgstr "Псевдонимы:"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3951,7 +3959,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -4018,11 +4026,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4041,7 +4049,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4117,6 +4125,11 @@ msgstr "Копирование образа: %s"
 #: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
+msgstr "Копирование образа: %s"
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+#, fuzzy
+msgid "Manage placement rules"
 msgstr "Копирование образа: %s"
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -4235,12 +4248,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4302,8 +4315,8 @@ msgstr "Копирование образа: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
@@ -4328,7 +4341,9 @@ msgstr "Имя контейнера: %s"
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4396,19 +4411,19 @@ msgstr "Имя контейнера: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4521,7 +4536,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4533,7 +4548,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4720,7 +4735,7 @@ msgstr " Использование сети:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4807,7 +4822,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4826,6 +4841,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4870,7 +4889,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4879,7 +4898,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4906,6 +4925,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, fuzzy, c-format
+msgid "Placement rule %s added to %s"
+msgstr "Копирование образа: %s"
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4939,12 +4983,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4982,37 +5026,37 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -5024,16 +5068,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -5056,11 +5100,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5154,7 +5198,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5190,7 +5234,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5230,17 +5274,17 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5351,6 +5395,11 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+#, fuzzy
+msgid "Remove instance placement rules"
+msgstr "Невозможно добавить имя контейнера в список"
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5368,7 +5417,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5425,7 +5474,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5461,7 +5510,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5556,7 +5605,7 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5645,7 +5694,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5681,15 +5730,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5785,11 +5834,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5916,7 +5965,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5939,7 +5988,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5985,6 +6034,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+#, fuzzy
+msgid "Show full placement rule configuration"
+msgstr "Копирование образа: %s"
+
 #: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
@@ -6003,11 +6057,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6017,7 +6071,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -6076,7 +6130,7 @@ msgstr "Копирование образа: %s"
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -6121,7 +6175,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6152,7 +6206,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6164,7 +6218,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
@@ -6197,7 +6251,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6367,7 +6421,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6461,17 +6515,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
@@ -6511,7 +6569,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
@@ -6547,11 +6605,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6572,7 +6635,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
@@ -6605,7 +6668,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6627,7 +6690,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6651,7 +6714,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6667,12 +6730,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6714,7 +6777,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6729,7 +6792,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6742,7 +6805,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6775,7 +6838,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6801,7 +6864,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6819,11 +6882,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6875,7 +6938,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6934,7 +6997,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6957,7 +7020,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6985,11 +7048,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7122,7 +7185,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7153,7 +7216,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7194,7 +7257,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7409,7 +7472,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7417,7 +7480,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7425,7 +7488,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7433,7 +7496,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7457,7 +7520,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7465,7 +7528,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7473,9 +7536,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7515,7 +7579,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7523,7 +7587,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7531,7 +7595,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7539,7 +7603,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7547,9 +7611,29 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/config_placement.go:117
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/config_placement.go:231
+#, fuzzy
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -8129,8 +8213,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8162,7 +8247,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8170,7 +8255,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8178,7 +8263,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8186,7 +8271,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8194,7 +8279,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8299,7 +8390,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8315,7 +8406,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8323,7 +8414,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8371,7 +8462,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -8379,7 +8470,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -8465,13 +8556,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8480,13 +8585,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8528,7 +8633,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8686,7 +8791,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8698,7 +8803,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8717,10 +8822,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -8855,7 +8974,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8863,7 +8982,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -8900,8 +9019,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "да"
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -113,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -631,6 +631,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -690,7 +694,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +761,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -784,7 +788,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -844,11 +848,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +909,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +990,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +1003,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1040,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1155,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1230,12 +1234,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1265,15 +1269,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1305,7 +1309,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,16 +1325,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1506,7 +1510,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1526,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,11 +1555,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1613,7 +1617,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1657,7 +1661,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1700,39 +1704,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1758,10 +1765,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1868,7 +1875,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1916,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1921,7 +1928,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1988,11 +1995,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2004,7 +2011,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2043,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2071,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,17 +2124,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2135,7 +2142,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2184,20 +2191,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2225,7 +2232,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2245,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2299,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2353,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2388,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2417,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,11 +2485,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2545,7 +2552,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2560,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2593,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2613,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2625,7 +2632,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2657,7 +2664,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2831,11 +2838,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2850,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2888,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2898,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2947,7 +2954,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3081,7 +3088,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3132,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3255,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3392,11 +3399,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3564,7 +3571,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3633,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3656,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3711,6 +3718,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3819,12 +3830,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3879,8 +3890,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3902,7 +3913,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3966,18 +3979,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4085,7 +4098,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4097,7 +4110,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4282,7 +4295,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4367,7 +4380,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4386,6 +4399,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4430,7 +4447,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4456,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4466,6 +4483,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4498,12 +4540,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4541,37 +4583,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4583,16 +4625,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4657,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4755,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4828,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4900,6 +4942,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4916,7 +4962,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4969,7 +5015,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,7 +5049,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5137,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5226,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5260,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5313,11 +5359,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5438,7 +5484,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5458,7 +5504,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5502,6 +5548,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5519,11 +5569,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5581,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5583,7 +5633,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,7 +5675,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5703,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5715,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5747,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5913,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5957,17 +6007,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6007,7 +6061,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6043,11 +6097,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6127,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6159,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6181,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6205,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6221,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6267,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6282,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6236,7 +6295,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6269,7 +6328,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6354,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6370,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6359,7 +6418,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6411,7 +6470,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6431,7 +6490,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,11 +6517,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6594,7 +6653,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6617,7 +6676,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6638,7 +6697,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6816,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,17 +6840,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6811,24 +6871,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7133,8 +7205,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7150,23 +7223,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7219,7 +7298,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7306,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7338,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7346,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7353,13 +7432,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7461,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7416,7 +7509,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7574,7 +7667,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7586,7 +7679,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7605,10 +7698,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7743,7 +7850,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7751,7 +7858,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7788,7 +7895,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -113,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -631,6 +631,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -690,7 +694,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +761,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -784,7 +788,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -844,11 +848,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +909,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +990,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +1003,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1040,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1155,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1230,12 +1234,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1265,15 +1269,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1305,7 +1309,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,16 +1325,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1506,7 +1510,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1526,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,11 +1555,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1613,7 +1617,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1657,7 +1661,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1700,39 +1704,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1758,10 +1765,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1868,7 +1875,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1916,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1921,7 +1928,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1988,11 +1995,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2004,7 +2011,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2043,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2071,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,17 +2124,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2135,7 +2142,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2184,20 +2191,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2225,7 +2232,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2245,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2299,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2353,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2388,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2417,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,11 +2485,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2545,7 +2552,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2560,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2593,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2613,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2625,7 +2632,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2657,7 +2664,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2831,11 +2838,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2850,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2888,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2898,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2947,7 +2954,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3081,7 +3088,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3132,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3255,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3392,11 +3399,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3564,7 +3571,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3633,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3656,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3711,6 +3718,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3819,12 +3830,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3879,8 +3890,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3902,7 +3913,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3966,18 +3979,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4085,7 +4098,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4097,7 +4110,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4282,7 +4295,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4367,7 +4380,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4386,6 +4399,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4430,7 +4447,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4456,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4466,6 +4483,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4498,12 +4540,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4541,37 +4583,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4583,16 +4625,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4657,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4755,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4828,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4900,6 +4942,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4916,7 +4962,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4969,7 +5015,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,7 +5049,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5137,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5226,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5260,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5313,11 +5359,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5438,7 +5484,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5458,7 +5504,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5502,6 +5548,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5519,11 +5569,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5581,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5583,7 +5633,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,7 +5675,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5703,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5715,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5747,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5913,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5957,17 +6007,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6007,7 +6061,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6043,11 +6097,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6127,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6159,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6181,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6205,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6221,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6267,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6282,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6236,7 +6295,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6269,7 +6328,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6354,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6370,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6359,7 +6418,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6411,7 +6470,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6431,7 +6490,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,11 +6517,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6594,7 +6653,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6617,7 +6676,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6638,7 +6697,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6816,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,17 +6840,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6811,24 +6871,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7133,8 +7205,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7150,23 +7223,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7219,7 +7298,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7306,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7338,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7346,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7353,13 +7432,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7461,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7416,7 +7509,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7574,7 +7667,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7586,7 +7679,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7605,10 +7698,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7743,7 +7850,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7751,7 +7858,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7788,7 +7895,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -109,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -627,6 +627,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -686,7 +690,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -737,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -780,7 +784,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -840,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1226,12 +1230,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1261,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1301,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1502,7 +1506,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,11 +1551,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1609,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1653,7 +1657,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1696,39 +1700,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1754,10 +1761,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1864,7 +1871,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1912,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1917,7 +1924,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1984,11 +1991,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2000,7 +2007,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2039,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2060,7 +2067,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,17 +2120,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2131,7 +2138,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2180,20 +2187,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2221,7 +2228,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2241,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2295,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2349,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2384,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2413,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,11 +2481,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2541,7 +2548,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2556,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2589,7 +2596,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2609,7 +2616,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2621,7 +2628,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2653,7 +2660,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2827,11 +2834,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2846,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2877,7 +2884,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2894,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2943,7 +2950,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3077,7 +3084,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3128,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3251,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3388,11 +3395,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3560,7 +3567,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3629,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3652,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3707,6 +3714,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3815,12 +3826,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3875,8 +3886,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3898,7 +3909,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3962,18 +3975,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4081,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4093,7 +4106,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4278,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4363,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4382,6 +4395,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4426,7 +4443,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4452,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4462,6 +4479,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4494,12 +4536,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4537,37 +4579,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4579,16 +4621,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4653,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4751,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4787,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4824,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4896,6 +4938,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4912,7 +4958,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4965,7 +5011,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -4999,7 +5045,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5133,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5222,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5256,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5309,11 +5355,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5434,7 +5480,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5454,7 +5500,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5498,6 +5544,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5515,11 +5565,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5577,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5579,7 +5629,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5621,7 +5671,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5699,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5711,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5743,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5909,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5953,17 +6003,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6003,7 +6057,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6039,11 +6093,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6123,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6155,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6177,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6201,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6217,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6263,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6278,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6232,7 +6291,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6265,7 +6324,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6350,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6366,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6355,7 +6414,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6407,7 +6466,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6427,7 +6486,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6454,11 +6513,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6590,7 +6649,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6613,7 +6672,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6634,7 +6693,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6812,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,17 +6836,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6807,24 +6867,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7129,8 +7201,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7146,23 +7219,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7215,7 +7294,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7302,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7334,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7342,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7349,13 +7428,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7457,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7505,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7570,7 +7663,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7582,7 +7675,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7601,10 +7694,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7739,7 +7846,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7747,7 +7854,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7784,7 +7891,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -113,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -631,6 +631,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -690,7 +694,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +761,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -784,7 +788,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -844,11 +848,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +909,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +990,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +1003,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1040,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1155,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1230,12 +1234,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1265,15 +1269,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1305,7 +1309,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,16 +1325,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1506,7 +1510,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1522,7 +1526,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,11 +1555,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1613,7 +1617,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1657,7 +1661,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1700,39 +1704,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1758,10 +1765,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1868,7 +1875,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1916,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1921,7 +1928,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1988,11 +1995,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2004,7 +2011,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2043,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2071,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,17 +2124,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2135,7 +2142,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2184,20 +2191,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2225,7 +2232,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2245,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2299,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2353,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2388,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2417,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,11 +2485,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2545,7 +2552,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2560,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2593,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2613,7 +2620,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2625,7 +2632,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2657,7 +2664,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2831,11 +2838,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2850,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2881,7 +2888,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2898,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2947,7 +2954,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3081,7 +3088,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3132,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3255,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3392,11 +3399,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3564,7 +3571,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3633,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3656,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3711,6 +3718,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3819,12 +3830,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3879,8 +3890,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3902,7 +3913,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3966,18 +3979,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4085,7 +4098,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4097,7 +4110,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4282,7 +4295,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4367,7 +4380,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4386,6 +4399,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4430,7 +4447,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4456,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4466,6 +4483,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4498,12 +4540,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4541,37 +4583,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4583,16 +4625,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4657,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4755,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4791,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4828,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4900,6 +4942,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4916,7 +4962,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4969,7 +5015,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5003,7 +5049,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5137,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5226,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5260,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5313,11 +5359,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5438,7 +5484,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5458,7 +5504,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5502,6 +5548,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5519,11 +5569,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5581,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5583,7 +5633,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5625,7 +5675,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5703,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5715,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5747,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5913,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5957,17 +6007,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6007,7 +6061,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6043,11 +6097,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6127,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6159,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6181,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6205,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6221,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6267,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6282,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6236,7 +6295,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6269,7 +6328,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6354,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6370,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6359,7 +6418,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6411,7 +6470,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6431,7 +6490,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,11 +6517,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6594,7 +6653,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6617,7 +6676,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6638,7 +6697,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6816,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,17 +6840,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6811,24 +6871,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7133,8 +7205,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7150,23 +7223,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7219,7 +7298,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7306,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7338,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7346,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7353,13 +7432,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7461,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7416,7 +7509,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7574,7 +7667,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7586,7 +7679,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7605,10 +7698,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7743,7 +7850,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7751,7 +7858,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7788,7 +7895,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -168,7 +168,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -510,7 +510,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -581,7 +581,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr "%s 不是一个目录"
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -689,7 +689,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -702,15 +702,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -791,6 +791,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -850,7 +854,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -901,7 +905,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -917,7 +921,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -944,7 +948,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1004,11 +1008,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1055,7 +1059,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1159,7 +1163,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1196,7 +1200,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1311,8 +1315,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1353,7 +1357,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1390,12 +1394,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1425,15 +1429,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1465,7 +1469,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1481,16 +1485,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1666,7 +1670,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1682,7 +1686,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1711,11 +1715,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1773,7 +1777,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1817,7 +1821,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1860,39 +1864,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1918,10 +1925,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -2028,7 +2035,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2069,7 +2076,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -2081,7 +2088,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2148,11 +2155,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2164,7 +2171,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2196,7 +2203,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2277,17 +2284,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2295,7 +2302,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2344,20 +2351,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2385,7 +2392,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2398,7 +2405,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2452,12 +2459,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2506,7 +2513,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2541,7 +2548,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2570,7 +2577,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2638,11 +2645,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2705,7 +2712,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2713,7 +2720,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2753,7 +2760,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2773,7 +2780,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2785,7 +2792,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2817,7 +2824,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2991,11 +2998,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3003,25 +3010,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3041,7 +3048,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3051,7 +3058,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3107,7 +3114,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3241,7 +3248,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3285,12 +3292,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3408,11 +3415,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3552,11 +3559,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3724,7 +3731,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3786,11 +3793,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3809,7 +3816,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3871,6 +3878,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3979,12 +3990,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4039,8 +4050,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -4062,7 +4073,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -4126,18 +4139,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4245,7 +4258,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4257,7 +4270,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4442,7 +4455,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4527,7 +4540,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4546,6 +4559,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4590,7 +4607,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4599,7 +4616,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4626,6 +4643,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4658,12 +4700,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4701,37 +4743,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4743,16 +4785,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4775,11 +4817,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4873,7 +4915,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4909,7 +4951,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4946,16 +4988,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5060,6 +5102,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -5076,7 +5122,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -5129,7 +5175,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5163,7 +5209,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5251,7 +5297,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5340,7 +5386,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5374,15 +5420,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5473,11 +5519,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5598,7 +5644,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5618,7 +5664,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5662,6 +5708,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5679,11 +5729,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5691,7 +5741,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5743,7 +5793,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5785,7 +5835,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5813,7 +5863,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5825,7 +5875,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5857,7 +5907,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6023,7 +6073,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6117,17 +6167,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6167,7 +6221,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6203,11 +6257,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6228,7 +6287,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6260,7 +6319,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6282,7 +6341,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6306,7 +6365,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6322,12 +6381,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6368,7 +6427,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6383,7 +6442,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6396,7 +6455,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6429,7 +6488,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6455,7 +6514,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6471,11 +6530,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6519,7 +6578,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6571,7 +6630,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6591,7 +6650,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6618,11 +6677,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6754,7 +6813,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6777,7 +6836,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6798,7 +6857,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6917,19 +6976,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6941,17 +7000,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6971,24 +7031,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7293,8 +7365,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7310,23 +7383,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7379,7 +7458,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7387,11 +7466,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7419,7 +7498,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7427,7 +7506,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7513,13 +7592,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7528,13 +7621,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7576,7 +7669,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7734,7 +7827,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7746,7 +7839,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7765,10 +7858,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7903,7 +8010,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7911,7 +8018,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7948,8 +8055,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-03-31 08:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1247
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -112,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:122
+#: lxc/config.go:126
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:518
+#: lxc/profile.go:522
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/profile.go:252
+#: lxc/cluster_group.go:149 lxc/profile.go:256
 msgid "(none)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:501 lxc/config.go:821
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:174 lxc/config.go:451 lxc/config.go:640 lxc/config.go:847
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:396
+#: lxc/config.go:400
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -630,6 +630,10 @@ msgstr ""
 
 #: lxc/config_device.go:78 lxc/config_device.go:79
 msgid "Add instance devices"
+msgstr ""
+
+#: lxc/config_placement.go:112 lxc/config_placement.go:114
+msgid "Add instance placement rules"
 msgstr ""
 
 #: lxc/cluster_group.go:724
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:113 lxc/profile.go:114
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +760,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:184 lxc/profile.go:185
+#: lxc/profile.go:188 lxc/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -843,11 +847,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:706 lxc/config.go:1104
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:110 lxc/config.go:402 lxc/config.go:558 lxc/config.go:780
+#: lxc/config.go:913 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:728
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1229,12 +1233,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:285
+#: lxc/config.go:360 lxc/config.go:1347 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
+#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:604
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
 #: lxc/storage_volume.go:1197
@@ -1264,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:275 lxc/profile.go:276
+#: lxc/profile.go:279 lxc/profile.go:280
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:282
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:357 lxc/profile.go:358
+#: lxc/profile.go:361 lxc/profile.go:362
 msgid "Create profiles"
 msgstr ""
 
@@ -1521,7 +1525,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,11 +1554,11 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
+#: lxc/profile.go:754 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
@@ -1612,7 +1616,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1656,7 +1660,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:439 lxc/profile.go:440
+#: lxc/profile.go:443 lxc/profile.go:444
 msgid "Delete profiles"
 msgstr ""
 
@@ -1699,39 +1703,42 @@ msgstr ""
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:104 lxc/config.go:397
+#: lxc/config.go:546 lxc/config.go:776 lxc/config.go:910 lxc/config.go:963
+#: lxc/config.go:1003 lxc/config.go:1058 lxc/config.go:1149 lxc/config.go:1180
+#: lxc/config.go:1234 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
-#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
-#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
-#: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
-#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
-#: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
-#: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
-#: lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845
-#: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
+#: lxc/config_placement.go:75 lxc/config_placement.go:114
+#: lxc/config_placement.go:233 lxc/config_placement.go:328
+#: lxc/config_placement.go:429 lxc/config_template.go:28
+#: lxc/config_template.go:68 lxc/config_template.go:119
+#: lxc/config_template.go:173 lxc/config_template.go:273
+#: lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87
+#: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
+#: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
+#: lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321
+#: lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226
+#: lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397
+#: lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092
+#: lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673
+#: lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006
+#: lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254
+#: lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
 #: lxc/network_forward.go:412 lxc/network_forward.go:497
@@ -1757,10 +1764,10 @@ msgstr ""
 #: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
 #: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
-#: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
-#: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/profile.go:35 lxc/profile.go:114 lxc/profile.go:189 lxc/profile.go:280
+#: lxc/profile.go:362 lxc/profile.go:444 lxc/profile.go:502 lxc/profile.go:638
+#: lxc/profile.go:714 lxc/profile.go:871 lxc/profile.go:959 lxc/profile.go:1019
+#: lxc/profile.go:1108 lxc/profile.go:1172 lxc/project.go:31 lxc/project.go:97
 #: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
 #: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
@@ -1867,7 +1874,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1915,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/profile.go:728
+#: lxc/profile.go:732
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1987,11 +1994,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1233 lxc/config.go:1234
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2003,7 +2010,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:99 lxc/config.go:100
+#: lxc/config.go:103 lxc/config.go:104
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2035,7 +2042,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:497 lxc/profile.go:498
+#: lxc/profile.go:501 lxc/profile.go:502
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2063,7 +2070,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:770
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,17 +2123,17 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:666 lxc/config.go:698 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
+#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1086
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:660 lxc/config.go:692
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 #: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/profile.go:1080 lxc/project.go:720 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
 #: lxc/storage_volume.go:2211
 #, c-format
@@ -2183,20 +2190,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2224,7 +2231,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2244,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2298,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2352,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2387,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,11 +2484,11 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/operation.go:109 lxc/profile.go:731 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1626 lxc/warning.go:94
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:1002 lxc/config.go:1003
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2559,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2592,7 +2599,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:639
+#: lxc/profile.go:643
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -2612,7 +2619,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:397
+#: lxc/config.go:401
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2624,7 +2631,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:392 lxc/config.go:393
+#: lxc/config.go:396 lxc/config.go:397
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2656,7 +2663,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:633 lxc/profile.go:634
+#: lxc/profile.go:637 lxc/profile.go:638
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2830,11 +2837,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2849,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2880,7 +2887,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2897,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2946,7 +2953,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1028 lxc/config.go:1086 lxc/config.go:1205 lxc/config.go:1297
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3080,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3391,11 +3398,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:713
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:710
+#: lxc/profile.go:714
 msgid ""
 "List profiles\n"
 "\n"
@@ -3563,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:962 lxc/config.go:963
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3710,6 +3717,10 @@ msgstr ""
 
 #: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
+msgstr ""
+
+#: lxc/config_placement.go:74 lxc/config_placement.go:75
+msgid "Manage placement rules"
 msgstr ""
 
 #: lxc/profile.go:34 lxc/profile.go:35
@@ -3818,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3878,8 +3889,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:146 lxc/profile.go:227
-#: lxc/profile.go:903 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:150 lxc/profile.go:231
+#: lxc/profile.go:907 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
@@ -3901,7 +3912,9 @@ msgstr ""
 
 #: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
 #: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
-#: lxc/config_device.go:804
+#: lxc/config_device.go:804 lxc/config_placement.go:154
+#: lxc/config_placement.go:258 lxc/config_placement.go:352
+#: lxc/config_placement.go:453
 msgid "Missing name"
 msgstr ""
 
@@ -3965,18 +3978,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:472 lxc/profile.go:554 lxc/profile.go:672 lxc/profile.go:987
-#: lxc/profile.go:1055 lxc/profile.go:1136
+#: lxc/profile.go:476 lxc/profile.go:558 lxc/profile.go:676 lxc/profile.go:991
+#: lxc/profile.go:1059 lxc/profile.go:1140
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/profile.go:413 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
 #: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
 #: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:315
+#: lxc/profile.go:319
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4084,7 +4097,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4096,7 +4109,7 @@ msgstr ""
 #: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
+#: lxc/network_zone.go:845 lxc/profile.go:752 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
@@ -4281,7 +4294,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4366,7 +4379,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4385,6 +4398,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_placement.go:232 lxc/config_placement.go:233
+msgid "Override profile inherited placement rules"
 msgstr ""
 
 #: lxc/main.go:96
@@ -4429,7 +4446,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:753
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4455,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4465,6 +4482,31 @@ msgstr ""
 
 #: lxc/copy.go:65
 msgid "Perform an incremental copy"
+msgstr ""
+
+#: lxc/config_placement.go:304
+#, c-format
+msgid "Placement %s overridden for %s"
+msgstr ""
+
+#: lxc/config_placement.go:407
+#, c-format
+msgid "Placement %s removed from %s"
+msgstr ""
+
+#: lxc/config_placement.go:215
+#, c-format
+msgid "Placement rule %s added to %s"
+msgstr ""
+
+#: lxc/config_placement.go:365 lxc/config_placement.go:386
+msgid "Placement rule doesn't exist"
+msgstr ""
+
+#: lxc/config_placement.go:389
+msgid ""
+"Placement rule from profile(s) cannot be removed from individual instance. "
+"Override rule or modify profile instead"
 msgstr ""
 
 #: lxc/remote.go:195
@@ -4497,12 +4539,12 @@ msgid "Press ctrl+c to finish"
 msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
-#: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/cluster_group.go:398 lxc/config.go:286 lxc/config.go:361
+#: lxc/config.go:1348 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:605
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
 #: lxc/storage_volume.go:1198
@@ -4540,37 +4582,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:423
+#: lxc/profile.go:427
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:482
+#: lxc/profile.go:486
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:913
+#: lxc/profile.go:917
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:938
+#: lxc/profile.go:942
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:997
+#: lxc/profile.go:1001
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4582,16 +4624,16 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:260
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4656,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4754,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4790,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4827,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4899,6 +4941,10 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
+#: lxc/config_placement.go:327 lxc/config_placement.go:328
+msgid "Remove instance placement rules"
+msgstr ""
+
 #: lxc/cluster_group.go:521
 msgid "Remove member from group"
 msgstr ""
@@ -4915,7 +4961,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:866 lxc/profile.go:867
+#: lxc/profile.go:870 lxc/profile.go:871
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4968,7 +5014,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:954 lxc/profile.go:955
+#: lxc/profile.go:958 lxc/profile.go:959
 msgid "Rename profiles"
 msgstr ""
 
@@ -5002,7 +5048,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1039
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5136,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5225,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1057 lxc/config.go:1058
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5259,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:545
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:546
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5312,11 +5358,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1018
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1015
+#: lxc/profile.go:1019
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5437,7 +5483,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1022
+#: lxc/profile.go:1026
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -5457,7 +5503,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:559
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5501,6 +5547,10 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
+#: lxc/config_placement.go:428 lxc/config_placement.go:429
+msgid "Show full placement rule configuration"
+msgstr ""
+
 #: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
@@ -5518,11 +5568,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1179 lxc/config.go:1180
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5580,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:775 lxc/config.go:776
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5582,7 +5632,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1103 lxc/profile.go:1104
+#: lxc/profile.go:1107 lxc/profile.go:1108
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5624,7 +5674,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:779
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5702,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5714,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5746,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5912,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -5956,17 +6006,21 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
+#: lxc/config_placement.go:275
+msgid "The profile placement doesn't exist"
+msgstr ""
+
 #: lxc/cluster.go:376
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:483
+#: lxc/config.go:487
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:459
+#: lxc/config.go:463
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6006,7 +6060,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:685
+#: lxc/profile.go:689
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -6042,11 +6096,16 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/config_placement.go:177 lxc/config_placement.go:198
+#: lxc/config_placement.go:270
+msgid "The rule already exists"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6126,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:678
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6158,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6180,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:310 lxc/config.go:507 lxc/config.go:727 lxc/config.go:827
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6204,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6220,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6266,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6281,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6235,7 +6294,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/network_zone.go:163 lxc/profile.go:755 lxc/project.go:581
 #: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
@@ -6268,7 +6327,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:776
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6353,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1148 lxc/config.go:1149
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6369,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:909 lxc/config.go:910
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6358,7 +6417,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1167 lxc/profile.go:1168
+#: lxc/profile.go:1171 lxc/profile.go:1172
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6410,7 +6469,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1172
+#: lxc/profile.go:1176
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -6430,7 +6489,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:914
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6457,11 +6516,11 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:279
+#: lxc/profile.go:283
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6593,7 +6652,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6616,7 +6675,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
+#: lxc/operation.go:104 lxc/profile.go:711 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6637,7 +6696,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6815,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,17 +6839,18 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1178 lxc/config.go:1232 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config_metadata.go:187 lxc/config_placement.go:423
+#: lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6810,24 +6870,36 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:1001 lxc/config.go:1147
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1056
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:505
+#: lxc/config_device.go:505 lxc/config_placement.go:321
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:865
+#: lxc/profile.go:112 lxc/profile.go:869
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:182
+#: lxc/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
+msgstr ""
+
+#: lxc/config_placement.go:117
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/config_placement.go:231
+msgid ""
+"[<remote>:]<instance> <rule-name> <kind> [<entity-type>] [key=value...] [--"
+"priority <priority>]"
 msgstr ""
 
 #: lxc/restore.go:20
@@ -7132,8 +7204,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
-#: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764
+#: lxc/config_placement.go:425 lxc/profile.go:360 lxc/profile.go:441
+#: lxc/profile.go:500 lxc/profile.go:1106
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7149,23 +7222,29 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:632 lxc/profile.go:1166
+#: lxc/profile.go:636 lxc/profile.go:1170
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1017
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:507
+#: lxc/config_device.go:507 lxc/config_placement.go:323
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:952
+#: lxc/profile.go:956
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:273
+#: lxc/config_placement.go:125
+msgid ""
+"[<remote>:]<profile> <rule-name> <kind> <entity-type> <key>=<value> "
+"[key=value...] [--priority <priority>]"
+msgstr ""
+
+#: lxc/profile.go:277
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -7218,7 +7297,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:102 lxc/config.go:774
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7305,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:395 lxc/config.go:908
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:544
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7337,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7345,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7352,13 +7431,27 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:102
+#: lxc/config.go:106
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config_placement.go:118
+msgid ""
+"lxc config placement add [<remote>:]instance1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instance with name \"instance1\" "
+"for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc config placement add [<remote>:]instance1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for the instance with name "
+"\"instance1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
+msgstr ""
+
+#: lxc/config.go:551
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7460,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1236
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1060
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7415,7 +7508,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7573,7 +7666,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:191
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7585,7 +7678,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:360
+#: lxc/profile.go:364
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7604,10 +7697,24 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:500
+#: lxc/profile.go:504
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
+msgstr ""
+
+#: lxc/config_placement.go:126
+msgid ""
+"lxc profile placement add [<remote>:]profile1 <rule-name> affinity "
+"cluster_group name=gpu\n"
+"    Will configure an affinity rule for the instances with profile "
+"\"profile1\" for the cluster group with name \"gpu\".\n"
+"\n"
+"lxc profile placement add [<remote>:]profile1 <rule-name> anti-affinity "
+"instance config.user.foo=bar,baz\n"
+"\tWill configure an anti-affinity rule for instances with profile "
+"\"profile1\" against other instances whose value for \"config.user.foo\" is "
+"\"bar\" or \"baz\"."
 msgstr ""
 
 #: lxc/project.go:99
@@ -7742,7 +7849,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7750,7 +7857,7 @@ msgstr ""
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: lxc/config.go:56
+#: lxc/config.go:60
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -7787,7 +7894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/shared/api/instance_snapshot.go
+++ b/shared/api/instance_snapshot.go
@@ -96,6 +96,16 @@ type InstanceSnapshot struct {
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
 	ExpandedDevices map[string]map[string]string `json:"expanded_devices,omitempty" yaml:"expanded_devices,omitempty"`
 
+	// Placement rules
+	//
+	// API extension: instance_placement_rules
+	PlacementRules map[string]InstancePlacementRule `json:"placement_rules" yaml:"placement_rules"`
+
+	// Expanded placement rules (all profiles and local placement rules merged)
+	//
+	// API extension: instance_placement_rules
+	ExpandedPlacementRules map[string]InstancePlacementRule `json:"expanded_placement_rules" yaml:"expanded_placement_rules"`
+
 	// Last start timestamp
 	// Example: 2021-03-23T20:00:00-04:00
 	LastUsedAt time.Time `json:"last_used_at" yaml:"last_used_at"`

--- a/shared/api/profile.go
+++ b/shared/api/profile.go
@@ -35,6 +35,11 @@ type ProfilePut struct {
 	// List of devices
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}, "eth0": {"type": "nic", "network": "lxdbr0", "name": "eth0"}}
 	Devices map[string]map[string]string `json:"devices" yaml:"devices"`
+
+	// List of instance placement rules
+	//
+	// API extension: instance_placement_rules
+	PlacementRules map[string]InstancePlacementRule `json:"placement_rules" yaml:"placement_rules"`
 }
 
 // Profile represents a LXD profile
@@ -60,6 +65,11 @@ type Profile struct {
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}, "eth0": {"type": "nic", "network": "lxdbr0", "name": "eth0"}}
 	Devices map[string]map[string]string `json:"devices" yaml:"devices"`
 
+	// List of instance placement rules
+	//
+	// API extension: instance_placement_rules
+	PlacementRules map[string]InstancePlacementRule `json:"placement_rules" yaml:"placement_rules"`
+
 	// List of URLs of objects using this profile
 	// Read only: true
 	// Example: ["/1.0/instances/c1", "/1.0/instances/v1"]
@@ -77,9 +87,10 @@ type Profile struct {
 // Writable converts a full Profile struct into a ProfilePut struct (filters read-only fields).
 func (profile *Profile) Writable() ProfilePut {
 	return ProfilePut{
-		Description: profile.Description,
-		Config:      profile.Config,
-		Devices:     profile.Devices,
+		Description:    profile.Description,
+		Config:         profile.Config,
+		Devices:        profile.Devices,
+		PlacementRules: profile.PlacementRules,
 	}
 }
 
@@ -88,6 +99,7 @@ func (profile *Profile) SetWritable(put ProfilePut) {
 	profile.Description = put.Description
 	profile.Config = put.Config
 	profile.Devices = put.Devices
+	profile.PlacementRules = put.PlacementRules
 }
 
 // URL returns the URL for the profile.

--- a/shared/api/selector.go
+++ b/shared/api/selector.go
@@ -1,0 +1,27 @@
+package api
+
+// SelectorMatcher contains the properties and values that a Selector selects against.
+//
+// swagger:model
+//
+// API extension: instance_placement_rules.
+type SelectorMatcher struct {
+	// Property is the property of the entity to perform the match against.
+	Property string `json:"property" yaml:"property"`
+
+	// Values are a list of values to find in the property.
+	Values []string `json:"values" yaml:"values"`
+}
+
+// Selector represents a method of selecting one or more entities of a particular type.
+//
+// swagger:model
+//
+// API extension: instance_placement_rules.
+type Selector struct {
+	// EntityType is the type of entity to perform the selection against.
+	EntityType string `json:"entity_type" yaml:"entity_type"`
+
+	// Matchers are a list of matchers to use when performing the selection.
+	Matchers []SelectorMatcher `json:"matchers" yaml:"matchers"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -444,6 +444,7 @@ var APIExtensions = []string{
 	"clustering_groups_used_by",
 	"container_bpf_delegation",
 	"override_snapshot_profiles_on_copy",
+	"instance_placement_rules",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/main.sh
+++ b/test/main.sh
@@ -303,6 +303,7 @@ if [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_upgrade "clustering upgrade"
     run_test test_clustering_upgrade_large "clustering upgrade_large"
     run_test test_clustering_groups "clustering groups"
+    run_test test_clustering_placement "clustering placement"
     run_test test_clustering_events "clustering events"
     run_test test_clustering_uuid "clustering uuid"
     run_test test_clustering_trust_add "clustering trust add"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3653,6 +3653,86 @@ test_clustering_autotarget() {
   kill_lxd "${LXD_TWO_DIR}"
 }
 
+test_clustering_placement() {
+    local LXD_DIR
+
+    setup_clustering_bridge
+    prefix="lxd$$"
+    bridge="${prefix}"
+
+    setup_clustering_netns 1
+    LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+    chmod +x "${LXD_ONE_DIR}"
+    ns1="${prefix}1"
+    spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+    # Add a newline at the end of each line. YAML as weird rules..
+    cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+    # Spawn a second node
+    setup_clustering_netns 2
+    LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+    chmod +x "${LXD_TWO_DIR}"
+    ns2="${prefix}2"
+    spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${LXD_ONE_DIR}"
+
+    # Spawn a third node
+    setup_clustering_netns 3
+    LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+    chmod +x "${LXD_THREE_DIR}"
+    ns3="${prefix}3"
+    spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}"
+
+    token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
+    lxc remote add cluster --token "${token}" "https://10.1.1.101:8443"
+
+    lxc cluster group create cluster:g1
+    lxc cluster group add cluster:node1 g1
+    lxc cluster group add cluster:node2 g1
+
+    LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage
+
+    lxc profile create cluster:p1
+    lxc profile set cluster:p1 user.deployment ha
+    lxc profile placement add cluster:p1 group-affinity affinity cluster_group name=g1
+    lxc profile placement add cluster:p1 instance-anti-affinity anti-affinity instance config.user.deployment=ha
+
+    lxc init testimage cluster:dummy1 -p default --target node1
+    lxc init testimage cluster:dummy2 -p default --target node1
+    lxc init testimage cluster:dummy3 -p default --target node2
+
+    # First instance with profile should go to node2 because it is the member in the cluster group with the fewest instances.
+    lxc init testimage cluster:c1 -p default -p p1
+    [ "$(lxc query cluster:/1.0/instances/c1?recursion=1 | jq -r .location)" = "node2" ]
+
+    # Second instance with profile should go to node1 because of the required anti affinity rule with other instances that
+    # have `user.deployment=ha`.
+    lxc init testimage cluster:c2 -p default -p p1
+    [ "$(lxc query cluster:/1.0/instances/c2?recursion=1 | jq -r .location)" = "node1" ]
+
+    # Third instance should fail to be scheduled because there are no more cluster members in the cluster group to satisfy
+    # the required anti-affinity rule.
+    ! lxc init testimage cluster:c3 -p default -p p1 || false
+
+    # Clean up
+    LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+    LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+    LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+    sleep 0.5
+    rm -f "${LXD_THREE_DIR}/unix.socket"
+    rm -f "${LXD_TWO_DIR}/unix.socket"
+    rm -f "${LXD_ONE_DIR}/unix.socket"
+
+    teardown_clustering_netns
+    teardown_clustering_bridge
+
+    kill_lxd "${LXD_ONE_DIR}"
+    kill_lxd "${LXD_TWO_DIR}"
+    kill_lxd "${LXD_THREE_DIR}"
+
+    lxc remote rm cluster
+}
+
 test_clustering_groups() {
   local LXD_DIR
 

--- a/test/suites/init_dump.sh
+++ b/test/suites/init_dump.sh
@@ -76,6 +76,7 @@ profiles:
       path: /
       pool: ${storage_pool}
       type: disk
+  placement_rules: {}
   name: default
 - config:
     limits.memory: 2GiB
@@ -86,6 +87,7 @@ profiles:
       nictype: bridged
       parent: lxdt$$
       type: nic
+  placement_rules: {}
   name: test-profile
 projects:
 - config:


### PR DESCRIPTION
Adds the ability to define placement rules on profiles and instances. Placement rules can be added with:
```bash
lxc {config,profile} placement add <rule-name> <rule-kind> <entity-type> <property>=<<value>,...> [--priority=<priority>]
```
For example:
```bash
lxc profile placement add my-rule affinity cluster_group name=gpu
```
Creates a required affinity rule for the cluster group "gpu". All instances with this profile will be placed on cluster members that are part of the "gpu" cluster group.

This PR shows the basic principle of the implementation but there are many more things to do:
- [ ] Rule validation in relation to project configuration (e.g. `restricted.cluster.groups`).
- [ ] Disallow rule creation if server is not clustered.
- [ ] Lots more testing.
- [ ] Concurrent scheduling.
- [ ] Further generalisation of rule validation via entity type metadata.
- [ ] Expose more entity type metadata to client, to allow auto-completion and client side validation.
- [ ] Documentation.
- [ ] Rule evaluation of existing instances on rule change.