### PR TITLE
Pre- instance-placement fixes

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -134,7 +134,7 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 // Any errors encountered during the setup process are also handled by the function.
 func unixHTTPClient(args *ConnectionArgs, path string, transportWrapper func(t *http.Transport) HTTPTransporter) (*http.Client, error) {
 	// Setup a Unix socket dialer
-	unixDial := func(_ context.Context, network, addr string) (net.Conn, error) {
+	unixDial := func(_ context.Context, _ string, _ string) (net.Conn, error) {
 		raddr, err := net.ResolveUnixAddr("unix", path)
 		if err != nil {
 			return nil, err

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -82,7 +82,7 @@ func (c *cmdConfig) command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -106,7 +106,7 @@ func (c *cmdConfigEdit) command() *cobra.Command {
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -398,7 +398,7 @@ func (c *cmdConfigGet) command() *cobra.Command {
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if strings.Contains(toComplete, ".") {
 				return c.global.cmpServerAllKeys(toComplete)
@@ -555,7 +555,7 @@ lxc config set core.https_address=[::]:8443
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as an instance property"))
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if strings.Contains(toComplete, ".") {
 				return c.global.cmpServerAllKeys(toComplete)
@@ -776,7 +776,7 @@ func (c *cmdConfigShow) command() *cobra.Command {
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -908,7 +908,7 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as an instance property"))
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if strings.Contains(toComplete, ".") {
 				// Only complete config keys which are currently set.
@@ -979,7 +979,7 @@ func (c *cmdConfigUefi) command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -512,11 +512,12 @@ func (c *cmdConfigGet) run(cmd *cobra.Command, args []string) error {
 		}
 
 		value := resp.Config[args[len(args)-1]]
-		if value == nil {
+		switch value {
+		case nil:
 			value = ""
-		} else if value == true { //nolint:revive
+		case true:
 			value = "true"
-		} else if value == false { //nolint:revive
+		case false:
 			value = "false"
 		}
 

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -93,7 +93,7 @@ func (c *cmdProfile) command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -112,7 +112,7 @@ func (c *cmdProfileAdd) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -196,7 +196,7 @@ lxc profile assign foo ''
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -280,7 +280,7 @@ func (c *cmdProfileCopy) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -364,7 +364,7 @@ lxc profile create p1 < config.yaml
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpRemotes(toComplete, false)
 		}
@@ -442,7 +442,7 @@ func (c *cmdProfileDelete) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -503,7 +503,7 @@ func (c *cmdProfileEdit) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -638,7 +638,7 @@ func (c *cmdProfileGet) command() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a profile property"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -727,7 +727,7 @@ u - Used By`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display profiles from all projects"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpRemotes(toComplete, false)
 		}
@@ -869,7 +869,7 @@ func (c *cmdProfileRemove) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -957,7 +957,7 @@ func (c *cmdProfileRename) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -1021,7 +1021,7 @@ For backward compatibility, a single configuration key may still be set with:
 	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a profile property"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -1106,7 +1106,7 @@ func (c *cmdProfileShow) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -1171,7 +1171,7 @@ func (c *cmdProfileUnset) command() *cobra.Command {
 	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a profile property"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -961,12 +961,12 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 			// but if LXD is using systemd socket activation then we just want to call os.Exit() directly.
 			// In this case the socket FDs and environment vars may be different, so we can't re-exec.
 			os.Exit(0) //nolint:revive
-		} else {
-			logger.Info("Restarting LXD daemon following removal from cluster")
-			err = util.ReplaceDaemon()
-			if err != nil {
-				logger.Error("Failed restarting LXD daemon", logger.Ctx{"err": err})
-			}
+		}
+
+		logger.Info("Restarting LXD daemon following removal from cluster")
+		err = util.ReplaceDaemon()
+		if err != nil {
+			logger.Error("Failed restarting LXD daemon", logger.Ctx{"err": err})
 		}
 	}()
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -210,7 +210,7 @@ var internalClusterHealCmd = APIEndpoint{
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func clusterGet(d *Daemon, r *http.Request) response.Response {
+func clusterGet(d *Daemon, _ *http.Request) response.Response {
 	s := d.State()
 	serverName := s.ServerName
 
@@ -3142,7 +3142,7 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 }
 
 func internalClusterHeal(d *Daemon, r *http.Request) response.Response {
-	migrateFunc := func(s *state.State, r *http.Request, inst instance.Instance, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, metadata map[string]any, op *operations.Operation) error {
+	migrateFunc := func(s *state.State, _ *http.Request, inst instance.Instance, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, _ map[string]any, _ *operations.Operation) error {
 		// This returns an error if the instance's storage pool is local.
 		// Since we only care about remote backed instances, this can be ignored and return nil instead.
 		poolName, err := inst.StoragePool()
@@ -4539,7 +4539,7 @@ func autoHealClusterTask(d *Daemon) (task.Func, task.Schedule) {
 			return // Skip healing if there are no cluster members to evacuate.
 		}
 
-		opRun := func(op *operations.Operation) error {
+		opRun := func(_ *operations.Operation) error {
 			err := autoHealCluster(ctx, s, offlineMembers)
 			if err != nil {
 				logger.Error("Failed healing cluster instances", logger.Ctx{"err": err})
@@ -4571,7 +4571,7 @@ func autoHealClusterTask(d *Daemon) (task.Func, task.Schedule) {
 	return f, task.Every(time.Minute)
 }
 
-func autoHealCluster(ctx context.Context, s *state.State, offlineMembers []db.NodeInfo) error {
+func autoHealCluster(_ context.Context, s *state.State, offlineMembers []db.NodeInfo) error {
 	logger.Info("Healing cluster instances")
 
 	dest, err := cluster.Connect(s.LocalConfig.ClusterAddress(), s.Endpoints.NetworkCert(), s.ServerCert(), nil, true)

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -214,7 +214,7 @@ func internalOptimizeImage(d *Daemon, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func internalRefreshImage(d *Daemon, r *http.Request) response.Response {
+func internalRefreshImage(d *Daemon, _ *http.Request) response.Response {
 	s := d.State()
 
 	err := autoUpdateImages(s.ShutdownCtx, s)
@@ -225,7 +225,7 @@ func internalRefreshImage(d *Daemon, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func internalWaitReady(d *Daemon, r *http.Request) response.Response {
+func internalWaitReady(d *Daemon, _ *http.Request) response.Response {
 	// Check that we're not shutting down.
 	isClosing := d.State().ShutdownCtx.Err() != nil
 	if isClosing {
@@ -1065,7 +1065,7 @@ func internalImportRootDevicePopulate(instancePoolName string, localDevices map[
 	}
 }
 
-func internalGC(d *Daemon, r *http.Request) response.Response {
+func internalGC(_ *Daemon, _ *http.Request) response.Response {
 	logger.Infof("Started forced garbage collection run")
 	runtime.GC()
 	runtimeDebug.FreeOSMemory()
@@ -1082,19 +1082,19 @@ func internalGC(d *Daemon, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func internalRAFTSnapshot(d *Daemon, r *http.Request) response.Response {
+func internalRAFTSnapshot(_ *Daemon, _ *http.Request) response.Response {
 	logger.Warn("Forced RAFT snapshot not supported")
 
 	return response.InternalError(fmt.Errorf("Not supported"))
 }
 
-func internalBGPState(d *Daemon, r *http.Request) response.Response {
+func internalBGPState(d *Daemon, _ *http.Request) response.Response {
 	s := d.State()
 
 	return response.SyncResponse(true, s.BGP.Debug())
 }
 
-func internalIdentityCacheRefresh(d *Daemon, r *http.Request) response.Response {
+func internalIdentityCacheRefresh(d *Daemon, _ *http.Request) response.Response {
 	logger.Debug("Received identity cache update notification - refreshing cache")
 	d.State().UpdateIdentityCache()
 	return response.EmptySyncResponse

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -189,7 +189,7 @@ func EnsureSchema(db *sql.DB, address string, dir string) (bool, error) {
 			return false, err
 		}
 
-		err = query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error {
+		err = query.Transaction(context.TODO(), db, func(_ context.Context, tx *sql.Tx) error {
 			stmt := `
 INSERT INTO nodes(id, name, address, schema, api_extensions, arch, description) VALUES(1, 'none', '0.0.0.0', ?, ?, ?, '')
 `

--- a/lxd/db/cluster/open_test.go
+++ b/lxd/db/cluster/open_test.go
@@ -112,7 +112,7 @@ func TestEnsureSchema_UpdateNodeVersion(t *testing.T) {
 		ready bool
 	}{
 		{
-			func(t *testing.T, db *sql.DB) {},
+			func(_ *testing.T, _ *sql.DB) {},
 			true,
 		},
 		{
@@ -165,7 +165,7 @@ CREATE TABLE schema (
 
 // Add a new node with the given address, schema version and number of api extensions.
 func addNode(t *testing.T, db *sql.DB, address string, schema int, apiExtensions int) {
-	err := query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error {
+	err := query.Transaction(context.TODO(), db, func(_ context.Context, tx *sql.Tx) error {
 		stmt := `
 INSERT INTO nodes(name, address, schema, api_extensions, arch, description) VALUES (?, ?, ?, ?, ?, '')
 `

--- a/lxd/db/cluster/open_test.go
+++ b/lxd/db/cluster/open_test.go
@@ -1,4 +1,4 @@
-package cluster_test
+package cluster
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/version"
@@ -24,14 +23,14 @@ func TestEnsureSchema_NoClustered(t *testing.T) {
 	assert.NoError(t, os.Mkdir(filepath.Join(dir, "global"), 0711))
 	db := newDB(t)
 	addNode(t, db, "0.0.0.0", 1, 1)
-	ready, err := cluster.EnsureSchema(db, "1.2.3.4:666", dir)
+	ready, err := EnsureSchema(db, "1.2.3.4:666", dir)
 	assert.True(t, ready)
 	assert.NoError(t, err)
 }
 
 // Exercise EnsureSchema failures when the cluster can't be upgraded right now.
 func TestEnsureSchema_ClusterNotUpgradable(t *testing.T) {
-	schema := cluster.SchemaVersion
+	schema := SchemaVersion
 	apiExtensions := len(version.APIExtensions)
 
 	cases := []struct {
@@ -91,7 +90,7 @@ func TestEnsureSchema_ClusterNotUpgradable(t *testing.T) {
 		t.Run(c.title, func(t *testing.T) {
 			db := newDB(t)
 			c.setup(t, db)
-			ready, err := cluster.EnsureSchema(db, "1", "/unused/db/dir")
+			ready, err := EnsureSchema(db, "1", "/unused/db/dir")
 			assert.Equal(t, c.ready, ready)
 			if c.error == "" {
 				assert.NoError(t, err)
@@ -105,7 +104,7 @@ func TestEnsureSchema_ClusterNotUpgradable(t *testing.T) {
 // Regardless of whether the schema could actually be upgraded or not, the
 // version of this node gets updated.
 func TestEnsureSchema_UpdateNodeVersion(t *testing.T) {
-	schema := cluster.SchemaVersion
+	schema := SchemaVersion
 	apiExtensions := len(version.APIExtensions)
 
 	cases := []struct {
@@ -134,7 +133,7 @@ func TestEnsureSchema_UpdateNodeVersion(t *testing.T) {
 			addNode(t, db, "1", schema-1, apiExtensions-1)
 
 			// Ensure the schema.
-			ready, err := cluster.EnsureSchema(db, "1", "/unused/db/dir")
+			ready, err := EnsureSchema(db, "1", "/unused/db/dir")
 			assert.NoError(t, err)
 			assert.Equal(t, c.ready, ready)
 
@@ -158,7 +157,7 @@ CREATE TABLE schema (
     UNIQUE (version)
 );
 `
-	_, err = db.Exec(createTableSchema + cluster.FreshSchema())
+	_, err = db.Exec(createTableSchema + FreshSchema())
 	require.NoError(t, err)
 
 	return db

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -150,7 +150,7 @@ ALTER TABLE identities ADD COLUMN updated_date DATETIME NOT NULL DEFAULT "0001-0
 	return nil
 }
 
-func updateFromV70(ctx context.Context, tx *sql.Tx) error {
+func updateFromV70(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE auth_groups (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -207,7 +207,7 @@ CREATE TABLE auth_groups_permissions (
 	return nil
 }
 
-func updateFromV69(ctx context.Context, tx *sql.Tx) error {
+func updateFromV69(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE identities (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -247,7 +247,7 @@ DROP TABLE certificates_projects;
 }
 
 // updateFromV68 fixes unique index for record name to make it zone specific.
-func updateFromV68(ctx context.Context, tx *sql.Tx) error {
+func updateFromV68(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE networks_zones_records_new (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -330,7 +330,7 @@ func updateFromV67(ctx context.Context, tx *sql.Tx) error {
 }
 
 // updateFromV66 adds creation_date column to storage_volumes and storage_volumes_snapshots tables.
-func updateFromV66(ctx context.Context, tx *sql.Tx) error {
+func updateFromV66(_ context.Context, tx *sql.Tx) error {
 	q := `
 ALTER TABLE storage_volumes ADD COLUMN creation_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z";
 ALTER TABLE storage_volumes_snapshots ADD COLUMN creation_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z";
@@ -376,7 +376,7 @@ CREATE VIEW storage_volumes_all (
 }
 
 // updateFromV65 fixes typo in cephobject.radosgw.endpoint* settings.
-func updateFromV65(ctx context.Context, tx *sql.Tx) error {
+func updateFromV65(_ context.Context, tx *sql.Tx) error {
 	q := `
 	UPDATE storage_pools_config
 	SET key = REPLACE(key, "cephobject.radosgsw.endpoint", "cephobject.radosgw.endpoint")
@@ -391,7 +391,7 @@ func updateFromV65(ctx context.Context, tx *sql.Tx) error {
 }
 
 // updatefromV64 updates nodes_cluster_groups to include an ID field so that it works well with lxd-generate.
-func updateFromV64(ctx context.Context, tx *sql.Tx) error {
+func updateFromV64(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "nodes_cluster_groups_new" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -539,7 +539,7 @@ func updateFromV62(ctx context.Context, tx *sql.Tx) error {
 }
 
 // updateFromV61 converts config value fields to NOT NULL and config key fields to TEXT (from VARCHAR).
-func updateFromV61(ctx context.Context, tx *sql.Tx) error {
+func updateFromV61(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "instances_config_new" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -743,7 +743,7 @@ ALTER TABLE "storage_volumes_snapshots_config_new" RENAME TO "storage_volumes_sn
 }
 
 // updateFromV60 creates the networks_load_balancers and networks_load_balancers_config tables.
-func updateFromV60(ctx context.Context, tx *sql.Tx) error {
+func updateFromV60(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_load_balancers" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -774,7 +774,7 @@ CREATE TABLE "networks_load_balancers_config" (
 	return nil
 }
 
-func updateFromV59(ctx context.Context, tx *sql.Tx) error {
+func updateFromV59(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE networks_zones_records (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -802,7 +802,7 @@ CREATE TABLE networks_zones_records_config (
 	return nil
 }
 
-func updateFromV58(ctx context.Context, tx *sql.Tx) error {
+func updateFromV58(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (
     SELECT max(
@@ -815,7 +815,7 @@ WHERE name='storage_volumes';
 	return err
 }
 
-func updateFromV57(ctx context.Context, tx *sql.Tx) error {
+func updateFromV57(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (
     SELECT coalesce(max(max(coalesce(storage_volumes.id, 0)), max(coalesce(storage_volumes_snapshots.id, 0))), 0)
@@ -826,7 +826,7 @@ WHERE name='storage_volumes';
 	return err
 }
 
-func updateFromV56(ctx context.Context, tx *sql.Tx) error {
+func updateFromV56(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (
     SELECT max(max(coalesce(storage_volumes.id, 0)), max(coalesce(storage_volumes_snapshots.id, 0)))
@@ -837,7 +837,7 @@ WHERE name='storage_volumes';
 	return err
 }
 
-func updateFromV55(ctx context.Context, tx *sql.Tx) error {
+func updateFromV55(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW storage_volumes_all;
 
@@ -1645,7 +1645,7 @@ CREATE VIEW storage_volumes_all (
 	return nil
 }
 
-func updateFromV54(ctx context.Context, tx *sql.Tx) error {
+func updateFromV54(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW certificates_projects_ref;
 DROP VIEW instances_config_ref;
@@ -1667,7 +1667,7 @@ DROP VIEW projects_used_by_ref;
 }
 
 // updateFromV53 creates the cluster_groups and nodes_cluster_groups tables.
-func updateFromV53(ctx context.Context, tx *sql.Tx) error {
+func updateFromV53(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "cluster_groups" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1696,7 +1696,7 @@ INSERT INTO nodes_cluster_groups (node_id, group_id) SELECT id, 1 FROM nodes;
 }
 
 // updateFromV52 creates the networks_zones and networks_zones_config tables.
-func updateFromV52(ctx context.Context, tx *sql.Tx) error {
+func updateFromV52(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_zones" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1724,7 +1724,7 @@ CREATE TABLE "networks_zones_config" (
 }
 
 // updateFromV51 creates the networks_peers and networks_peers_config tables.
-func updateFromV51(ctx context.Context, tx *sql.Tx) error {
+func updateFromV51(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_peers" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1757,7 +1757,7 @@ CREATE TABLE "networks_peers_config" (
 }
 
 // updateFromV50 creates the nodes_config table.
-func updateFromV50(ctx context.Context, tx *sql.Tx) error {
+func updateFromV50(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "nodes_config" (
 id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1777,7 +1777,7 @@ UNIQUE (node_id, key)
 }
 
 // updateFromV49 creates the networks_forwards and networks_forwards_config tables.
-func updateFromV49(ctx context.Context, tx *sql.Tx) error {
+func updateFromV49(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_forwards" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1808,7 +1808,7 @@ CREATE TABLE "networks_forwards_config" (
 }
 
 // updateFromV48 renames the "pending" column to "state" in the "nodes" table.
-func updateFromV48(ctx context.Context, tx *sql.Tx) error {
+func updateFromV48(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 ALTER TABLE nodes
 RENAME COLUMN pending TO state;
@@ -1821,7 +1821,7 @@ RENAME COLUMN pending TO state;
 }
 
 // updateFromV47 adds warnings.
-func updateFromV47(ctx context.Context, tx *sql.Tx) error {
+func updateFromV47(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE warnings (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1852,7 +1852,7 @@ CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_i
 }
 
 // updateFromV46 adds support for restricting certificates to projects.
-func updateFromV46(ctx context.Context, tx *sql.Tx) error {
+func updateFromV46(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 ALTER TABLE certificates ADD COLUMN restricted INTEGER NOT NULL DEFAULT 0;
 CREATE TABLE certificates_projects (
@@ -1876,7 +1876,7 @@ CREATE VIEW certificates_projects_ref (fingerprint, value) AS
 }
 
 // updateFromV45 updates projects_used_by_ref to include ceph volumes.
-func updateFromV45(ctx context.Context, tx *sql.Tx) error {
+func updateFromV45(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW projects_used_by_ref;
 CREATE VIEW projects_used_by_ref (name,
@@ -1929,7 +1929,7 @@ CREATE VIEW projects_used_by_ref (name,
 
 // updateFromV44 adds networks_acls table, and adds a foreign key relationship between networks and projects.
 // API extension: network_acl.
-func updateFromV44(ctx context.Context, tx *sql.Tx) error {
+func updateFromV44(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW projects_used_by_ref;
 
@@ -2047,7 +2047,7 @@ CREATE VIEW projects_used_by_ref (name,
 }
 
 // updateFromV43 adds a unique index to the storage_pools_config and networks_config tables.
-func updateFromV43(ctx context.Context, tx *sql.Tx) error {
+func updateFromV43(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`CREATE UNIQUE INDEX storage_pools_unique_storage_pool_id_node_id_key ON storage_pools_config (storage_pool_id, IFNULL(node_id, -1), key);
 		CREATE UNIQUE INDEX networks_unique_network_id_node_id_key ON networks_config (network_id, IFNULL(node_id, -1), key);
 	`)
@@ -2191,7 +2191,7 @@ func updateFromV41(ctx context.Context, tx *sql.Tx) error {
 }
 
 // Add state column to storage_pools_nodes tables. Set existing row's state to 1 ("created").
-func updateFromV40(ctx context.Context, tx *sql.Tx) error {
+func updateFromV40(_ context.Context, tx *sql.Tx) error {
 	stmt := `
 		ALTER TABLE storage_pools_nodes ADD COLUMN state INTEGER NOT NULL DEFAULT 0;
 		UPDATE storage_pools_nodes SET state = 1;
@@ -2201,7 +2201,7 @@ func updateFromV40(ctx context.Context, tx *sql.Tx) error {
 }
 
 // Add state column to networks_nodes tables. Set existing row's state to 1 ("created").
-func updateFromV39(ctx context.Context, tx *sql.Tx) error {
+func updateFromV39(_ context.Context, tx *sql.Tx) error {
 	stmt := `
 		ALTER TABLE networks_nodes ADD COLUMN state INTEGER NOT NULL DEFAULT 0;
 		UPDATE networks_nodes SET state = 1;
@@ -2211,7 +2211,7 @@ func updateFromV39(ctx context.Context, tx *sql.Tx) error {
 }
 
 // Add storage_volumes_backups table.
-func updateFromV38(ctx context.Context, tx *sql.Tx) error {
+func updateFromV38(_ context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE storage_volumes_backups (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -2248,7 +2248,7 @@ func updateFromV37(ctx context.Context, tx *sql.Tx) error {
 }
 
 // Add networks to projects references.
-func updateFromV36(ctx context.Context, tx *sql.Tx) error {
+func updateFromV36(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW projects_used_by_ref;
 CREATE VIEW projects_used_by_ref (name,
@@ -2287,7 +2287,7 @@ CREATE VIEW projects_used_by_ref (name,
 
 // This fixes node IDs of storage volumes on non-remote pools which were
 // wrongly set to NULL.
-func updateFromV35(ctx context.Context, tx *sql.Tx) error {
+func updateFromV35(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 WITH storage_volumes_tmp (id, node_id)
 AS (
@@ -2604,7 +2604,7 @@ CREATE TRIGGER storage_volumes_check_id
 // and set existing networks to project_id 1.
 // This is made a lot more complex because it requires re-creating the referenced tables as there is no way to
 // disable foreign keys temporarily within a transaction.
-func updateFromV33(ctx context.Context, tx *sql.Tx) error {
+func updateFromV33(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE networks_new (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -2661,7 +2661,7 @@ ALTER TABLE networks_config_new RENAME TO networks_config;
 }
 
 // Add type field to networks.
-func updateFromV32(ctx context.Context, tx *sql.Tx) error {
+func updateFromV32(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE networks ADD COLUMN type INTEGER NOT NULL DEFAULT 0;")
 	if err != nil {
 		return fmt.Errorf("Failed to add type column to networks table: %w", err)
@@ -2671,7 +2671,7 @@ func updateFromV32(ctx context.Context, tx *sql.Tx) error {
 }
 
 // Add failure_domain column to nodes table.
-func updateFromV31(ctx context.Context, tx *sql.Tx) error {
+func updateFromV31(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE nodes_failure_domains (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -2690,7 +2690,7 @@ ALTER TABLE nodes
 }
 
 // Add content type field to storage volumes.
-func updateFromV30(ctx context.Context, tx *sql.Tx) error {
+func updateFromV30(_ context.Context, tx *sql.Tx) error {
 	stmts := `ALTER TABLE storage_volumes ADD COLUMN content_type INTEGER NOT NULL DEFAULT 0;
 UPDATE storage_volumes SET content_type = 1 WHERE type = 3;
 UPDATE storage_volumes SET content_type = 1 WHERE storage_volumes.id IN (
@@ -2738,7 +2738,7 @@ CREATE VIEW storage_volumes_all (
 }
 
 // Add storage volumes to projects references and fix images.
-func updateFromV29(ctx context.Context, tx *sql.Tx) error {
+func updateFromV29(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW projects_used_by_ref;
 CREATE VIEW projects_used_by_ref (name,
@@ -2771,13 +2771,13 @@ CREATE VIEW projects_used_by_ref (name,
 }
 
 // Attempt to add missing project feature.
-func updateFromV28(ctx context.Context, tx *sql.Tx) error {
+func updateFromV28(_ context.Context, tx *sql.Tx) error {
 	_, _ = tx.Exec("INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.storage.volumes', 'true');")
 	return nil
 }
 
 // Add expiry date to storage volume snapshots.
-func updateFromV27(ctx context.Context, tx *sql.Tx) error {
+func updateFromV27(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE storage_volumes_snapshots ADD COLUMN expiry_date DATETIME;")
 	return err
 }
@@ -3096,7 +3096,7 @@ SELECT ?, ?, 'zfs.pool_name', name FROM storage_pools WHERE id=?
 }
 
 // Fix "images_profiles" table (missing UNIQUE).
-func updateFromV21(ctx context.Context, tx *sql.Tx) error {
+func updateFromV21(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 ALTER TABLE images_profiles RENAME TO old_images_profiles;
 CREATE TABLE images_profiles (
@@ -3114,7 +3114,7 @@ DROP TABLE old_images_profiles;
 }
 
 // Add "images_profiles" table.
-func updateFromV20(ctx context.Context, tx *sql.Tx) error {
+func updateFromV20(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE images_profiles (
 	image_id INTEGER NOT NULL,
@@ -3146,7 +3146,7 @@ INSERT INTO images_profiles (image_id, profile_id)
 }
 
 // Add a new "arch" column to the "nodes" table.
-func updateFromV19(ctx context.Context, tx *sql.Tx) error {
+func updateFromV19(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("PRAGMA ignore_check_constraints=on")
 	if err != nil {
 		return err
@@ -3177,7 +3177,7 @@ func updateFromV19(ctx context.Context, tx *sql.Tx) error {
 }
 
 // Rename 'containers' to 'instances' in *_used_by_ref views.
-func updateFromV18(ctx context.Context, tx *sql.Tx) error {
+func updateFromV18(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW profiles_used_by_ref;
 CREATE VIEW profiles_used_by_ref (project,
@@ -3219,7 +3219,7 @@ CREATE VIEW projects_used_by_ref (name,
 }
 
 // Add nodes_roles table.
-func updateFromV17(ctx context.Context, tx *sql.Tx) error {
+func updateFromV17(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE nodes_roles (
     node_id INTEGER NOT NULL,
@@ -3233,7 +3233,7 @@ CREATE TABLE nodes_roles (
 }
 
 // Add image type column.
-func updateFromV16(ctx context.Context, tx *sql.Tx) error {
+func updateFromV16(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE images ADD COLUMN type INTEGER NOT NULL DEFAULT 0;")
 	return err
 }
@@ -3622,7 +3622,7 @@ SELECT instances_devices.id, instance_id, instances_devices.name, instances_devi
 }
 
 // Rename all containers* tables to instances*/.
-func updateFromV14(ctx context.Context, tx *sql.Tx) error {
+func updateFromV14(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 ALTER TABLE containers RENAME TO instances;
 ALTER TABLE containers_backups RENAME COLUMN container_id TO instance_id;
@@ -3719,12 +3719,12 @@ CREATE VIEW profiles_used_by_ref (project,
 	return err
 }
 
-func updateFromV13(ctx context.Context, tx *sql.Tx) error {
+func updateFromV13(_ context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE containers ADD COLUMN expiry_date DATETIME;")
 	return err
 }
 
-func updateFromV12(ctx context.Context, tx *sql.Tx) error {
+func updateFromV12(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW profiles_used_by_ref;
 CREATE VIEW profiles_used_by_ref (project,
@@ -4257,7 +4257,7 @@ CREATE VIEW profiles_used_by_ref (project, name, value) AS
 	return err
 }
 
-func updateFromV10(ctx context.Context, tx *sql.Tx) error {
+func updateFromV10(_ context.Context, tx *sql.Tx) error {
 	stmt := `
 ALTER TABLE storage_volumes ADD COLUMN snapshot INTEGER NOT NULL DEFAULT 0;
 UPDATE storage_volumes SET snapshot = 0;
@@ -4267,7 +4267,7 @@ UPDATE storage_volumes SET snapshot = 0;
 }
 
 // Add a new 'type' column to the operations table.
-func updateFromV9(ctx context.Context, tx *sql.Tx) error {
+func updateFromV9(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 	ALTER TABLE operations ADD COLUMN type INTEGER NOT NULL DEFAULT 0;
 	UPDATE operations SET type = 0;
@@ -4278,13 +4278,13 @@ func updateFromV9(ctx context.Context, tx *sql.Tx) error {
 
 // The lvm.thinpool_name and lvm.vg_name config keys are node-specific and need
 // to be linked to nodes.
-func updateFromV8(ctx context.Context, tx *sql.Tx) error {
+func updateFromV8(_ context.Context, _ *sql.Tx) error {
 	// Moved to patchLvmNodeSpecificConfigKeys, since there's no schema
 	// change. That makes it easier to backport.
 	return nil
 }
 
-func updateFromV7(ctx context.Context, tx *sql.Tx) error {
+func updateFromV7(_ context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE containers_backups (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4465,13 +4465,13 @@ INSERT INTO storage_volumes_config(storage_volume_id, key, value) VALUES(?, ?, ?
 	return nil
 }
 
-func updateFromV4(ctx context.Context, tx *sql.Tx) error {
+func updateFromV4(_ context.Context, tx *sql.Tx) error {
 	stmt := "UPDATE networks SET state = 1"
 	_, err := tx.Exec(stmt)
 	return err
 }
 
-func updateFromV3(ctx context.Context, tx *sql.Tx) error {
+func updateFromV3(_ context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE storage_pools_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4488,7 +4488,7 @@ UPDATE storage_pools SET state = 1;
 	return err
 }
 
-func updateFromV2(ctx context.Context, tx *sql.Tx) error {
+func updateFromV2(_ context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE operations (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4502,7 +4502,7 @@ CREATE TABLE operations (
 	return err
 }
 
-func updateFromV1(ctx context.Context, tx *sql.Tx) error {
+func updateFromV1(_ context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE certificates (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4709,7 +4709,7 @@ CREATE TABLE storage_volumes_config (
 	return err
 }
 
-func updateFromV0(ctx context.Context, tx *sql.Tx) error {
+func updateFromV0(_ context.Context, tx *sql.Tx) error {
 	// v0..v1 the dawn of clustering
 	stmt := `
 CREATE TABLE nodes (

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -1,4 +1,4 @@
-package cluster_test
+package cluster
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -20,7 +19,7 @@ import (
 )
 
 func TestUpdateFromV0(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(1, nil)
 	require.NoError(t, err)
 
@@ -40,7 +39,7 @@ func TestUpdateFromV0(t *testing.T) {
 }
 
 func TestUpdateFromV1_Certificates(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(2, nil)
 	require.NoError(t, err)
 
@@ -53,7 +52,7 @@ func TestUpdateFromV1_Certificates(t *testing.T) {
 }
 
 func TestUpdateFromV1_Config(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(2, nil)
 	require.NoError(t, err)
 
@@ -66,7 +65,7 @@ func TestUpdateFromV1_Config(t *testing.T) {
 }
 
 func TestUpdateFromV1_Containers(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(2, nil)
 	require.NoError(t, err)
 
@@ -100,7 +99,7 @@ INSERT INTO containers VALUES (2, 2, 'jammy', 2, 2, 1, ?, 1, ?, 'Ubuntu LTS')
 }
 
 func TestUpdateFromV1_Network(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(2, nil)
 	require.NoError(t, err)
 
@@ -124,7 +123,7 @@ func TestUpdateFromV1_ConfigTables(t *testing.T) {
 }
 
 func testConfigTable(t *testing.T, table string, setup func(db *sql.DB)) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(2, nil)
 	require.NoError(t, err)
 
@@ -183,7 +182,7 @@ func testConfigTable(t *testing.T, table string, setup func(db *sql.DB)) {
 }
 
 func TestUpdateFromV2(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(3, nil)
 	require.NoError(t, err)
 
@@ -208,7 +207,7 @@ func TestUpdateFromV2(t *testing.T) {
 }
 
 func TestUpdateFromV3(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(4, nil)
 	require.NoError(t, err)
 
@@ -227,7 +226,7 @@ func TestUpdateFromV3(t *testing.T) {
 }
 
 func TestUpdateFromV5(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(6, func(db *sql.DB) {
 		// Create two nodes.
 		_, err := db.Exec(
@@ -298,7 +297,7 @@ SELECT id FROM storage_volumes WHERE storage_pool_id=2 AND name='v1' ORDER BY id
 }
 
 func TestUpdateFromV6(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(7, func(db *sql.DB) {
 		// Create two nodes.
 		_, err := db.Exec(
@@ -354,7 +353,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 }
 
 func TestUpdateFromV9(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(10, func(db *sql.DB) {
 		// Create a node.
 		_, err := db.Exec(
@@ -380,7 +379,7 @@ func TestUpdateFromV9(t *testing.T) {
 }
 
 func TestUpdateFromV11(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(12, func(db *sql.DB) {
 		// Insert a node.
 		_, err := db.Exec(
@@ -468,7 +467,7 @@ INSERT INTO containers VALUES (4, 1, 'xenial', 1, 1, 0, ?, 0, ?, 'Xenial Xerus',
 }
 
 func TestUpdateFromV14(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(15, func(db *sql.DB) {
 		// Insert a node.
 		_, err := db.Exec(
@@ -497,7 +496,7 @@ INSERT INTO containers VALUES (1, 1, 'eoan', 1, 1, 0, ?, 0, ?, 'Eoan Ermine', 1,
 }
 
 func TestUpdateFromV15(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(16, func(db *sql.DB) {
 		// Insert a node.
 		_, err := db.Exec(
@@ -589,7 +588,7 @@ INSERT INTO instances VALUES (2, 1, 'eoan/snap', 2, 1, 0, ?, 0, ?, 'Eoan Ermine 
 }
 
 func TestUpdateFromV19(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(20, func(db *sql.DB) {
 		// Insert a node.
 		_, err := db.Exec(
@@ -625,7 +624,7 @@ VALUES (2, 'n2', '', '2.2.3.4:666', 1, 32, ?, 0)`, time.Now())
 }
 
 func TestUpdateFromV25(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(26, func(db *sql.DB) {
 		// Insert a node.
 		_, err := db.Exec(
@@ -677,14 +676,14 @@ func TestUpdateFromV25(t *testing.T) {
 }
 
 func TestUpdateFromV26_WithoutVolumes(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(27, func(db *sql.DB) {})
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 }
 
 func TestUpdateFromV26_WithVolumes(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(27, func(db *sql.DB) {
 		// Insert a node.
 		_, err := db.Exec(
@@ -722,7 +721,7 @@ func TestUpdateFromV26_WithVolumes(t *testing.T) {
 }
 
 func TestUpdateFromV34(t *testing.T) {
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(35, func(db *sql.DB) {
 		// Insert two nodes.
 		_, err := db.Exec(
@@ -771,7 +770,7 @@ func TestUpdateFromV69(t *testing.T) {
 	c1 := string(shared.TestingKeyPair().PublicKey())
 	c2 := string(shared.TestingAltKeyPair().PublicKey())
 
-	schema := cluster.Schema()
+	schema := Schema()
 	db, err := schema.ExerciseUpdate(70, func(db *sql.DB) {
 		_, err := db.Exec(`
 INSERT INTO certificates (fingerprint, type, name, certificate, restricted) VALUES ('eeef45f0570ce713864c86ec60c8d88f60b4844d3a8849b262c77cb18e88394d', 1, 'restricted-client', ?, 1);
@@ -790,9 +789,9 @@ INSERT INTO certificates_projects (certificate_id, project_id) VALUES (1, 4);
 	})
 	require.NoError(t, err)
 
-	getTLSIdentityByFingerprint := func(fingerprint string) cluster.Identity {
-		identity := cluster.Identity{}
-		row := db.QueryRow(`SELECT id, auth_method, type, identifier, name, metadata FROM identities WHERE auth_method = ? AND identifier = ?`, cluster.AuthMethod(api.AuthenticationMethodTLS), fingerprint)
+	getTLSIdentityByFingerprint := func(fingerprint string) Identity {
+		identity := Identity{}
+		row := db.QueryRow(`SELECT id, auth_method, type, identifier, name, metadata FROM identities WHERE auth_method = ? AND identifier = ?`, AuthMethod(api.AuthenticationMethodTLS), fingerprint)
 		require.NoError(t, row.Err())
 		err = row.Scan(&identity.ID, &identity.AuthMethod, &identity.Type, &identity.Identifier, &identity.Name, &identity.Metadata)
 		require.NoError(t, row.Err())
@@ -802,7 +801,7 @@ INSERT INTO certificates_projects (certificate_id, project_id) VALUES (1, 4);
 	identity := getTLSIdentityByFingerprint("eeef45f0570ce713864c86ec60c8d88f60b4844d3a8849b262c77cb18e88394d")
 	assert.Equal(t, api.IdentityTypeCertificateClientRestricted, string(identity.Type))
 	assert.Equal(t, "restricted-client", identity.Name)
-	var metadata cluster.CertificateMetadata
+	var metadata CertificateMetadata
 	err = json.Unmarshal([]byte(identity.Metadata), &metadata)
 	require.NoError(t, err)
 	assert.Equal(t, c1, metadata.Certificate)

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -677,7 +677,7 @@ func TestUpdateFromV25(t *testing.T) {
 
 func TestUpdateFromV26_WithoutVolumes(t *testing.T) {
 	schema := Schema()
-	db, err := schema.ExerciseUpdate(27, func(db *sql.DB) {})
+	db, err := schema.ExerciseUpdate(27, func(_ *sql.DB) {})
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 }

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -33,9 +34,12 @@ func TestUpdateFromV0(t *testing.T) {
 	require.Error(t, err)
 
 	// Unique constraint on address
-	stmt = "INSERT INTO nodes VALUES (3, 'bar', 'gasp', '1.2.3.4:666', 9, 11), ?, 0)"
+	stmt = "INSERT INTO nodes VALUES (3, 'bar', 'gasp', '1.2.3.4:666', 9, 11, ?, 0)"
 	_, err = db.Exec(stmt, time.Now())
 	require.Error(t, err)
+	var sqliteErr sqlite3.Error
+	require.True(t, errors.As(err, &sqliteErr))
+	require.Equal(t, sqlite3.ErrConstraintUnique, sqliteErr.ExtendedCode)
 }
 
 func TestUpdateFromV1_Certificates(t *testing.T) {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -337,11 +337,11 @@ func (d *common) VolatileSet(changes map[string]string) error {
 	if !d.volatileSetPersistDisable {
 		var err error
 		if d.isSnapshot {
-			err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			err = d.state.DB.Cluster.Transaction(context.TODO(), func(_ context.Context, tx *db.ClusterTx) error {
 				return tx.UpdateInstanceSnapshotConfig(d.id, changes)
 			})
 		} else {
-			err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			err = d.state.DB.Cluster.Transaction(context.TODO(), func(_ context.Context, tx *db.ClusterTx) error {
 				return tx.UpdateInstanceConfig(d.id, changes)
 			})
 		}
@@ -1168,7 +1168,7 @@ func (d *common) recordLastState() error {
 	d.expandedConfig["volatile.last_state.power"] = instance.PowerStateRunning
 
 	// Database updates
-	return d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	return d.state.DB.Cluster.Transaction(context.TODO(), func(_ context.Context, tx *db.ClusterTx) error {
 		// Record power state.
 		err = tx.UpdateInstancePowerState(d.id, instance.PowerStateRunning)
 		if err != nil {
@@ -1745,14 +1745,14 @@ func (d *common) checkRootVolumeNotInUse() error {
 		return err
 	}
 
-	err = storagePools.VolumeUsedByProfileDevices(d.state, storagePool.Name(), d.Project().Name, &rootVolume.StorageVolume, func(profileID int64, profile api.Profile, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(d.state, storagePool.Name(), d.Project().Name, &rootVolume.StorageVolume, func(_ int64, _ api.Profile, _ api.Project, _ []string) error {
 		return fmt.Errorf(`"%s/%s" is attached to a profile`, rootVolume.Type, rootVolume.Name)
 	})
 	if err != nil {
 		return err
 	}
 
-	err = storagePools.VolumeUsedByInstanceDevices(d.state, storagePool.Name(), d.Project().Name, &rootVolume.StorageVolume, false, func(inst db.InstanceArgs, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(d.state, storagePool.Name(), d.Project().Name, &rootVolume.StorageVolume, false, func(inst db.InstanceArgs, _ api.Project, _ []string) error {
 		if inst.Name == d.Name() && inst.Project == d.Project().Name {
 			return nil
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4942,7 +4942,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 }
 
 // Export backs up the instance.
-func (d *lxc) Export(w io.Writer, properties map[string]string, expiration time.Time, tracker *ioprogress.ProgressTracker) (api.ImageMetadata, error) {
+func (d *lxc) Export(w io.Writer, properties map[string]string, expiration time.Time, _ *ioprogress.ProgressTracker) (api.ImageMetadata, error) {
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -5530,7 +5530,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 				operationtype.InstanceLiveMigrate,
 				nil,
 				nil,
-				func(op *operations.Operation) error {
+				func(_ *operations.Operation) error {
 					result := <-restoreSuccess
 					if !result {
 						return fmt.Errorf("restore failed, failing CRIU")
@@ -5539,7 +5539,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 					return nil
 				},
 				nil,
-				func(op *operations.Operation, r *http.Request, w http.ResponseWriter) error {
+				func(_ *operations.Operation, r *http.Request, w http.ResponseWriter) error {
 					secret := r.FormValue("secret")
 					if secret == "" {
 						return fmt.Errorf("Missing action script secret")
@@ -8277,7 +8277,7 @@ type lxcCgroupReadWriter struct {
 }
 
 // Get retrieves the value of a cgroup key for a specific controller and version.
-func (rw *lxcCgroupReadWriter) Get(version cgroup.Backend, controller string, key string) (string, error) {
+func (rw *lxcCgroupReadWriter) Get(version cgroup.Backend, _ string, key string) (string, error) {
 	if !rw.running {
 		lxcKey := "lxc.cgroup." + key
 
@@ -8292,7 +8292,7 @@ func (rw *lxcCgroupReadWriter) Get(version cgroup.Backend, controller string, ke
 }
 
 // Set writes a value to a cgroup key for a specific controller and version.
-func (rw *lxcCgroupReadWriter) Set(version cgroup.Backend, controller string, key string, value string) error {
+func (rw *lxcCgroupReadWriter) Set(version cgroup.Backend, _ string, key string, value string) error {
 	if !rw.running {
 		if version == cgroup.V1 {
 			return lxcSetConfigItem(rw.cc, "lxc.cgroup."+key, value)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1578,7 +1578,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		// files be sure to mount the 9P share in the VM with the "access=0" option to allow
 		// only root user in VM to access the mounted share.
 		err := filepath.Walk(filepath.Join(d.Path(), "config"),
-			func(path string, info os.FileInfo, err error) error {
+			func(path string, _ os.FileInfo, err error) error {
 				if err != nil {
 					return err
 				}
@@ -2117,7 +2117,7 @@ func (d *qemu) saveConnectionInfo(connInfo *agentAPI.API10Put) error {
 }
 
 // OnHook is the top-level hook handler.
-func (d *qemu) OnHook(hookName string, args map[string]string) error {
+func (d *qemu) OnHook(_ string, _ map[string]string) error {
 	return instance.ErrNotImplemented
 }
 
@@ -5393,7 +5393,7 @@ func allowRemoveSecurityProtectionStart(state *state.State, poolName string, vol
 	if shared.IsFalseOrEmpty(dbVolume.Config["security.shared"]) {
 		// Only check instances here, as a VM root volume cannot be part of a profile
 		// when not using security.shared
-		err := storagePools.VolumeUsedByInstanceDevices(state, pool.Name(), volumeProject, &dbVolume.StorageVolume, true, func(inst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+		err := storagePools.VolumeUsedByInstanceDevices(state, pool.Name(), volumeProject, &dbVolume.StorageVolume, true, func(inst db.InstanceArgs, _ api.Project, _ []string) error {
 			// The volume is always attached to its instance
 			if proj.Name == inst.Project && volumeName == inst.Name {
 				return nil
@@ -7923,7 +7923,7 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 }
 
 // RenderFull returns all info about the instance.
-func (d *qemu) RenderFull(hostInterfaces []net.Interface) (*api.InstanceFull, any, error) {
+func (d *qemu) RenderFull(_ []net.Interface) (*api.InstanceFull, any, error) {
 	if d.IsSnapshot() {
 		return nil, nil, fmt.Errorf("RenderFull doesn't work with snapshots")
 	}
@@ -8053,7 +8053,7 @@ func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error
 }
 
 // RenderState returns just state info about the instance.
-func (d *qemu) RenderState(hostInterfaces []net.Interface) (*api.InstanceState, error) {
+func (d *qemu) RenderState(_ []net.Interface) (*api.InstanceState, error) {
 	return d.renderState(d.statusCode())
 }
 
@@ -8913,7 +8913,7 @@ func (d *qemu) version() (*version.DottedVersion, error) {
 // If the instance is not running, it returns ErrInstanceIsStopped.
 // If agent metrics are enabled, it tries to get the metrics from the agent.
 // If the agent is not reachable, it falls back to getting the metrics directly from QEMU.
-func (d *qemu) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error) {
+func (d *qemu) Metrics(_ []net.Interface) (*metrics.MetricSet, error) {
 	if !d.IsRunning() {
 		return nil, ErrInstanceIsStopped
 	}

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -165,7 +165,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Update container configuration
-		do = func(op *operations.Operation) error {
+		do = func(_ *operations.Operation) error {
 			defer unlock()
 
 			args := db.InstanceArgs{
@@ -189,7 +189,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		opType = operationtype.InstanceUpdate
 	} else {
 		// Snapshot Restore
-		do = func(op *operations.Operation) error {
+		do = func(_ *operations.Operation) error {
 			defer unlock()
 
 			return instanceSnapRestore(s, projectName, name, configRaw.Restore, configRaw.Stateful)

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -515,7 +515,7 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 	_, err = rj.GetString("expires_at")
 	if err != nil {
 		// Skip updating the snapshot since the requested key wasn't provided
-		do = func(op *operations.Operation) error {
+		do = func(_ *operations.Operation) error {
 			return nil
 		}
 	} else {
@@ -532,7 +532,7 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 		}
 
 		// Update instance configuration
-		do = func(op *operations.Operation) error {
+		do = func(_ *operations.Operation) error {
 			args := db.InstanceArgs{
 				Architecture: snapInst.Architecture(),
 				Config:       snapInst.LocalConfig(),
@@ -614,7 +614,7 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func snapshotGet(s *state.State, r *http.Request, snapInst instance.Instance) response.Response {
+func snapshotGet(s *state.State, _ *http.Request, snapInst instance.Instance) response.Response {
 	render, _, err := snapInst.Render(storagePools.RenderSnapshotUsage(s, snapInst))
 	if err != nil {
 		return response.SmartError(err)
@@ -772,7 +772,7 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 		return response.Conflict(err)
 	}
 
-	rename := func(op *operations.Operation) error {
+	rename := func(_ *operations.Operation) error {
 		return snapInst.Rename(fullName, false)
 	}
 
@@ -819,7 +819,7 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func snapshotDelete(s *state.State, r *http.Request, snapInst instance.Instance) response.Response {
-	remove := func(op *operations.Operation) error {
+	remove := func(_ *operations.Operation) error {
 		return snapInst.Delete(false)
 	}
 

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -182,7 +182,7 @@ func createFromNone(s *state.State, r *http.Request, projectName string, profile
 		args.Architecture = architecture
 	}
 
-	run := func(op *operations.Operation) error {
+	run := func(_ *operations.Operation) error {
 		// Actually create the instance.
 		_, err := instanceCreateAsEmpty(s, args)
 		if err != nil {
@@ -822,7 +822,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	// Copy reverter so far so we can use it inside run after this function has finished.
 	runRevert := revert.Clone()
 
-	run := func(op *operations.Operation) error {
+	run := func(_ *operations.Operation) error {
 		defer func() { _ = backupFile.Close() }()
 		defer runRevert.Fail()
 

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -656,7 +656,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
+		err = notifier(func(_ db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(details.effectiveProject.Name).UpdateProfile(details.profileName, profile.Writable(), "")
 		})
 		if err != nil {

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -158,7 +158,7 @@ func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, vol *
 
 	// Pass false to expandDevices, as we only want to see instances directly using a volume, rather than their
 	// profiles using a volume.
-	err = storagePools.VolumeUsedByInstanceDevices(s, vol.Pool, vol.Project, &vol.StorageVolume, false, func(inst db.InstanceArgs, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(s, vol.Pool, vol.Project, &vol.StorageVolume, false, func(inst db.InstanceArgs, _ api.Project, _ []string) error {
 		volumeUsedBy = append(volumeUsedBy, api.NewURL().Path(version.APIVersion, "instances", inst.Name).Project(inst.Project).String())
 		return nil
 	})
@@ -166,7 +166,7 @@ func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, vol *
 		return []string{}, err
 	}
 
-	err = storagePools.VolumeUsedByProfileDevices(s, vol.Pool, requestProjectName, &vol.StorageVolume, func(profileID int64, profile api.Profile, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(s, vol.Pool, requestProjectName, &vol.StorageVolume, func(_ int64, profile api.Profile, p api.Project, _ []string) error {
 		volumeUsedBy = append(volumeUsedBy, api.NewURL().Path(version.APIVersion, "profiles", profile.Name).Project(p.Name).String())
 		return nil
 	})


### PR DESCRIPTION
Work on #15277 has thrown a lot of linter errors. I think this is due to updates to `golangci-lint` as a lot of these files have already had lint errors fixed, but now the linter seems to be catching a lot more cases (especially unused parameters).

There were also a couple of other things I fixed/removed along the way. Adding them here to keep the size of the other PR down and focused.