### PR TITLE
lxd/storage/drivers/zfs: suggest `zfs.external` if in snap and ZFS tools are missing

### DIFF
--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -72,7 +72,7 @@ func (d *tpm) validateEnvironment() error {
 	// Validate the required binary.
 	_, err := exec.LookPath("swtpm")
 	if err != nil {
-		return fmt.Errorf("Required tool '%s' is missing", "swtpm")
+		return fmt.Errorf("Required tool %q is missing", "swtpm")
 	}
 
 	if d.inst.Type() == instancetype.Container {

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -46,7 +46,7 @@ func (d *ceph) load() error {
 	for _, tool := range []string{"ceph", "rbd"} {
 		_, err := exec.LookPath(tool)
 		if err != nil {
-			return fmt.Errorf("Required tool '%s' is missing", tool)
+			return fmt.Errorf("Required tool %q is missing", tool)
 		}
 	}
 

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -45,7 +45,7 @@ func (d *cephfs) load() error {
 	for _, tool := range []string{"ceph", "rbd"} {
 		_, err := exec.LookPath(tool)
 		if err != nil {
-			return fmt.Errorf("Required tool '%s' is missing", tool)
+			return fmt.Errorf("Required tool %q is missing", tool)
 		}
 	}
 

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -68,7 +68,7 @@ func (d *zfs) load() error {
 	for _, tool := range []string{"zpool", "zfs"} {
 		_, err := exec.LookPath(tool)
 		if err != nil {
-			return fmt.Errorf("Required tool '%s' is missing", tool)
+			return fmt.Errorf("Required tool %q is missing", tool)
 		}
 	}
 

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -64,14 +64,6 @@ func (d *zfs) load() error {
 		return fmt.Errorf("Error loading %q module: %w", "zfs", err)
 	}
 
-	// Validate the needed tools are present.
-	for _, tool := range []string{"zpool", "zfs"} {
-		_, err := exec.LookPath(tool)
-		if err != nil {
-			return fmt.Errorf("Required tool %q is missing", tool)
-		}
-	}
-
 	// Get the version information.
 	if zfsVersion == "" {
 		version, err := d.version()
@@ -80,6 +72,14 @@ func (d *zfs) load() error {
 		}
 
 		zfsVersion = version
+	}
+
+	// Validate the needed tools are present.
+	for _, tool := range []string{"zpool", "zfs"} {
+		_, err := exec.LookPath(tool)
+		if err != nil {
+			return fmt.Errorf("Required tool %q is missing", tool)
+		}
 	}
 
 	// Decide whether we can use features added by 0.8.0.

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -78,6 +78,10 @@ func (d *zfs) load() error {
 	for _, tool := range []string{"zpool", "zfs"} {
 		_, err := exec.LookPath(tool)
 		if err != nil {
+			if shared.InSnap() {
+				return fmt.Errorf("Required tool %q is missing. The snap does not contain ZFS tools matching the module version (%q). Consider installing ZFS tools in the host and use 'snap set lxd zfs.external=true'", tool, zfsVersion)
+			}
+
 			return fmt.Errorf("Required tool %q is missing", tool)
 		}
 	}


### PR DESCRIPTION
ATM, if no `zpool` of the right version can be found in the LXD snap, this error is displayed:

```
root@v1:~# lxc storage create zfs zfs
Error: Required tool 'zpool' is missing
```

There is also a more verbose error logged by the snap'ed daemon but it requires the user to look at `journalctl -u snap.lxd.daemon`.

Make the workaround more easily discoverable by tweaking the error message.