### PR TITLE
lxd/instance: Don't enforce device/config validation on snapshots (from Incus)

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -163,15 +163,18 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.In
 		return nil, nil, fmt.Errorf("Failed to expand config: %w", err)
 	}
 
-	// Validate expanded config (allows mixed instance types for profiles).
-	err = instance.ValidConfig(s.OS, d.expandedConfig, true, instancetype.Any)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Invalid config: %w", err)
-	}
+	// When not a snapshot, perform full validation.
+	if !args.Snapshot {
+		// Validate expanded config (allows mixed instance types for profiles).
+		err = instance.ValidConfig(s.OS, d.expandedConfig, true, instancetype.Any)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Invalid config: %w", err)
+		}
 
-	err = instance.ValidDevices(s, d.project, d.Type(), d.localDevices, d.expandedDevices)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Invalid devices: %w", err)
+		err = instance.ValidDevices(s, d.project, d.Type(), d.localDevices, d.expandedDevices)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Invalid devices: %w", err)
+		}
 	}
 
 	_, rootDiskDevice, err := d.getRootDiskDevice()

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -249,15 +249,18 @@ func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.I
 		return nil, nil, fmt.Errorf("Failed to expand config: %w", err)
 	}
 
-	// Validate expanded config (allows mixed instance types for profiles).
-	err = instance.ValidConfig(s.OS, d.expandedConfig, true, instancetype.Any)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Invalid config: %w", err)
-	}
+	// When not a snapshot, perform full validation.
+	if !args.Snapshot {
+		// Validate expanded config (allows mixed instance types for profiles).
+		err = instance.ValidConfig(s.OS, d.expandedConfig, true, instancetype.Any)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Invalid config: %w", err)
+		}
 
-	err = instance.ValidDevices(s, d.project, d.Type(), d.localDevices, d.expandedDevices)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Invalid devices: %w", err)
+		err = instance.ValidDevices(s, d.project, d.Type(), d.localDevices, d.expandedDevices)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Invalid devices: %w", err)
+		}
 	}
 
 	// Retrieve the instance's storage pool.

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -75,6 +75,21 @@ test_migration() {
     done
   fi
 
+  # Test config overrides for migration of instance with snapshots
+  lxc_remote network create l1:foonet ipv4.address=10.100.10.1/24
+  lxc_remote network create l2:foonet2 ipv4.address=10.100.100.1/24
+  ensure_import_testimage
+  lxc_remote init testimage l1:u1
+  lxc_remote config device add l1:u1 eth1 nic name=eth1 network=foonet ipv4.address=10.100.10.10
+  lxc_remote snapshot l1:u1 snap
+
+  lxc_remote copy l1:u1 l2: -d eth1,ipv4.address=10.100.100.10 -d eth1,network=foonet2
+
+  lxc_remote delete l1:u1
+  lxc_remote delete l2:u1
+  lxc_remote network delete l1:foonet
+  lxc_remote network delete l2:foonet2
+
   lxc_remote remote remove l1
   lxc_remote remote remove l2
   kill_lxd "$LXD2_DIR"


### PR DESCRIPTION
(cherry picked from commit b4399dfc50a5238c9a63434a37205358c16489bf)

License: Apache-2.0

Tested with:
```
$ lxc init images:alpine/edge u2
$ lxc config device override u2 eth0 ipv4.address=10.142.210.80      # Add custom IP address to eth0
$ lxc snapshot u2 snap2
$ lxc copy u2 tester: -d eth0,ipv4.address=10.64.126.100                    # From target remote IP range
Error: Failed migration on source: Error from migration control target: Failed creating instance snapshot record "u2/snap2": Failed initialising instance: Invalid devices: Device validation failed for "eth0": Device IP address "10.142.210.80" not within network "lxdbr0" subnet
```