### PR TITLE
lxd/device/cdi: ubuntu core: add mesa-2404 contents to config search …

### DIFF
--- a/lxd/device/cdi/spec.go
+++ b/lxd/device/cdi/spec.go
@@ -69,7 +69,8 @@ func generateNvidiaSpec(s *state.State, cdiID ID, inst instance.Instance) (*spec
 	if s.OS.InUbuntuCore() {
 		devRootPath = "/"
 
-		gpuInterfaceProviderWrapper := os.Getenv("SNAP") + "/gpu-2404/bin/gpu-2404-provider-wrapper"
+		gpuCore24Root := os.Getenv("SNAP") + "/gpu-2404"
+		gpuInterfaceProviderWrapper := gpuCore24Root + "/bin/gpu-2404-provider-wrapper"
 
 		// Let's ensure that user has mesa-2404 snap connected.
 		if !shared.PathExists(gpuInterfaceProviderWrapper) {
@@ -99,7 +100,7 @@ func generateNvidiaSpec(s *state.State, cdiID ID, inst instance.Instance) (*spec
 		}
 
 		rootPath = strings.TrimSuffix(rootPath, "\n")
-		configSearchPaths = []string{rootPath + "/usr/share"}
+		configSearchPaths = []string{rootPath + "/usr/share", gpuCore24Root + "/usr/share"}
 
 		// Let's ensure that user did:
 		// snap connect mesa-2404:kernel-gpu-2404 pc-kernel


### PR DESCRIPTION
…paths

Some files, particularly 10_nvidia_wayland.json are now distributed not as a part of pc-kernel nvidia component, but as a part of mesa-2404 snap. We should add it to a configuration files search locations list too.