### PR TITLE
Network: Improve network validation

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -278,6 +278,95 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		}
 	}
 
+	// Validate that NIC passthrough does not allow IPs from OVN range.
+	err = d.validateExternalRoutes()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateExternalRoutes checks that external routes do not allow to passthrough IPs from OVN range.
+func (d *nicOVN) validateExternalRoutes() error {
+	var (
+		routesListIPv4 []*net.IPNet
+		routesListIPv6 []*net.IPNet
+
+		ovnRangesListIPv4 []*shared.IPRange
+		ovnRangesListIPv6 []*shared.IPRange
+
+		uplink *api.Network
+
+		err error
+	)
+
+	if d.network.Config() == nil {
+		return fmt.Errorf("Network config is missing for NIC device %q", d.name)
+	}
+
+	uplinkName := d.network.Config()["network"]
+	if uplinkName == "" {
+		return fmt.Errorf(`OVN network %q is missing "network" config option`, d.network.Name())
+	}
+
+	// Get uplink network config.
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Uplink has to be in the "default" project.
+		_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, uplinkName)
+
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to get config for network %q: %w", uplinkName, err)
+	}
+
+	if d.config["ipv4.routes.external"] != "" {
+		routesListIPv4, err = shared.ParseNetworks(d.config["ipv4.routes.external"])
+		if err != nil {
+			return fmt.Errorf("Failed parsing ipv4.routes: %w", err)
+		}
+
+		if uplink.Config["ipv4.ovn.ranges"] != "" {
+			ovnRangesListIPv4, err = shared.ParseIPRanges(uplink.Config["ipv4.ovn.ranges"])
+			if err != nil {
+				return fmt.Errorf("Failed parsing ipv4.ovn.ranges: %w", err)
+			}
+		}
+	}
+
+	if d.config["ipv6.routes.external"] != "" {
+		routesListIPv6, err = shared.ParseNetworks(d.config["ipv6.routes.external"])
+		if err != nil {
+			return fmt.Errorf("Failed parsing ipv6.routes: %w", err)
+		}
+
+		if uplink.Config["ipv6.ovn.ranges"] != "" {
+			ovnRangesListIPv6, err = shared.ParseIPRanges(uplink.Config["ipv6.ovn.ranges"])
+			if err != nil {
+				return fmt.Errorf("Failed parsing ipv6.ovn.ranges: %w", err)
+			}
+		}
+	}
+
+	// Validate "ipv4.routes.external".
+	for _, routes := range routesListIPv4 {
+		for _, ovnRange := range ovnRangesListIPv4 {
+			if ovnRange.ContainsIP(routes.IP.To16()) {
+				return fmt.Errorf(`Route %q overlaps with "ipv4.ovn.ranges" (%q)`, routes, ovnRange)
+			}
+		}
+	}
+
+	// Validate "ipv6.routes.external".
+	for _, routes := range routesListIPv6 {
+		for _, ovnRange := range ovnRangesListIPv6 {
+			if ovnRange.ContainsIP(routes.IP.To16()) {
+				return fmt.Errorf(`Route %q overlaps with "ipv6.ovn.ranges" (%q)`, routes, ovnRange)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -798,6 +798,13 @@ func (n *bridge) Validate(config map[string]string) error {
 		return err
 	}
 
+	// Check that ipv4.routes and ipv6.routes contain the routes for existing OVN network
+	// forwards and load balancers.
+	err = n.validateRoutes(config)
+	if err != nil {
+		return err
+	}
+
 	// Validate network name when used in fan mode.
 	bridgeMode := config["bridge.mode"]
 	if bridgeMode == "fan" && len(n.name) > 11 {

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -209,6 +209,105 @@ func (n *common) validateZoneNames(config map[string]string) error {
 	return nil
 }
 
+// validateRoutes checks that ip routes are compatible with existing forwards and load balancers.
+func (n *common) validateRoutes(config map[string]string) error {
+	var (
+		routesListIPv4 []*net.IPNet
+		routesListIPv6 []*net.IPNet
+
+		forwards      map[string]map[string][]string
+		loadBalancers map[string]map[string][]string
+
+		err error
+	)
+
+	if config["ipv4.routes"] != "" {
+		routesListIPv4, err = shared.ParseNetworks(config["ipv4.routes"])
+		if err != nil {
+			return fmt.Errorf("Failed parsing ipv4.routes: %w", err)
+		}
+	}
+
+	if config["ipv6.routes"] != "" {
+		routesListIPv6, err = shared.ParseNetworks(config["ipv6.routes"])
+		if err != nil {
+			return fmt.Errorf("Failed parsing ipv6.routes: %w", err)
+		}
+	}
+
+	// Get all listen addresses for all dependent OVN networks.
+	// OVN networks do not support per-member forwards.
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		forwards, err = tx.GetProjectNetworkForwardListenAddressesByUplink(ctx, n.name, false)
+		if err != nil {
+			return fmt.Errorf("Failed to get listen addresses of OVN network forwards: %w", err)
+		}
+
+		loadBalancers, err = tx.GetProjectNetworkLoadBalancerListenAddressesByUplink(ctx, n.name, false)
+		if err != nil {
+			return fmt.Errorf("Failed to get listen addresses of OVN load balancers: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	checkListenAddressesOVN := func(project string, network string, ips []string) error {
+		for _, ip := range ips {
+			var routesKey string
+
+			netIP := net.ParseIP(ip)
+			routeExists := false
+
+			if netIP.To4() != nil {
+				// Listen address is IPv4.
+				for _, routes := range routesListIPv4 {
+					if routes.Contains(netIP) {
+						routeExists = true
+					}
+				}
+
+				routesKey = "ipv4.routes"
+			} else {
+				// Listen address is IPv6.
+				for _, routes := range routesListIPv6 {
+					if routes.Contains(netIP) {
+						routeExists = true
+					}
+				}
+
+				routesKey = "ipv6.routes"
+			}
+
+			if !routeExists {
+				return fmt.Errorf("%q is missing network for listener %q of network %q in project %q", routesKey, ip, network, project)
+			}
+		}
+
+		return nil
+	}
+
+	// Check that IP routes are provided for already existing OVN forwards and load balancers.
+	for _, listenAddresses := range []map[string]map[string][]string{forwards, loadBalancers} {
+		for project, networks := range listenAddresses {
+			for network, ips := range networks {
+				if n.name == network && n.project == project {
+					continue // Skip forwards set up on the uplink.
+				}
+
+				err = checkListenAddressesOVN(project, network, ips)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // ValidateName validates network name.
 func (n *common) ValidateName(name string) error {
 	err := validate.IsURLSegmentSafe(name)

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -219,6 +219,13 @@ func (n *physical) Validate(config map[string]string) error {
 		return err
 	}
 
+	// Check that ipv4.routes and ipv6.routes contain the routes for existing OVN network
+	// forwards and load balancers.
+	err = n.validateRoutes(config)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/shared/network_ip.go
+++ b/shared/network_ip.go
@@ -154,3 +154,19 @@ func (r *IPRange) String() string {
 
 	return fmt.Sprintf("%v-%v", r.Start, r.End)
 }
+
+// ParseNetworks parses a comma separated list of IP networks in CIDR notation.
+func ParseNetworks(netList string) ([]*net.IPNet, error) {
+	networks := strings.Split(netList, ",")
+	ipNetworks := make([]*net.IPNet, 0, len(networks))
+	for _, network := range networks {
+		_, ipNet, err := net.ParseCIDR(strings.TrimSpace(network))
+		if err != nil {
+			return nil, err
+		}
+
+		ipNetworks = append(ipNetworks, ipNet)
+	}
+
+	return ipNetworks, nil
+}


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15221.

**Changes:**
- Validate that listen addresses of network forwards and load balancers do not overlap with OVN ranges. However, allow forwards and load balancers on OVN networks using `volatile.network.ipv4.address` and `volatile.network.ipv6.address` as listen address.
- Validate that `ipv4.routes` and `ipv6.routes` on physical and bridge networks are compatible with existing forwards and load balancers.
- Prevent using IPs from OVN range for NIC passthrough to an instance using `ipv4.routes.external` and `ipv6.routes.external`.
- Add tests to check that forwards and load balancers cannot be created with a listen address that overlaps with OVN ranges.
- Add tests to check that `ipv4.routes` and `ipv6.routes` cannot be removed for existing OVN forwards and load balancers.
- Add tests to check that forwards and load balancers can be set up on `volatile.network.ipv4.address` and `volatile.network.ipv6.address` of the associated OVN network.
- Add tests to check that instance NIC passthrough does not allow using IPs from OVN ranges.