### PR TITLE
test/suites/backup: On cephfs add sync calls after `file push`

### DIFF
--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -736,6 +736,7 @@ _backup_volume_export_with_project() {
 
   # Create file on the custom volume.
   echo foo | lxc file push - c1/mnt/test
+  LXC_LOCAL='' lxc_remote exec c1 -- sync /mnt/test
 
   # Snapshot the custom volume.
   lxc storage volume set "${custom_vol_pool}" testvol user.foo=test-snap0
@@ -743,6 +744,7 @@ _backup_volume_export_with_project() {
 
   # Change the content (the snapshot will contain the old value).
   echo bar | lxc file push - c1/mnt/test
+  LXC_LOCAL='' lxc_remote exec c1 -- sync /mnt/test
 
   lxc storage volume set "${custom_vol_pool}" testvol user.foo=test-snap1
   lxc storage volume snapshot "${custom_vol_pool}" testvol test-snap1


### PR DESCRIPTION
Fixes the flaky test of volume export on cephfs.

Tested with custom PR on github which isolates the core of the backup_volume_export test and runs it in a loop:
https://github.com/canonical/lxd/pull/15306

Without the sync call, the test suite failed after 17 runs of the inner loop. With the sync, it run for 100 runs without failure.