### PR TITLE
Resources: Add device's filesystem UUID if present

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2638,3 +2638,7 @@ Adds new {config:option}`instance-security:security.delegate_bpf`.* group of opt
 ## `override_snapshot_profiles_on_copy`
 
 This adds a request option to set snapshot's target profile on instance copy to be inherited from target instance.
+
+## `resources_device_fs_uuid`
+
+Adds the field `device_fs_uuid` including the respective UUID to each disk and partition indicating whether or not a filesystem is located on the device.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5496,6 +5496,11 @@ definitions:
                 example: "259:0"
                 type: string
                 x-go-name: Device
+            device_fs_uuid:
+                description: UUID of the filesystem on the device
+                example: 9313518c-0e13-4067-9746-5c1703830b78
+                type: string
+                x-go-name: DeviceFSUUID
             device_id:
                 description: Device by-id identifier
                 example: nvme-eui.0000000001000000e4d25cafae2e4c00
@@ -5595,6 +5600,11 @@ definitions:
                 example: "259:1"
                 type: string
                 x-go-name: Device
+            device_fs_uuid:
+                description: UUID of the filesystem on the device
+                example: 9313518c-0e13-4067-9746-5c1703830b78
+                type: string
+                x-go-name: DeviceFSUUID
             id:
                 description: ID of the partition (device name)
                 example: nvme0n1p1

--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -13,7 +12,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -438,24 +436,4 @@ func GetStorage() (*api.ResourcesStorage, error) {
 	}
 
 	return &storage, nil
-}
-
-// GetDisksByID returns all disks whose ID contains the filter prefix.
-func GetDisksByID(filterPrefix string) ([]string, error) {
-	disks, err := os.ReadDir(devDiskByID)
-	if err != nil {
-		return nil, fmt.Errorf("Failed getting disks by ID: %w", err)
-	}
-
-	var filteredDisks []string
-	for _, disk := range disks {
-		// Skip the disk if it does not have the prefix.
-		if !shared.StringHasPrefix(disk.Name(), filterPrefix) {
-			continue
-		}
-
-		filteredDisks = append(filteredDisks, path.Join(devDiskByID, disk.Name()))
-	}
-
-	return filteredDisks, nil
 }

--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -16,7 +16,6 @@ import (
 )
 
 var devDiskByPath = "/dev/disk/by-path"
-var devDiskByID = "/dev/disk/by-id"
 var runUdevData = "/run/udev/data"
 var sysClassBlock = "/sys/class/block"
 var procSelfMountInfo = "/proc/self/mountinfo"
@@ -385,15 +384,15 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			}
 
 			// Try to find the udev device id
-			if sysfsExists(devDiskByID) {
-				links, err := os.ReadDir(devDiskByID)
+			if sysfsExists(block.DevDiskByID) {
+				links, err := os.ReadDir(block.DevDiskByID)
 				if err != nil {
-					return nil, fmt.Errorf("Failed to list the links in %q: %w", devDiskByID, err)
+					return nil, fmt.Errorf("Failed to list the links in %q: %w", block.DevDiskByID, err)
 				}
 
 				for _, link := range links {
 					linkName := link.Name()
-					linkPath := filepath.Join(devDiskByID, linkName)
+					linkPath := filepath.Join(block.DevDiskByID, linkName)
 
 					linkTarget, err := filepath.EvalSymlinks(linkPath)
 					if err != nil {

--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -12,6 +12,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -357,6 +358,12 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 				partition.Size = partitionSize * 512
 
+				// Pull device filesystem UUID information.
+				partition.DeviceFSUUID, err = block.DiskFSUUID(filepath.Join("/dev", subEntryName))
+				if err != nil {
+					return nil, err
+				}
+
 				// Add to list
 				disk.Partitions = append(disk.Partitions, partition)
 			}
@@ -418,6 +425,12 @@ func GetStorage() (*api.ResourcesStorage, error) {
 				if err == nil {
 					disk.RPM = diskRotational
 				}
+			}
+
+			// Pull device filesystem UUID information.
+			disk.DeviceFSUUID, err = block.DiskFSUUID(filepath.Join("/dev", entryName))
+			if err != nil {
+				return nil, err
 			}
 
 			// Add to list

--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -108,6 +108,16 @@ func DiskBlockSize(path string) (uint32, error) {
 	return res, nil
 }
 
+// DiskFSUUID returns the UUID of a filesystem on the device.
+func DiskFSUUID(pathName string) (string, error) {
+	uuid, err := shared.RunCommandContext(context.TODO(), "blkid", "-s", "UUID", "-o", "value", pathName)
+	if err != nil {
+		return "", fmt.Errorf("Failed to retrieve filesystem UUID from device %q: %w", pathName, err)
+	}
+
+	return strings.TrimSpace(uuid), nil
+}
+
 // WaitDiskDeviceResize waits until the disk device reflects the new size.
 func WaitDiskDeviceResize(ctx context.Context, diskPath string, newSizeBytes int64) error {
 	_, ok := ctx.Deadline()

--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -15,6 +15,9 @@ import (
 	"github.com/canonical/lxd/shared"
 )
 
+// DevDiskByID represents the system's path for disks identified by their ID.
+const DevDiskByID = "/dev/disk/by-id"
+
 // devicePathFilterFunc is a function that accepts device path and returns true
 // if the path matches the required criteria.
 type devicePathFilterFunc func(devPath string) bool

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -784,7 +784,7 @@ func loopDeviceSetup(sourcePath string) (string, error) {
 		return strings.TrimSpace(out), nil
 	}
 
-	if !(strings.Contains(err.Error(), "direct io") || strings.Contains(err.Error(), "Invalid argument")) {
+	if !strings.Contains(err.Error(), "direct io") && !strings.Contains(err.Error(), "Invalid argument") {
 		return "", err
 	}
 

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/canonical/lxd/lxd/idmap"
 	"github.com/canonical/lxd/lxd/locking"
 	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -223,7 +224,7 @@ func tryExists(ctx context.Context, path string) bool {
 // fsUUID returns the filesystem UUID for the given block path.
 // error is returned if the given block device exists but has no UUID.
 func fsUUID(path string) (string, error) {
-	val, err := shared.RunCommandContext(context.TODO(), "blkid", "-s", "UUID", "-o", "value", path)
+	val, err := block.DiskFSUUID(path)
 	if err != nil {
 		return "", err
 	}
@@ -234,7 +235,7 @@ func fsUUID(path string) (string, error) {
 		return "", fmt.Errorf("No UUID for device %q", path)
 	}
 
-	return strings.TrimSpace(val), nil
+	return val, nil
 }
 
 // fsProbe returns the filesystem type for the given block path.

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -679,6 +679,12 @@ type ResourcesStorageDisk struct {
 	//
 	// API extension: resources_disk_address
 	USBAddress string `json:"usb_address,omitempty" yaml:"usb_address,omitempty"`
+
+	// UUID of the filesystem on the device
+	// Example: 9313518c-0e13-4067-9746-5c1703830b78
+	//
+	// API extension: resources_device_fs_uuid
+	DeviceFSUUID string `json:"device_fs_uuid" yaml:"device_fs_uuid"`
 }
 
 // ResourcesStorageDiskPartition represents a partition on a disk
@@ -710,6 +716,12 @@ type ResourcesStorageDiskPartition struct {
 	// Mounted status of the partition.
 	// Example: true
 	Mounted bool `json:"mounted" yaml:"mounted"`
+
+	// UUID of the filesystem on the device
+	// Example: 9313518c-0e13-4067-9746-5c1703830b78
+	//
+	// API extension: resources_device_fs_uuid
+	DeviceFSUUID string `json:"device_fs_uuid" yaml:"device_fs_uuid"`
 }
 
 // ResourcesMemory represents the memory resources available on the system

--- a/shared/util.go
+++ b/shared/util.go
@@ -996,7 +996,7 @@ func RemoveDuplicatesFromString(s string, sep string) string {
 
 	dup := sep + sep
 	for strings.Contains(s, dup) {
-		s = strings.Replace(s, dup, sep, -1)
+		s = strings.ReplaceAll(s, dup, sep)
 	}
 
 	return s

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -444,6 +444,7 @@ var APIExtensions = []string{
 	"clustering_groups_used_by",
 	"container_bpf_delegation",
 	"override_snapshot_profiles_on_copy",
+	"resources_device_fs_uuid",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This allows MicroCloud checking (https://github.com/canonical/microcloud/pull/724) whether or not a device is already used after fetching the list of disks from `/1.0/resources`. 

The PR adds another field `device_fs_uuid` to both disks and partitions returned from the resources endpoint.
A new API extension `resources_device_fs_uuid` is added to indicate this change.