### PR TITLE
Network: Improve network priority during network startup

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -915,10 +915,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	allNodes := false
-	if s.ServerClustered && request.QueryParam(r, "target") == "" {
-		allNodes = true
-	}
+	allNodes := s.ServerClustered && request.QueryParam(r, "target") == ""
 
 	n, err := doNetworkGet(s, r, allNodes, details.requestProject.Name, details.requestProject.Config, details.networkName)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15273.

**Changes:**  
- Set `networkPriorityLogical` to bridge interfaces that have "bridge.external_interfaces" field set, since they might depend on managed physical networks.