### PR TITLE
Refactor devlxd API

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -350,13 +350,14 @@ func ConnectDevLXDWithContext(ctx context.Context, socketPath string, args *Conn
 	ctxConnected, ctxConnectedCancel := context.WithCancel(context.Background())
 
 	return &ProtocolDevLXD{
-		ctx:                ctx,
-		ctxConnected:       ctxConnected,
-		ctxConnectedCancel: ctxConnectedCancel,
-		http:               client,
-		httpBaseURL:        *baseURL,
-		httpUnixPath:       socketPath,
-		httpUserAgent:      useragent,
+		ctx:                  ctx,
+		ctxConnected:         ctxConnected,
+		ctxConnectedCancel:   ctxConnectedCancel,
+		http:                 client,
+		httpBaseURL:          *baseURL,
+		httpUnixPath:         socketPath,
+		httpUserAgent:        useragent,
+		eventListenerManager: newEventListenerManager(ctx),
 	}, nil
 }
 

--- a/client/connection.go
+++ b/client/connection.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	"github.com/canonical/lxd/shared"
@@ -116,14 +115,13 @@ func ConnectLXDHTTPWithContext(ctx context.Context, args *ConnectionArgs, client
 
 	// Initialize the client struct
 	server := ProtocolLXD{
-		ctx:                ctx,
-		httpBaseURL:        *httpBaseURL,
-		httpProtocol:       "custom",
-		httpUserAgent:      args.UserAgent,
-		ctxConnected:       ctxConnected,
-		ctxConnectedCancel: ctxConnectedCancel,
-		eventConns:         make(map[string]*websocket.Conn),
-		eventListeners:     make(map[string][]*EventListener),
+		ctx:                  ctx,
+		httpBaseURL:          *httpBaseURL,
+		httpProtocol:         "custom",
+		httpUserAgent:        args.UserAgent,
+		ctxConnected:         ctxConnected,
+		ctxConnectedCancel:   ctxConnectedCancel,
+		eventListenerManager: newEventListenerManager(ctx),
 	}
 
 	// Setup the HTTP client
@@ -175,15 +173,14 @@ func ConnectLXDUnixWithContext(ctx context.Context, path string, args *Connectio
 
 	// Initialize the client struct
 	server := ProtocolLXD{
-		ctx:                ctx,
-		httpBaseURL:        *httpBaseURL,
-		httpUnixPath:       path,
-		httpProtocol:       "unix",
-		httpUserAgent:      args.UserAgent,
-		ctxConnected:       ctxConnected,
-		ctxConnectedCancel: ctxConnectedCancel,
-		eventConns:         make(map[string]*websocket.Conn),
-		eventListeners:     make(map[string][]*EventListener),
+		ctx:                  ctx,
+		httpBaseURL:          *httpBaseURL,
+		httpUnixPath:         path,
+		httpProtocol:         "unix",
+		httpUserAgent:        args.UserAgent,
+		ctxConnected:         ctxConnected,
+		ctxConnectedCancel:   ctxConnectedCancel,
+		eventListenerManager: newEventListenerManager(ctx),
 	}
 
 	// Determine the socket path.
@@ -379,15 +376,14 @@ func httpsLXD(ctx context.Context, requestURL string, args *ConnectionArgs) (Ins
 
 	// Initialize the client struct
 	server := ProtocolLXD{
-		ctx:                ctx,
-		httpCertificate:    args.TLSServerCert,
-		httpBaseURL:        *httpBaseURL,
-		httpProtocol:       "https",
-		httpUserAgent:      args.UserAgent,
-		ctxConnected:       ctxConnected,
-		ctxConnectedCancel: ctxConnectedCancel,
-		eventConns:         make(map[string]*websocket.Conn),
-		eventListeners:     make(map[string][]*EventListener),
+		ctx:                  ctx,
+		httpCertificate:      args.TLSServerCert,
+		httpBaseURL:          *httpBaseURL,
+		httpProtocol:         "https",
+		httpUserAgent:        args.UserAgent,
+		ctxConnected:         ctxConnected,
+		ctxConnectedCancel:   ctxConnectedCancel,
+		eventListenerManager: newEventListenerManager(ctx),
 	}
 
 	if shared.ValueInSlice(args.AuthType, []string{api.AuthenticationMethodOIDC}) {

--- a/client/devlxd.go
+++ b/client/devlxd.go
@@ -31,6 +31,8 @@ type ProtocolDevLXD struct {
 	httpBaseURL   url.URL
 	httpUnixPath  string
 	httpUserAgent string
+
+	eventListenerManager *eventListenerManager
 }
 
 // GetConnectionInfo returns the basic connection information used to interact with the server.

--- a/client/devlxd.go
+++ b/client/devlxd.go
@@ -62,6 +62,14 @@ func (r *ProtocolDevLXD) Disconnect() {
 	r.ctxConnectedCancel()
 }
 
+// RawQuery allows directly querying the devLXD.
+//
+// This should only be used by internal LXD tools.
+func (r *ProtocolDevLXD) RawQuery(method string, path string, data any, ETag string) (*api.DevLXDResponse, string, error) {
+	url := r.httpBaseURL.String() + path
+	return r.rawQuery(method, url, data, ETag)
+}
+
 // rawQuery is a method that sends HTTP request to the devLXD with the provided
 // method, URL, data, and ETag. It processes the request based on the data's
 // type and handles the HTTP response, returning parsed results or an error

--- a/client/devlxd.go
+++ b/client/devlxd.go
@@ -1,0 +1,187 @@
+package lxd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/version"
+)
+
+// ProtocolDevLXD represents a devLXD API server.
+type ProtocolDevLXD struct {
+	ctx context.Context
+
+	// Context related to the current connection.
+	ctxConnected       context.Context
+	ctxConnectedCancel context.CancelFunc
+
+	// HTTP client information.
+	http          *http.Client
+	httpBaseURL   url.URL
+	httpUnixPath  string
+	httpUserAgent string
+}
+
+// GetConnectionInfo returns the basic connection information used to interact with the server.
+func (r *ProtocolDevLXD) GetConnectionInfo() (*ConnectionInfo, error) {
+	return &ConnectionInfo{
+		Protocol:   "devlxd",
+		URL:        r.httpBaseURL.String(),
+		SocketPath: r.httpUnixPath,
+	}, nil
+}
+
+// GetHTTPClient returns the http client used for the connection. This can be used to set custom http options.
+func (r *ProtocolDevLXD) GetHTTPClient() (*http.Client, error) {
+	if r.http == nil {
+		return nil, fmt.Errorf("HTTP client isn't set, bad connection")
+	}
+
+	return r.http, nil
+}
+
+// DoHTTP performs a Request.
+func (r *ProtocolDevLXD) DoHTTP(req *http.Request) (resp *http.Response, err error) {
+	// Set the user agent
+	if r.httpUserAgent != "" {
+		req.Header.Set("User-Agent", r.httpUserAgent)
+	}
+
+	return r.http.Do(req)
+}
+
+// Disconnect is a no-op for devLXD.
+func (r *ProtocolDevLXD) Disconnect() {
+	r.ctxConnectedCancel()
+}
+
+// rawQuery is a method that sends HTTP request to the devLXD with the provided
+// method, URL, data, and ETag. It processes the request based on the data's
+// type and handles the HTTP response, returning parsed results or an error
+// if it occurs.
+func (r *ProtocolDevLXD) rawQuery(method string, url string, data any, ETag string) (devLXDResp *api.DevLXDResponse, etag string, err error) {
+	var req *http.Request
+
+	// Log the request
+	logger.Debug("Sending request to devLXD", logger.Ctx{
+		"method": method,
+		"url":    url,
+		"etag":   ETag,
+	})
+
+	// Get a new HTTP request setup
+	if data != nil {
+		// Encode the provided data
+		buf := bytes.Buffer{}
+		err := json.NewEncoder(&buf).Encode(data)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// Some data to be sent along with the request
+		// Use a reader since the request body needs to be seekable
+		req, err = http.NewRequestWithContext(r.ctx, method, url, bytes.NewReader(buf.Bytes()))
+		if err != nil {
+			return nil, "", err
+		}
+
+		// Set the encoding accordingly
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		// No data to be sent along with the request
+		req, err = http.NewRequestWithContext(r.ctx, method, url, nil)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	// Set the ETag.
+	if ETag != "" {
+		req.Header.Set("If-Match", ETag)
+	}
+
+	req.Header.Set("User-Agent", r.httpUserAgent)
+
+	// Send the request.
+	resp, err := r.http.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	defer resp.Body.Close()
+
+	return devLXDParseResponse(resp)
+}
+
+// query sends a query to the devLXD and returns the response.
+func (r *ProtocolDevLXD) query(method string, path string, data any, ETag string) (devLXDResp *api.DevLXDResponse, etag string, err error) {
+	// Generate the URL
+	urlString := r.httpBaseURL.String() + "/" + version.APIVersion
+	if path != "" {
+		urlString += path
+	}
+
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, "", err
+	}
+
+	url.RawQuery = url.Query().Encode()
+
+	// Run the actual query
+	return r.rawQuery(method, url.String(), data, ETag)
+}
+
+// queryStruct sends a query to the devLXD, then converts the response content into the specified target struct.
+// The function returns the etag of the response, and handles any errors during this process.
+func (r *ProtocolDevLXD) queryStruct(method string, urlPath string, data any, ETag string, target any) (etag string, err error) {
+	resp, etag, err := r.query(method, urlPath, data, ETag)
+	if err != nil {
+		return "", err
+	}
+
+	err = resp.ContentAsStruct(&target)
+	if err != nil {
+		return "", err
+	}
+
+	return etag, nil
+}
+
+// devLXDParseResponse processes the HTTP response from the devLXD. It reads the response body,
+// checks the status code, and returns a DevLXDResponse struct containing the content and status code.
+// If the response is not successful, it returns an error instead.
+func devLXDParseResponse(resp *http.Response) (*api.DevLXDResponse, string, error) {
+	var content []byte
+	var err error
+
+	// Get the ETag
+	etag := resp.Header.Get("ETag")
+
+	// Read response body.
+	content, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("Failed to read response body from %q: %v", resp.Request.URL.String(), err)
+	}
+
+	// Handel error response.
+	if resp.StatusCode != http.StatusOK {
+		if len(content) == 0 {
+			return nil, "", api.NewGenericStatusError(resp.StatusCode)
+		}
+
+		return nil, "", api.NewStatusError(resp.StatusCode, string(content))
+	}
+
+	return &api.DevLXDResponse{
+		Content:    content,
+		StatusCode: resp.StatusCode,
+	}, etag, nil
+}

--- a/client/devlxd_config.go
+++ b/client/devlxd_config.go
@@ -1,0 +1,50 @@
+package lxd
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// GetConfig retrieves a guest's configuration as a map.
+func (r *ProtocolDevLXD) GetConfig() (map[string]string, error) {
+	var keyPaths []string
+
+	// Fetch list of config key url paths.
+	_, err := r.queryStruct(http.MethodGet, "/config", nil, "", &keyPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over key paths and fetch their values.
+	config := make(map[string]string, len(keyPaths))
+	for _, path := range keyPaths {
+		// Extract the key from the path.
+		_, key, ok := strings.Cut(path, "/config/")
+		if !ok {
+			continue
+		}
+
+		// Fetch the value for the key.
+		value, err := r.GetConfigByKey(key)
+		if err != nil {
+			return nil, err
+		}
+
+		config[key] = value
+	}
+
+	return config, nil
+}
+
+// GetConfigByKey retrieves a guest's configuration for the given key.
+func (r *ProtocolDevLXD) GetConfigByKey(key string) (string, error) {
+	url := api.NewURL().Path("config", key).URL
+	resp, _, err := r.query(http.MethodGet, url.String(), nil, "")
+	if err != nil {
+		return "", err
+	}
+
+	return string(resp.Content), nil
+}

--- a/client/devlxd_devices.go
+++ b/client/devlxd_devices.go
@@ -1,0 +1,17 @@
+package lxd
+
+import (
+	"net/http"
+)
+
+// GetDevices retrieves a map of guest's devices.
+func (r *ProtocolDevLXD) GetDevices() (devices map[string]map[string]string, err error) {
+	devices = make(map[string]map[string]string)
+
+	_, err = r.queryStruct(http.MethodGet, "/devices", nil, "", &devices)
+	if err != nil {
+		return nil, err
+	}
+
+	return devices, nil
+}

--- a/client/devlxd_events.go
+++ b/client/devlxd_events.go
@@ -1,0 +1,16 @@
+package lxd
+
+import (
+	"github.com/gorilla/websocket"
+)
+
+// GetEvents connects to the devLXD event monitoring interface.
+func (r *ProtocolDevLXD) GetEvents() (*EventListener, error) {
+	// Wrap websocket connection in a function to allow the manager to
+	// establish a new connection.
+	getWebsocket := func() (*websocket.Conn, error) {
+		return r.RawWebsocket("/events")
+	}
+
+	return r.eventListenerManager.getEvents(r.ctxConnected, getWebsocket, "")
+}

--- a/client/devlxd_images.go
+++ b/client/devlxd_images.go
@@ -1,0 +1,19 @@
+package lxd
+
+import (
+	"fmt"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/version"
+)
+
+// GetImageFile exports the image with a given fingerprint from the host's LXD.
+// Note that only cached and public images can be exported.
+func (r *ProtocolDevLXD) GetImageFile(fingerprint string, req ImageFileRequest) (*ImageFileResponse, error) {
+	if req.MetaFile == nil {
+		return nil, fmt.Errorf("The MetaFile field is required")
+	}
+
+	url := api.NewURL().Scheme(r.httpBaseURL.Scheme).Host(r.httpBaseURL.Host).Path(version.APIVersion, "images", fingerprint, "export").URL
+	return lxdDownloadImage(fingerprint, url.String(), r.httpUserAgent, r.DoHTTP, req)
+}

--- a/client/devlxd_metadata.go
+++ b/client/devlxd_metadata.go
@@ -1,0 +1,15 @@
+package lxd
+
+import (
+	"net/http"
+)
+
+// GetMetadata retrieves the instance's meta-data.
+func (r *ProtocolDevLXD) GetMetadata() (metadata string, err error) {
+	resp, _, err := r.query(http.MethodGet, "/meta-data", nil, "")
+	if err != nil {
+		return "", err
+	}
+
+	return string(resp.Content), nil
+}

--- a/client/devlxd_state.go
+++ b/client/devlxd_state.go
@@ -1,0 +1,29 @@
+package lxd
+
+import (
+	"net/http"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// GetState retrieves the guest state.
+func (r *ProtocolDevLXD) GetState() (*api.DevLXDGet, error) {
+	var info api.DevLXDGet
+
+	_, err := r.queryStruct(http.MethodGet, "", nil, "", &info)
+	if err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// UpdateState updates the guest state.
+func (r *ProtocolDevLXD) UpdateState(req api.DevLXDPut) error {
+	_, _, err := r.query(http.MethodPatch, "", req, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/client/devlxd_ubuntu_pro.go
+++ b/client/devlxd_ubuntu_pro.go
@@ -1,0 +1,31 @@
+package lxd
+
+import (
+	"net/http"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// GetUbuntuPro retrieves the guest's Ubuntu Pro settings.
+func (r *ProtocolDevLXD) GetUbuntuPro() (*api.UbuntuProSettings, error) {
+	var info api.UbuntuProSettings
+
+	_, err := r.queryStruct(http.MethodGet, "/ubuntu-pro", nil, "", &info)
+	if err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// CreateUbuntuProToken creates a new Ubuntu Pro token.
+func (r *ProtocolDevLXD) CreateUbuntuProToken() (*api.UbuntuProGuestTokenResponse, error) {
+	var token api.UbuntuProGuestTokenResponse
+
+	_, err := r.queryStruct(http.MethodPost, "/ubuntu-pro/token", nil, "", &token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &token, nil
+}

--- a/client/events.go
+++ b/client/events.go
@@ -2,15 +2,20 @@ package lxd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/gorilla/websocket"
+
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/revert"
 )
 
 // The EventListener struct is used to interact with a LXD event stream.
 type EventListener struct {
-	r         *ProtocolLXD
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	err       error
@@ -74,24 +79,6 @@ func (e *EventListener) RemoveHandler(target *EventTarget) error {
 
 // Disconnect must be used once done listening for events.
 func (e *EventListener) Disconnect() {
-	// Handle locking
-	e.r.eventListenersLock.Lock()
-	defer e.r.eventListenersLock.Unlock()
-
-	if e.ctx.Err() != nil {
-		return
-	}
-
-	// Locate and remove it from the global list
-	for i, listener := range e.r.eventListeners[e.projectName] {
-		if listener == e {
-			copy(e.r.eventListeners[e.projectName][i:], e.r.eventListeners[e.projectName][i+1:])
-			e.r.eventListeners[e.projectName][len(e.r.eventListeners[e.projectName])-1] = nil
-			e.r.eventListeners[e.projectName] = e.r.eventListeners[e.projectName][:len(e.r.eventListeners[e.projectName])-1]
-			break
-		}
-	}
-
 	// Turn off the handler
 	e.err = nil
 	e.ctxCancel()
@@ -106,4 +93,211 @@ func (e *EventListener) Wait() error {
 // IsActive returns true if this listener is still connected, false otherwise.
 func (e *EventListener) IsActive() bool {
 	return e.ctx.Err() == nil
+}
+
+// The eventListenerManager is used to manage event listeners.
+type eventListenerManager struct {
+	ctx context.Context
+
+	// eventConns contains event listener connections associated to a project name (or empty for all projects).
+	eventConns map[string]*websocket.Conn
+
+	// eventConnsLock controls write access to the eventConns.
+	eventConnsLock sync.Mutex
+
+	// eventListeners is a slice of event listeners associated to a project name (or empty for all projects).
+	eventListeners     map[string][]*EventListener
+	eventListenersLock sync.Mutex
+}
+
+// newEventListenerManager creates a new event listener manager.
+func newEventListenerManager(ctx context.Context) *eventListenerManager {
+	return &eventListenerManager{
+		ctx:            ctx,
+		eventConns:     make(map[string]*websocket.Conn),
+		eventListeners: make(map[string][]*EventListener),
+	}
+}
+
+// getEvents connects to the LXD monitoring interface.
+func (m *eventListenerManager) getEvents(ctxConnected context.Context, websocketHook func() (*websocket.Conn, error), project string) (*EventListener, error) {
+	// If a specific project is not provided, listen to all projects.
+	allProjects := project == ""
+
+	// Prevent anything else from interacting with the listeners
+	m.eventListenersLock.Lock()
+	defer m.eventListenersLock.Unlock()
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Make sure the context is cancelled in case of an error
+	// to prevent leaking a go routine that waits for it.
+	revert.Add(func() {
+		cancel()
+	})
+
+	// Setup a new listener
+	listener := EventListener{
+		ctx:       ctx,
+		ctxCancel: cancel,
+	}
+
+	if !allProjects {
+		listener.projectName = project
+	}
+
+	// Make sure we remove the listener from the list when it's context is done.
+	go func() {
+		<-ctx.Done()
+		m.eventListenersLock.Lock()
+		defer m.eventListenersLock.Unlock()
+
+		// Locate and remove the listener from the global list
+		for i, l := range m.eventListeners[listener.projectName] {
+			if &listener == l {
+				copy(m.eventListeners[listener.projectName][i:], m.eventListeners[listener.projectName][i+1:])
+				m.eventListeners[listener.projectName][len(m.eventListeners[listener.projectName])-1] = nil
+				m.eventListeners[listener.projectName] = m.eventListeners[listener.projectName][:len(m.eventListeners[listener.projectName])-1]
+				return
+			}
+		}
+	}()
+
+	// There is an existing Go routine for the required project filter, so just add another target.
+	if m.eventListeners[listener.projectName] != nil {
+		m.eventListeners[listener.projectName] = append(m.eventListeners[listener.projectName], &listener)
+		revert.Success()
+		return &listener, nil
+	}
+
+	// Connect to the websocket.
+	wsConn, err := websocketHook()
+	if err != nil {
+		return nil, err
+	}
+
+	m.eventConnsLock.Lock()
+	m.eventConns[listener.projectName] = wsConn // Save for others to use.
+	m.eventConnsLock.Unlock()
+
+	// Initialize the event listener list if we were able to connect to the events websocket.
+	m.eventListeners[listener.projectName] = []*EventListener{&listener}
+
+	// Spawn a watcher that will close the websocket connection after all
+	// listeners are gone.
+	stopCh := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-time.After(time.Minute):
+			case <-ctxConnected.Done():
+			case <-stopCh:
+			}
+
+			m.eventListenersLock.Lock()
+			m.eventConnsLock.Lock()
+			if len(m.eventListeners[listener.projectName]) == 0 {
+				// We don't need the connection anymore, disconnect and clear.
+				if m.eventListeners[listener.projectName] != nil {
+					_ = m.eventConns[listener.projectName].Close()
+					delete(m.eventConns, listener.projectName)
+				}
+
+				m.eventListeners[listener.projectName] = nil
+				m.eventListenersLock.Unlock()
+				m.eventConnsLock.Unlock()
+
+				return
+			}
+
+			m.eventListenersLock.Unlock()
+			m.eventConnsLock.Unlock()
+		}
+	}()
+
+	// Spawn the listener
+	go func() {
+		for {
+			_, data, err := wsConn.ReadMessage()
+			if err != nil {
+				// Prevent anything else from interacting with the listeners
+				m.eventListenersLock.Lock()
+				defer m.eventListenersLock.Unlock()
+
+				// Tell all the current listeners about the failure
+				for _, listener := range m.eventListeners[listener.projectName] {
+					listener.err = err
+					listener.ctxCancel()
+				}
+
+				// And remove them all from the list so that when watcher routine runs it will
+				// close the websocket connection.
+				m.eventListeners[listener.projectName] = nil
+
+				close(stopCh) // Instruct watcher go routine to cleanup.
+				return
+			}
+
+			// Attempt to unpack the message
+			event := api.Event{}
+			err = json.Unmarshal(data, &event)
+			if err != nil {
+				continue
+			}
+
+			// Extract the message type
+			if event.Type == "" {
+				continue
+			}
+
+			// Send the message to all handlers
+			m.eventListenersLock.Lock()
+			for _, listener := range m.eventListeners[listener.projectName] {
+				listener.targetsLock.Lock()
+				for _, target := range listener.targets {
+					if target.types != nil && !shared.ValueInSlice(event.Type, target.types) {
+						continue
+					}
+
+					go target.function(event)
+				}
+
+				listener.targetsLock.Unlock()
+			}
+
+			m.eventListenersLock.Unlock()
+		}
+	}()
+
+	revert.Success()
+	return &listener, nil
+}
+
+// SendEvent send an event to the server via the client's event listener connection.
+func (m *eventListenerManager) SendEvent(event api.Event) error {
+	m.eventConnsLock.Lock()
+	defer m.eventConnsLock.Unlock()
+
+	// Find an available event listener connection.
+	// It doesn't matter which project the event listener connection is using, as this only affects which
+	// events are received from the server, not which events we can send to it.
+	var eventConn *websocket.Conn
+	for _, eventConn = range m.eventConns {
+		break
+	}
+
+	if eventConn == nil {
+		return fmt.Errorf("No available event listener connection")
+	}
+
+	deadline, ok := m.ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(5 * time.Second)
+	}
+
+	_ = eventConn.SetWriteDeadline(deadline)
+	return eventConn.WriteJSON(event)
 }

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -472,6 +472,9 @@ type InstanceServer interface {
 // The DevLXDServer type represents a devLXD server.
 type DevLXDServer interface {
 	Server
+
+	// Internal functions (for internal use)
+	RawQuery(method string, path string, data any, queryETag string) (resp *api.DevLXDResponse, ETag string, err error)
 }
 
 // The ConnectionInfo struct represents general information for a connection.

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -477,6 +477,9 @@ type DevLXDServer interface {
 	GetState() (state *api.DevLXDGet, err error)
 	UpdateState(state api.DevLXDPut) error
 
+	// DevLXD devices.
+	GetDevices() (devices map[string]map[string]string, err error)
+
 	// Internal functions (for internal use)
 	RawQuery(method string, path string, data any, queryETag string) (resp *api.DevLXDResponse, ETag string, err error)
 }

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -469,6 +469,11 @@ type InstanceServer interface {
 	RawOperation(method string, path string, data any, queryETag string) (op Operation, ETag string, err error)
 }
 
+// The DevLXDServer type represents a devLXD server.
+type DevLXDServer interface {
+	Server
+}
+
 // The ConnectionInfo struct represents general information for a connection.
 type ConnectionInfo struct {
 	Addresses   []string

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -473,6 +473,10 @@ type InstanceServer interface {
 type DevLXDServer interface {
 	Server
 
+	// DevLXD info/state.
+	GetState() (state *api.DevLXDGet, err error)
+	UpdateState(state api.DevLXDPut) error
+
 	// Internal functions (for internal use)
 	RawQuery(method string, path string, data any, queryETag string) (resp *api.DevLXDResponse, ETag string, err error)
 }

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -477,6 +477,9 @@ type DevLXDServer interface {
 	GetState() (state *api.DevLXDGet, err error)
 	UpdateState(state api.DevLXDPut) error
 
+	// DevLXD metadata.
+	GetMetadata() (metadata string, err error)
+
 	// DevLXD devices.
 	GetDevices() (devices map[string]map[string]string, err error)
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -483,6 +483,9 @@ type DevLXDServer interface {
 	// DevLXD devices.
 	GetDevices() (devices map[string]map[string]string, err error)
 
+	// DevLXD events.
+	GetEvents() (*EventListener, error)
+
 	// DevLXD Ubuntu Pro.
 	GetUbuntuPro() (*api.UbuntuProSettings, error)
 	CreateUbuntuProToken() (*api.UbuntuProGuestTokenResponse, error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -477,6 +477,10 @@ type DevLXDServer interface {
 	GetState() (state *api.DevLXDGet, err error)
 	UpdateState(state api.DevLXDPut) error
 
+	// DevLXD config.
+	GetConfig() (map[string]string, error)
+	GetConfigByKey(key string) (string, error)
+
 	// DevLXD metadata.
 	GetMetadata() (metadata string, err error)
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -486,6 +486,9 @@ type DevLXDServer interface {
 	// DevLXD events.
 	GetEvents() (*EventListener, error)
 
+	// DevLXD images.
+	GetImageFile(fingerprint string, req ImageFileRequest) (resp *ImageFileResponse, err error)
+
 	// DevLXD Ubuntu Pro.
 	GetUbuntuPro() (*api.UbuntuProSettings, error)
 	CreateUbuntuProToken() (*api.UbuntuProGuestTokenResponse, error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -483,6 +483,10 @@ type DevLXDServer interface {
 	// DevLXD devices.
 	GetDevices() (devices map[string]map[string]string, err error)
 
+	// DevLXD Ubuntu Pro.
+	GetUbuntuPro() (*api.UbuntuProSettings, error)
+	CreateUbuntuProToken() (*api.UbuntuProGuestTokenResponse, error)
+
 	// Internal functions (for internal use)
 	RawQuery(method string, path string, data any, queryETag string) (resp *api.DevLXDResponse, ETag string, err error)
 }

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	neturl "net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -27,15 +26,8 @@ type ProtocolLXD struct {
 	ctxConnected       context.Context
 	ctxConnectedCancel context.CancelFunc
 
-	// eventConns contains event listener connections associated to a project name (or empty for all projects).
-	eventConns map[string]*websocket.Conn
-
-	// eventConnsLock controls write access to the eventConns.
-	eventConnsLock sync.Mutex
-
-	// eventListeners is a slice of event listeners associated to a project name (or empty for all projects).
-	eventListeners     map[string][]*EventListener
-	eventListenersLock sync.Mutex
+	// eventListenersLock is used to synchronize access to the event listeners.
+	eventListenerManager *eventListenerManager
 
 	http            *http.Client
 	httpCertificate string

--- a/client/lxd_events.go
+++ b/client/lxd_events.go
@@ -1,163 +1,46 @@
 package lxd
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/gorilla/websocket"
 
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
 
-// Event handling functions
-
 // getEvents connects to the LXD monitoring interface.
 func (r *ProtocolLXD) getEvents(allProjects bool) (*EventListener, error) {
-	// Prevent anything else from interacting with the listeners
-	r.eventListenersLock.Lock()
-	defer r.eventListenersLock.Unlock()
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Setup a new listener
-	listener := EventListener{
-		r:         r,
-		ctx:       ctx,
-		ctxCancel: cancel,
-	}
-
+	// Resolve the project name.
 	connInfo, _ := r.GetConnectionInfo()
 	if connInfo.Project == "" {
 		return nil, fmt.Errorf("Unexpected empty project in connection info")
 	}
 
+	project := ""
 	if !allProjects {
-		listener.projectName = connInfo.Project
+		project = connInfo.Project
 	}
 
-	// There is an existing Go routine for the required project filter, so just add another target.
-	if r.eventListeners[listener.projectName] != nil {
-		r.eventListeners[listener.projectName] = append(r.eventListeners[listener.projectName], &listener)
-		return &listener, nil
-	}
-
-	// Setup a new connection with LXD
-	var url string
-	var err error
-	if allProjects {
-		url, err = r.setQueryAttributes("/events?all-projects=true")
-	} else {
-		url, err = r.setQueryAttributes("/events")
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	// Connect websocket and save.
-	wsConn, err := r.websocket(url)
-	if err != nil {
-		return nil, err
-	}
-
-	r.eventConnsLock.Lock()
-	r.eventConns[listener.projectName] = wsConn // Save for others to use.
-	r.eventConnsLock.Unlock()
-
-	// Initialize the event listener list if we were able to connect to the events websocket.
-	r.eventListeners[listener.projectName] = []*EventListener{&listener}
-
-	// Spawn a watcher that will close the websocket connection after all
-	// listeners are gone.
-	stopCh := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-time.After(time.Minute):
-			case <-r.ctxConnected.Done():
-			case <-stopCh:
-			}
-
-			r.eventListenersLock.Lock()
-			r.eventConnsLock.Lock()
-			if len(r.eventListeners[listener.projectName]) == 0 {
-				// We don't need the connection anymore, disconnect and clear.
-				if r.eventListeners[listener.projectName] != nil {
-					_ = r.eventConns[listener.projectName].Close()
-					delete(r.eventConns, listener.projectName)
-				}
-
-				r.eventListeners[listener.projectName] = nil
-				r.eventListenersLock.Unlock()
-				r.eventConnsLock.Unlock()
-
-				return
-			}
-
-			r.eventListenersLock.Unlock()
-			r.eventConnsLock.Unlock()
+	// Wrap websocket connection in a function to allow the manager to
+	// establish a new connection.
+	getWebsocket := func() (*websocket.Conn, error) {
+		// Resolve LXD events URL.
+		var url string
+		var err error
+		if allProjects {
+			url, err = r.setQueryAttributes("/events?all-projects=true")
+		} else {
+			url, err = r.setQueryAttributes("/events")
 		}
-	}()
 
-	// Spawn the listener
-	go func() {
-		for {
-			_, data, err := wsConn.ReadMessage()
-			if err != nil {
-				// Prevent anything else from interacting with the listeners
-				r.eventListenersLock.Lock()
-				defer r.eventListenersLock.Unlock()
-
-				// Tell all the current listeners about the failure
-				for _, listener := range r.eventListeners[listener.projectName] {
-					listener.err = err
-					listener.ctxCancel()
-				}
-
-				// And remove them all from the list so that when watcher routine runs it will
-				// close the websocket connection.
-				r.eventListeners[listener.projectName] = nil
-
-				close(stopCh) // Instruct watcher go routine to cleanup.
-
-				return
-			}
-
-			// Attempt to unpack the message
-			event := api.Event{}
-			err = json.Unmarshal(data, &event)
-			if err != nil {
-				continue
-			}
-
-			// Extract the message type
-			if event.Type == "" {
-				continue
-			}
-
-			// Send the message to all handlers
-			r.eventListenersLock.Lock()
-			for _, listener := range r.eventListeners[listener.projectName] {
-				listener.targetsLock.Lock()
-				for _, target := range listener.targets {
-					if target.types != nil && !shared.ValueInSlice(event.Type, target.types) {
-						continue
-					}
-
-					go target.function(event)
-				}
-
-				listener.targetsLock.Unlock()
-			}
-
-			r.eventListenersLock.Unlock()
+		if err != nil {
+			return nil, err
 		}
-	}()
 
-	return &listener, nil
+		return r.websocket(url)
+	}
+
+	return r.eventListenerManager.getEvents(r.ctxConnected, getWebsocket, project)
 }
 
 // GetEvents gets the events for the project defined on the client.
@@ -172,26 +55,5 @@ func (r *ProtocolLXD) GetEventsAllProjects() (*EventListener, error) {
 
 // SendEvent send an event to the server via the client's event listener connection.
 func (r *ProtocolLXD) SendEvent(event api.Event) error {
-	r.eventConnsLock.Lock()
-	defer r.eventConnsLock.Unlock()
-
-	// Find an available event listener connection.
-	// It doesn't matter which project the event listener connection is using, as this only affects which
-	// events are received from the server, not which events we can send to it.
-	var eventConn *websocket.Conn
-	for _, eventConn = range r.eventConns {
-		break
-	}
-
-	if eventConn == nil {
-		return fmt.Errorf("No available event listener connection")
-	}
-
-	deadline, ok := r.ctx.Deadline()
-	if !ok {
-		deadline = time.Now().Add(5 * time.Second)
-	}
-
-	_ = eventConn.SetWriteDeadline(deadline)
-	return eventConn.WriteJSON(event)
+	return r.eventListenerManager.SendEvent(event)
 }

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gorilla/websocket"
-
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -114,8 +112,7 @@ func (r *ProtocolLXD) UseProject(name string) InstanceServer {
 		requireAuthenticated: r.requireAuthenticated,
 		clusterTarget:        r.clusterTarget,
 		project:              name,
-		eventConns:           make(map[string]*websocket.Conn),  // New project specific listener conns.
-		eventListeners:       make(map[string][]*EventListener), // New project specific listeners.
+		eventListenerManager: r.eventListenerManager,
 		oidcClient:           r.oidcClient,
 	}
 }
@@ -136,8 +133,7 @@ func (r *ProtocolLXD) UseTarget(name string) InstanceServer {
 		httpUserAgent:        r.httpUserAgent,
 		requireAuthenticated: r.requireAuthenticated,
 		project:              r.project,
-		eventConns:           make(map[string]*websocket.Conn),  // New target specific listener conns.
-		eventListeners:       make(map[string][]*EventListener), // New target specific listeners.
+		eventListenerManager: r.eventListenerManager,
 		oidcClient:           r.oidcClient,
 		clusterTarget:        name,
 	}

--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -136,10 +136,10 @@ func startDevlxdServer(d *Daemon) error {
 		return nil
 	}
 
-	servers["devlxd"] = devLxdServer(d)
+	servers["devlxd"] = devLXDServer(d)
 
 	// Prepare the devlxd server.
-	devlxdListener, err := createDevLxdlListener("/dev")
+	devlxdListener, err := createDevLXDListener("/dev")
 	if err != nil {
 		return err
 	}

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -341,10 +341,6 @@ var devLXDUbuntuProEndpoint = devLXDAPIEndpoint{
 }
 
 func devLXDUbuntuProGetHandler(d *Daemon, r *http.Request) *devLXDResponse {
-	if r.Method != http.MethodGet {
-		return errorResponse(http.StatusMethodNotAllowed, http.StatusText(http.StatusMethodNotAllowed))
-	}
-
 	// Get a http.Client.
 	client, err := getClient(d.serverCID, int(d.serverPort), d.serverCertificate)
 	if err != nil {
@@ -384,10 +380,6 @@ var devLXDUbuntuProTokenEndpoint = devLXDAPIEndpoint{
 }
 
 func devLXDUbuntuProTokenPostHandler(d *Daemon, r *http.Request) *devLXDResponse {
-	if r.Method != http.MethodPost {
-		return errorResponse(http.StatusMethodNotAllowed, http.StatusText(http.StatusMethodNotAllowed))
-	}
-
 	// Get a http.Client.
 	client, err := getClient(d.serverCID, int(d.serverPort), d.serverCertificate)
 	if err != nil {

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -140,7 +140,7 @@ func devLXDMetadataGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request)
 	var client lxd.InstanceServer
 	var err error
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		client, err = getVsockClient(d)
 		if err == nil {
 			break

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -156,14 +156,7 @@ func devLXDConfigGetHandler(d *Daemon, r *http.Request) *devLXDResponse {
 		return smartResponse(fmt.Errorf("Failed parsing response from LXD: %w", err))
 	}
 
-	filtered := []string{}
-	for _, k := range config {
-		if strings.HasPrefix(k, "/1.0/config/user.") || strings.HasPrefix(k, "/1.0/config/cloud-init.") {
-			filtered = append(filtered, k)
-		}
-	}
-
-	return okResponse(filtered, "json")
+		return okResponse(config, "json")
 }
 
 var devLXDConfigKeyEndpoint = devLXDAPIEndpoint{

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -25,15 +25,15 @@ import (
 
 type devLXDHandlerFunc func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse
 
-// DevLxdServer creates an http.Server capable of handling requests against the
+// devLXDServer creates an http.Server capable of handling requests against the
 // /dev/lxd Unix socket endpoint created inside VMs.
-func devLxdServer(d *Daemon) *http.Server {
+func devLXDServer(d *Daemon) *http.Server {
 	return &http.Server{
-		Handler: devLxdAPI(d),
+		Handler: devLXDAPI(d),
 	}
 }
 
-type devLxdHandler struct {
+type devLXDHandler struct {
 	path string
 
 	/*
@@ -60,12 +60,12 @@ func getVsockClient(d *Daemon) (lxd.InstanceServer, error) {
 	return server, nil
 }
 
-var devlxdConfigGet = devLxdHandler{
+var devLXDConfigGet = devLXDHandler{
 	path:        "/1.0/config",
-	handlerFunc: devlxdConfigGetHandler,
+	handlerFunc: devLXDConfigGetHandler,
 }
 
-func devlxdConfigGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDConfigGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
 		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
@@ -94,12 +94,12 @@ func devlxdConfigGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *
 	return okResponse(filtered, "json")
 }
 
-var devlxdConfigKeyGet = devLxdHandler{
+var devLXDConfigKeyGet = devLXDHandler{
 	path:        "/1.0/config/{key}",
-	handlerFunc: devlxdConfigKeyGetHandler,
+	handlerFunc: devLXDConfigKeyGetHandler,
 }
 
-func devlxdConfigKeyGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDConfigKeyGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	key, err := url.PathUnescape(mux.Vars(r)["key"])
 	if err != nil {
 		return &devLxdResponse{"bad request", http.StatusBadRequest, "raw"}
@@ -131,12 +131,12 @@ func devlxdConfigKeyGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request
 	return okResponse(value, "raw")
 }
 
-var devlxdMetadataGet = devLxdHandler{
+var devLXDMetadataGet = devLXDHandler{
 	path:        "/1.0/meta-data",
-	handlerFunc: devlxdMetadataGetHandler,
+	handlerFunc: devLXDMetadataGetHandler,
 }
 
-func devlxdMetadataGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDMetadataGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	var client lxd.InstanceServer
 	var err error
 
@@ -170,12 +170,12 @@ func devlxdMetadataGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request)
 	return okResponse(metaData, "raw")
 }
 
-var devLxdEventsGet = devLxdHandler{
+var devLXDEventsGet = devLXDHandler{
 	path:        "/1.0/events",
-	handlerFunc: devlxdEventsGetHandler,
+	handlerFunc: devLXDEventsGetHandler,
 }
 
-func devlxdEventsGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDEventsGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	err := eventsGet(d, r).Render(w, r)
 	if err != nil {
 		return smartResponse(err)
@@ -184,12 +184,12 @@ func devlxdEventsGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *
 	return okResponse("", "raw")
 }
 
-var devlxdAPIGet = devLxdHandler{
+var devLXDAPIGet = devLXDHandler{
 	path:        "/1.0",
-	handlerFunc: devlxdAPIGetHandler,
+	handlerFunc: devLXDAPIGetHandler,
 }
 
-func devlxdAPIGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDAPIGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
 		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
@@ -223,12 +223,12 @@ func devlxdAPIGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *dev
 	return &devLxdResponse{`method "` + r.Method + `" not allowed`, http.StatusBadRequest, "raw"}
 }
 
-var devlxdDevicesGet = devLxdHandler{
+var devLXDDevicesGet = devLXDHandler{
 	path:        "/1.0/devices",
-	handlerFunc: devlxdDevicesGetHandler,
+	handlerFunc: devLXDDevicesGetHandler,
 }
 
-func devlxdDevicesGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDDevicesGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
 		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
@@ -251,12 +251,12 @@ func devlxdDevicesGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) 
 	return okResponse(devices, "json")
 }
 
-var devlxdImageExport = devLxdHandler{
+var devLXDImageExport = devLXDHandler{
 	path:        "/1.0/images/{fingerprint}/export",
-	handlerFunc: devlxdImageExportHandler,
+	handlerFunc: devLXDImageExportHandler,
 }
 
-func devlxdImageExportHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDImageExportHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	// Extract the fingerprint.
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
 	if err != nil {
@@ -298,12 +298,12 @@ func devlxdImageExportHandler(d *Daemon, w http.ResponseWriter, r *http.Request)
 	return nil
 }
 
-var devlxdUbuntuProGet = devLxdHandler{
+var devLXDUbuntuProGet = devLXDHandler{
 	path:        "/1.0/ubuntu-pro",
-	handlerFunc: devlxdUbuntuProGetHandler,
+	handlerFunc: devLXDUbuntuProGetHandler,
 }
 
-func devlxdUbuntuProGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDUbuntuProGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	if r.Method != http.MethodGet {
 		return errorResponse(http.StatusMethodNotAllowed, http.StatusText(http.StatusMethodNotAllowed))
 	}
@@ -341,12 +341,12 @@ func devlxdUbuntuProGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request
 	return okResponse(settingsResponse, "json")
 }
 
-var devlxdUbuntuProTokenPost = devLxdHandler{
+var devLXDUbuntuProTokenPost = devLXDHandler{
 	path:        "/1.0/ubuntu-pro/token",
-	handlerFunc: devlxdUbuntuProTokenPostHandler,
+	handlerFunc: devLXDUbuntuProTokenPostHandler,
 }
 
-func devlxdUbuntuProTokenPostHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDUbuntuProTokenPostHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	if r.Method != http.MethodPost {
 		return errorResponse(http.StatusMethodNotAllowed, http.StatusText(http.StatusMethodNotAllowed))
 	}
@@ -388,22 +388,22 @@ func devlxdUbuntuProTokenPostHandler(d *Daemon, w http.ResponseWriter, r *http.R
 	return okResponse(tokenResponse, "json")
 }
 
-var handlers = []devLxdHandler{
+var handlers = []devLXDHandler{
 	{
 		path: "/",
 		handlerFunc: func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 			return okResponse([]string{"/1.0"}, "json")
 		},
 	},
-	devlxdAPIGet,
-	devlxdConfigGet,
-	devlxdConfigKeyGet,
-	devlxdMetadataGet,
-	devLxdEventsGet,
-	devlxdDevicesGet,
-	devlxdImageExport,
-	devlxdUbuntuProGet,
-	devlxdUbuntuProTokenPost,
+	devLXDAPIGet,
+	devLXDConfigGet,
+	devLXDConfigKeyGet,
+	devLXDMetadataGet,
+	devLXDEventsGet,
+	devLXDDevicesGet,
+	devLXDImageExport,
+	devLXDUbuntuProGet,
+	devLXDUbuntuProTokenPost,
 }
 
 func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devLxdResponse, d *Daemon) func(http.ResponseWriter, *http.Request) {
@@ -427,7 +427,7 @@ func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devLxdRespons
 	}
 }
 
-func devLxdAPI(d *Daemon) http.Handler {
+func devLXDAPI(d *Daemon) http.Handler {
 	m := mux.NewRouter()
 	m.UseEncodedPath() // Allow encoded values in path segments.
 
@@ -438,8 +438,8 @@ func devLxdAPI(d *Daemon) http.Handler {
 	return m
 }
 
-// Create a new net.Listener bound to the unix socket of the devlxd endpoint.
-func createDevLxdlListener(dir string) (net.Listener, error) {
+// Create a new net.Listener bound to the unix socket of the devLXD endpoint.
+func createDevLXDListener(dir string) (net.Listener, error) {
 	path := filepath.Join(dir, "lxd", "sock")
 
 	err := os.MkdirAll(filepath.Dir(path), 0755)

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -23,7 +23,7 @@ import (
 	"github.com/canonical/lxd/shared/version"
 )
 
-type devLXDHandlerFunc func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse
+type devLXDHandlerFunc func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse
 
 // devLXDServer creates an http.Server capable of handling requests against the
 // /dev/lxd Unix socket endpoint created inside VMs.
@@ -65,7 +65,7 @@ var devLXDConfigGet = devLXDHandler{
 	handlerFunc: devLXDConfigGetHandler,
 }
 
-func devLXDConfigGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDConfigGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
 		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
@@ -99,14 +99,14 @@ var devLXDConfigKeyGet = devLXDHandler{
 	handlerFunc: devLXDConfigKeyGetHandler,
 }
 
-func devLXDConfigKeyGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDConfigKeyGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	key, err := url.PathUnescape(mux.Vars(r)["key"])
 	if err != nil {
-		return &devLxdResponse{"bad request", http.StatusBadRequest, "raw"}
+		return &devLXDResponse{"bad request", http.StatusBadRequest, "raw"}
 	}
 
 	if !strings.HasPrefix(key, "user.") && !strings.HasPrefix(key, "cloud-init.") {
-		return &devLxdResponse{"not authorized", http.StatusForbidden, "raw"}
+		return &devLXDResponse{"not authorized", http.StatusForbidden, "raw"}
 	}
 
 	client, err := getVsockClient(d)
@@ -136,7 +136,7 @@ var devLXDMetadataGet = devLXDHandler{
 	handlerFunc: devLXDMetadataGetHandler,
 }
 
-func devLXDMetadataGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDMetadataGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	var client lxd.InstanceServer
 	var err error
 
@@ -175,7 +175,7 @@ var devLXDEventsGet = devLXDHandler{
 	handlerFunc: devLXDEventsGetHandler,
 }
 
-func devLXDEventsGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDEventsGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	err := eventsGet(d, r).Render(w, r)
 	if err != nil {
 		return smartResponse(err)
@@ -189,7 +189,7 @@ var devLXDAPIGet = devLXDHandler{
 	handlerFunc: devLXDAPIGetHandler,
 }
 
-func devLXDAPIGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDAPIGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
 		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
@@ -220,7 +220,7 @@ func devLXDAPIGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *dev
 		return okResponse("", "raw")
 	}
 
-	return &devLxdResponse{`method "` + r.Method + `" not allowed`, http.StatusBadRequest, "raw"}
+	return &devLXDResponse{`method "` + r.Method + `" not allowed`, http.StatusBadRequest, "raw"}
 }
 
 var devLXDDevicesGet = devLXDHandler{
@@ -228,7 +228,7 @@ var devLXDDevicesGet = devLXDHandler{
 	handlerFunc: devLXDDevicesGetHandler,
 }
 
-func devLXDDevicesGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDDevicesGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
 		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
@@ -256,7 +256,7 @@ var devLXDImageExport = devLXDHandler{
 	handlerFunc: devLXDImageExportHandler,
 }
 
-func devLXDImageExportHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDImageExportHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	// Extract the fingerprint.
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
 	if err != nil {
@@ -303,7 +303,7 @@ var devLXDUbuntuProGet = devLXDHandler{
 	handlerFunc: devLXDUbuntuProGetHandler,
 }
 
-func devLXDUbuntuProGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDUbuntuProGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	if r.Method != http.MethodGet {
 		return errorResponse(http.StatusMethodNotAllowed, http.StatusText(http.StatusMethodNotAllowed))
 	}
@@ -346,7 +346,7 @@ var devLXDUbuntuProTokenPost = devLXDHandler{
 	handlerFunc: devLXDUbuntuProTokenPostHandler,
 }
 
-func devLXDUbuntuProTokenPostHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+func devLXDUbuntuProTokenPostHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 	if r.Method != http.MethodPost {
 		return errorResponse(http.StatusMethodNotAllowed, http.StatusText(http.StatusMethodNotAllowed))
 	}
@@ -391,7 +391,7 @@ func devLXDUbuntuProTokenPostHandler(d *Daemon, w http.ResponseWriter, r *http.R
 var handlers = []devLXDHandler{
 	{
 		path: "/",
-		handlerFunc: func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
+		handlerFunc: func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLXDResponse {
 			return okResponse([]string{"/1.0"}, "json")
 		},
 	},
@@ -406,7 +406,7 @@ var handlers = []devLXDHandler{
 	devLXDUbuntuProTokenPost,
 }
 
-func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devLxdResponse, d *Daemon) func(http.ResponseWriter, *http.Request) {
+func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devLXDResponse, d *Daemon) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		resp := f(d, w, r)
 		if resp == nil {

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -156,7 +156,7 @@ func devLXDConfigGetHandler(d *Daemon, r *http.Request) *devLXDResponse {
 		return smartResponse(fmt.Errorf("Failed parsing response from LXD: %w", err))
 	}
 
-		return okResponse(config, "json")
+	return okResponse(config, "json")
 }
 
 var devLXDConfigKeyEndpoint = devLXDAPIEndpoint{
@@ -464,6 +464,11 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 			resp = handleRequest(ep.Delete)
 		default:
 			resp = errorResponse(http.StatusNotFound, fmt.Sprintf("Method %q not found", r.Method))
+		}
+
+		if resp == nil {
+			// The response may be nil in case of octet-stream or multipart responses.
+			return
 		}
 
 		// Write response.

--- a/lxd-agent/response.go
+++ b/lxd-agent/response.go
@@ -6,21 +6,21 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
-type devLxdResponse struct {
+type devLXDResponse struct {
 	content any
 	code    int
 	ctype   string
 }
 
-func errorResponse(code int, msg string) *devLxdResponse {
-	return &devLxdResponse{msg, code, "raw"}
+func errorResponse(code int, msg string) *devLXDResponse {
+	return &devLXDResponse{msg, code, "raw"}
 }
 
-func okResponse(ct any, ctype string) *devLxdResponse {
-	return &devLxdResponse{ct, http.StatusOK, ctype}
+func okResponse(ct any, ctype string) *devLXDResponse {
+	return &devLXDResponse{ct, http.StatusOK, ctype}
 }
 
-func smartResponse(err error) *devLxdResponse {
+func smartResponse(err error) *devLXDResponse {
 	if err == nil {
 		return okResponse(nil, "")
 	}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -246,7 +246,7 @@ func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Re
 		if resp != nil {
 			err = resp.Render(w, r)
 			if err != nil {
-				writeErr := response.DevLxdErrorResponse(err, true).Render(w, r)
+				writeErr := response.DevLXDErrorResponse(err, true).Render(w, r)
 				if writeErr != nil {
 					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
 				}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -11,11 +11,9 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/canonical/lxd/lxd/auth"
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
 	"github.com/canonical/lxd/lxd/cluster/request"
 	"github.com/canonical/lxd/lxd/db"
-	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/metrics"
 	lxdRequest "github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
@@ -224,39 +222,6 @@ func restServer(d *Daemon) *http.Server {
 		Handler:     &lxdHTTPServer{r: mux, d: d},
 		ConnContext: lxdRequest.SaveConnectionInContext,
 	}
-}
-
-func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
-		lxdRequest.SetCtxValue(r, lxdRequest.CtxProtocol, auth.AuthenticationMethodDevLXD)
-
-		trusted, inst, err := authenticateAgentCert(d.State(), r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if !trusted {
-			http.Error(w, "", http.StatusUnauthorized)
-			return
-		}
-
-		resp := f(d, inst, w, r)
-		if resp != nil {
-			err = resp.Render(w, r)
-			if err != nil {
-				writeErr := response.DevLXDErrorResponse(err, true).Render(w, r)
-				if writeErr != nil {
-					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
-				}
-			}
-		}
-	}
-}
-
-func vSockServer(d *Daemon) *http.Server {
-	return &http.Server{Handler: devLXDAPI(d, hoistReqVM)}
 }
 
 func metricsServer(d *Daemon) *http.Server {

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -228,7 +228,7 @@ func restServer(d *Daemon) *http.Server {
 
 func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Set devlxd auth method to identify this request as coming from the /dev/lxd socket.
+		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
 		lxdRequest.SetCtxValue(r, lxdRequest.CtxProtocol, auth.AuthenticationMethodDevLXD)
 
 		trusted, inst, err := authenticateAgentCert(d.State(), r)
@@ -256,7 +256,7 @@ func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Re
 }
 
 func vSockServer(d *Daemon) *http.Server {
-	return &http.Server{Handler: devLxdAPI(d, hoistReqVM)}
+	return &http.Server{Handler: devLXDAPI(d, hoistReqVM)}
 }
 
 func metricsServer(d *Daemon) *http.Server {

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -45,7 +45,7 @@ func hoistReqContainer(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc)
 
 	s := d.State()
 
-	c, err := findContainerForPid(cred.Pid, s)
+	c, err := findContainerForPID(cred.Pid, s)
 	if err != nil {
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusInternalServerError, err.Error()), false)
 	}
@@ -156,7 +156,7 @@ func (m *ConnPidMapper) GetConnUcred(conn *net.UnixConn) *unix.Ucred {
 
 var errPIDNotInContainer = errors.New("Process ID not found in container")
 
-func findContainerForPid(pid int32, s *state.State) (instance.Container, error) {
+func findContainerForPID(pid int32, s *state.State) (instance.Container, error) {
 	/*
 	 * Try and figure out which container a pid is in. There is probably a
 	 * better way to do this. Based on rharper's initial performance

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -35,6 +35,8 @@ func devLXDServer(d *Daemon) *http.Server {
 	}
 }
 
+// hoistReqContainer identifies the calling container based on the Unix socket credentials,
+// verifies it's the container's root user, and passes the identified container to the handler.
 func hoistReqContainer(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
 	conn := ucred.GetConnFromContext(r.Context())
 

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -40,7 +40,12 @@ func devLXDServer(d *Daemon) *http.Server {
 func hoistReqContainer(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
 	conn := ucred.GetConnFromContext(r.Context())
 
-	cred := pidMapper.GetConnUcred(conn.(*net.UnixConn))
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusInternalServerError, "Not a unix connection"), false)
+	}
+
+	cred := pidMapper.GetConnUcred(unixConn)
 	if cred == nil {
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusInternalServerError, errPIDNotInContainer.Error()), false)
 	}

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -67,7 +67,8 @@ func hoistReqContainer(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc)
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusUnauthorized, "Access denied for non-root user"), false)
 	}
 
-	return handler(d, c, r)
+	request.SetCtxValue(r, request.CtxDevLXDInstance, c)
+	return handler(d, r)
 }
 
 /*

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -13,7 +13,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/request"
@@ -37,9 +36,6 @@ func devLXDServer(d *Daemon) *http.Server {
 }
 
 func hoistReqContainer(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
-	// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
-	request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
-
 	conn := ucred.GetConnFromContext(r.Context())
 
 	cred := pidMapper.GetConnUcred(conn.(*net.UnixConn))

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/instance/instancetype"
+	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/lxd/ucred"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+)
+
+// devLXDServer creates an http.Server capable of handling requests against the
+// /dev/lxd Unix socket endpoint created inside containers.
+func devLXDServer(d *Daemon) *http.Server {
+	return &http.Server{
+		Handler:     devLXDAPI(d, hoistReqContainer),
+		ConnState:   pidMapper.ConnStateHandler,
+		ConnContext: request.SaveConnectionInContext,
+	}
+}
+
+func hoistReqContainer(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
+		request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
+
+		conn := ucred.GetConnFromContext(r.Context())
+
+		cred := pidMapper.GetConnUcred(conn.(*net.UnixConn))
+		if cred == nil {
+			http.Error(w, errPIDNotInContainer.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		s := d.State()
+
+		c, err := findContainerForPid(cred.Pid, s)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Access control
+		rootUID := uint32(0)
+
+		idmapset, err := c.CurrentIdmap()
+		if err == nil && idmapset != nil {
+			uid, _ := idmapset.ShiftIntoNs(0, 0)
+			rootUID = uint32(uid)
+		}
+
+		if rootUID != cred.Uid {
+			http.Error(w, "Access denied for non-root user", http.StatusUnauthorized)
+			return
+		}
+
+		resp := f(d, c, w, r)
+		if resp != nil {
+			err = resp.Render(w, r)
+			if err != nil {
+				writeErr := response.DevLXDErrorResponse(err, false).Render(w, r)
+				if writeErr != nil {
+					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
+				}
+			}
+		}
+	}
+}
+
+/*
+ * Everything below here is the guts of the unix socket bits. Unfortunately,
+ * golang's API does not make this easy. What happens is:
+ *
+ * 1. We install a ConnState listener on the http.Server, which does the
+ *    initial unix socket credential exchange. When we get a connection started
+ *    event, we use SO_PEERCRED to extract the creds for the socket.
+ *
+ * 2. We store a map from the connection pointer to the pid for that
+ *    connection, so that once the HTTP negotiation occurrs and we get a
+ *    ResponseWriter, we know (because we negotiated on the first byte) which
+ *    pid the connection belogs to.
+ *
+ * 3. Regular HTTP negotiation and dispatch occurs via net/http.
+ *
+ * 4. When rendering the response via ResponseWriter, we match its underlying
+ *    connection against what we stored in step (2) to figure out which container
+ *    it came from.
+ */
+
+/*
+ * We keep this in a global so that we can reference it from the server and
+ * from our http handlers, since there appears to be no way to pass information
+ * around here.
+ */
+var pidMapper = ConnPidMapper{m: map[*net.UnixConn]*unix.Ucred{}}
+
+// ConnPidMapper is threadsafe cache of unix connections to process IDs. We use this in hoistReq to determine
+// the instance that the connection has been made from.
+type ConnPidMapper struct {
+	m     map[*net.UnixConn]*unix.Ucred
+	mLock sync.Mutex
+}
+
+// ConnStateHandler is used in the `ConnState` field of the devLXD http.Server so that we can cache the process ID of the
+// caller when a new connection is made and delete it when the connection is closed.
+func (m *ConnPidMapper) ConnStateHandler(conn net.Conn, state http.ConnState) {
+	unixConn, _ := conn.(*net.UnixConn)
+	if unixConn == nil {
+		logger.Error("Invalid type for devlxd connection", logger.Ctx{"conn_type": fmt.Sprintf("%T", conn)})
+		return
+	}
+
+	switch state {
+	case http.StateNew:
+		cred, err := ucred.GetCred(unixConn)
+		if err != nil {
+			logger.Debug("Error getting ucred for devlxd connection", logger.Ctx{"err": err})
+		} else {
+			m.mLock.Lock()
+			m.m[unixConn] = cred
+			m.mLock.Unlock()
+		}
+
+	case http.StateActive:
+		return
+	case http.StateIdle:
+		return
+	case http.StateHijacked:
+		/*
+		 * The "Hijacked" state indicates that the connection has been
+		 * taken over from net/http. This is useful for things like
+		 * developing websocket libraries, who want to upgrade the
+		 * connection to a websocket one, and not use net/http any
+		 * more. Whatever the case, we want to forget about it since we
+		 * won't see it either.
+		 */
+		m.mLock.Lock()
+		delete(m.m, unixConn)
+		m.mLock.Unlock()
+	case http.StateClosed:
+		m.mLock.Lock()
+		delete(m.m, unixConn)
+		m.mLock.Unlock()
+	default:
+		logger.Debug("Unknown state for devlxd connection", logger.Ctx{"state": state.String()})
+	}
+}
+
+// GetConnUcred returns a previously stored ucred associated to a connection.
+// Returns nil if no ucred found for the connection.
+func (m *ConnPidMapper) GetConnUcred(conn *net.UnixConn) *unix.Ucred {
+	m.mLock.Lock()
+	defer m.mLock.Unlock()
+	return pidMapper.m[conn]
+}
+
+var errPIDNotInContainer = errors.New("Process ID not found in container")
+
+func findContainerForPid(pid int32, s *state.State) (instance.Container, error) {
+	/*
+	 * Try and figure out which container a pid is in. There is probably a
+	 * better way to do this. Based on rharper's initial performance
+	 * metrics, looping over every container and calling newLxdContainer is
+	 * expensive, so I wanted to avoid that if possible, so this happens in
+	 * a two step process:
+	 *
+	 * 1. Walk up the process tree until you see something that looks like
+	 *    an lxc monitor process and extract its name from there.
+	 *
+	 * 2. If this fails, it may be that someone did an `lxc exec foo -- bash`,
+	 *    so the process isn't actually a descendant of the container's
+	 *    init. In this case we just look through all the containers until
+	 *    we find an init with a matching pid namespace. This is probably
+	 *    uncommon, so hopefully the slowness won't hurt us.
+	 */
+
+	origpid := pid
+
+	for pid > 1 {
+		procPID := "/proc/" + fmt.Sprint(pid)
+		cmdline, err := os.ReadFile(procPID + "/cmdline")
+		if err != nil {
+			return nil, err
+		}
+
+		if strings.HasPrefix(string(cmdline), "[lxc monitor]") {
+			// container names can't have spaces
+			parts := strings.Split(string(cmdline), " ")
+			name := strings.TrimSuffix(parts[len(parts)-1], "\x00")
+
+			projectName := api.ProjectDefaultName
+			if strings.Contains(name, "_") {
+				projectName, name, _ = strings.Cut(name, "_")
+			}
+
+			inst, err := instance.LoadByProjectAndName(s, projectName, name)
+			if err != nil {
+				return nil, err
+			}
+
+			if inst.Type() != instancetype.Container {
+				return nil, fmt.Errorf("Instance is not container type")
+			}
+
+			// Explicitly ignore type assertion check. We've just checked that it's a container.
+			c, _ := inst.(instance.Container)
+			return c, nil
+		}
+
+		status, err := os.ReadFile(procPID + "/status")
+		if err != nil {
+			return nil, err
+		}
+
+		for _, line := range strings.Split(string(status), "\n") {
+			ppidStr, found := strings.CutPrefix(line, "PPid:")
+			if !found {
+				continue
+			}
+
+			// ParseUint avoid scanning for `-` sign.
+			ppid, err := strconv.ParseUint(strings.TrimSpace(ppidStr), 10, 32)
+			if err != nil {
+				return nil, err
+			}
+
+			if ppid > math.MaxInt32 {
+				return nil, fmt.Errorf("PPid value too large: Upper bound exceeded")
+			}
+
+			pid = int32(ppid)
+			break
+		}
+	}
+
+	origPidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", origpid))
+	if err != nil {
+		return nil, err
+	}
+
+	instances, err := instance.LoadNodeAll(s, instancetype.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, inst := range instances {
+		if inst.Type() != instancetype.Container {
+			continue
+		}
+
+		if !inst.IsRunning() {
+			continue
+		}
+
+		initpid := inst.InitPID()
+		pidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", initpid))
+		if err != nil {
+			return nil, err
+		}
+
+		if origPidNs == pidNs {
+			// Explicitly ignore type assertion check. The instance must be a container if we've found it via the process ID.
+			c, _ := inst.(instance.Container)
+			return c, nil
+		}
+	}
+
+	return nil, errPIDNotInContainer
+}

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -36,7 +36,7 @@ func devLXDServer(d *Daemon) *http.Server {
 	}
 }
 
-func hoistReqContainer(d *Daemon, w http.ResponseWriter, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
+func hoistReqContainer(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
 	// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
 	request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
 
@@ -67,7 +67,7 @@ func hoistReqContainer(d *Daemon, w http.ResponseWriter, r *http.Request, handle
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusUnauthorized, "Access denied for non-root user"), false)
 	}
 
-	return handler(d, c, w, r)
+	return handler(d, c, r)
 }
 
 /*

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -25,7 +25,7 @@ func vSockServer(d *Daemon) *http.Server {
 	}
 }
 
-func hoistReqVM(d *Daemon, w http.ResponseWriter, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
+func hoistReqVM(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
 	// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
 	request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
 
@@ -38,7 +38,7 @@ func hoistReqVM(d *Daemon, w http.ResponseWriter, r *http.Request, handler devLX
 		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusUnauthorized), true)
 	}
 
-	return handler(d, inst, w, r)
+	return handler(d, inst, r)
 }
 
 func authenticateAgentCert(s *state.State, r *http.Request) (bool, instance.Instance, error) {

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/instance"
@@ -26,9 +25,6 @@ func vSockServer(d *Daemon) *http.Server {
 }
 
 func hoistReqVM(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
-	// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
-	request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
-
 	trusted, inst, err := authenticateAgentCert(d.State(), r)
 	if err != nil {
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusInternalServerError, err.Error()), true)

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -24,6 +24,8 @@ func vSockServer(d *Daemon) *http.Server {
 	}
 }
 
+// hoistReqVM authenticates a VM accessing /dev/lxd over vsock using its agent certificate,
+// identifies and retrieves the corresponding instance, and passes it to the handler if trusted.
 func hoistReqVM(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) response.Response {
 	trusted, inst, err := authenticateAgentCert(d.State(), r)
 	if err != nil {

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -38,7 +38,8 @@ func hoistReqVM(d *Daemon, r *http.Request, handler devLXDAPIHandlerFunc) respon
 		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusUnauthorized), true)
 	}
 
-	return handler(d, inst, r)
+	request.SetCtxValue(r, request.CtxDevLXDInstance, inst)
+	return handler(d, r)
 }
 
 func authenticateAgentCert(s *state.State, r *http.Request) (bool, instance.Instance, error) {

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -6,12 +6,49 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared/logger"
 )
+
+func vSockServer(d *Daemon) *http.Server {
+	return &http.Server{Handler: devLXDAPI(d, hoistReqVM)}
+}
+
+func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
+		request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
+
+		trusted, inst, err := authenticateAgentCert(d.State(), r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if !trusted {
+			http.Error(w, "", http.StatusUnauthorized)
+			return
+		}
+
+		resp := f(d, inst, w, r)
+		if resp != nil {
+			err = resp.Render(w, r)
+			if err != nil {
+				writeErr := response.DevLXDErrorResponse(err, true).Render(w, r)
+				if writeErr != nil {
+					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
+				}
+			}
+		}
+	}
+}
 
 func authenticateAgentCert(s *state.State, r *http.Request) (bool, instance.Instance, error) {
 	var vsockID int

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1422,7 +1422,7 @@ func (d *Daemon) init() error {
 		UnixSocket:           d.UnixSocket(),
 		Cert:                 networkCert,
 		RestServer:           restServer(d),
-		DevLxdServer:         devLxdServer(d),
+		DevLxdServer:         devLXDServer(d),
 		LocalUnixSocketGroup: d.config.Group,
 		NetworkAddress:       localHTTPAddress,
 		ClusterAddress:       localClusterAddress,

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1832,7 +1832,7 @@ func (d *Daemon) init() error {
 		// Setup seccomp handler
 		if d.os.SeccompListener {
 			seccompServer, err := seccomp.NewSeccompServer(d.State(), shared.VarPath("seccomp.socket"), func(pid int32, state *state.State) (seccomp.Instance, error) {
-				return findContainerForPid(pid, state)
+				return findContainerForPID(pid, state)
 			})
 			if err != nil {
 				return err

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -94,7 +94,7 @@ type Daemon struct {
 	dns           *dns.Server
 
 	// Event servers
-	devlxdEvents     *events.DevLXDServer
+	devLXDEvents     *events.DevLXDServer
 	events           *events.Server
 	internalListener *events.InternalListener
 
@@ -183,13 +183,13 @@ type DaemonConfig struct {
 // newDaemon returns a new Daemon object with the given configuration.
 func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 	lxdEvents := events.NewServer(daemon.Debug, daemon.Verbose, cluster.EventHubPush)
-	devlxdEvents := events.NewDevLXDServer(daemon.Debug, daemon.Verbose)
+	devLXDEvents := events.NewDevLXDServer(daemon.Debug, daemon.Verbose)
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 
 	d := &Daemon{
 		identityCache:  &identity.Cache{},
 		config:         config,
-		devlxdEvents:   devlxdEvents,
+		devLXDEvents:   devLXDEvents,
 		events:         lxdEvents,
 		tasks:          task.NewGroup(),
 		clusterTasks:   task.NewGroup(),
@@ -683,7 +683,7 @@ func (d *Daemon) State() *state.State {
 		OS:                  d.os,
 		Endpoints:           d.endpoints,
 		Events:              d.events,
-		DevlxdEvents:        d.devlxdEvents,
+		DevlxdEvents:        d.devLXDEvents,
 		Firewall:            d.firewall,
 		Proxy:               d.proxy,
 		ServerCert:          d.serverCert,
@@ -1389,12 +1389,12 @@ func (d *Daemon) init() error {
 			logger.Warn("Failed setting up shared mounts", logger.Ctx{"err": err})
 		}
 
-		// Attempt to Mount the devlxd tmpfs
-		devlxd := filepath.Join(d.os.VarDir, "devlxd")
-		if !filesystem.IsMountPoint(devlxd) {
-			err = unix.Mount("tmpfs", devlxd, "tmpfs", 0, "size=100k,mode=0755")
+		// Attempt to Mount the devLXD tmpfs
+		devLXD := filepath.Join(d.os.VarDir, "devlxd")
+		if !filesystem.IsMountPoint(devLXD) {
+			err = unix.Mount("tmpfs", devLXD, "tmpfs", 0, "size=100k,mode=0755")
 			if err != nil {
-				logger.Warn("Failed to mount devlxd", logger.Ctx{"err": err})
+				logger.Warn("Failed to mount devLXD", logger.Ctx{"err": err})
 			}
 		}
 	}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -2,30 +2,21 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"math"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/gorilla/mux"
-	"golang.org/x/sys/unix"
 
-	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cloudinit"
 	"github.com/canonical/lxd/lxd/events"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/lifecycle"
-	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/lxd/lxd/state"
-	"github.com/canonical/lxd/lxd/ucred"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
@@ -36,16 +27,6 @@ import (
 type hoistFunc func(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request)
 
 type devLXDHandlerFunc func(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response
-
-// devLXDServer creates an http.Server capable of handling requests against the
-// /dev/lxd Unix socket endpoint created inside containers.
-func devLXDServer(d *Daemon) *http.Server {
-	return &http.Server{
-		Handler:     devLXDAPI(d, hoistReq),
-		ConnState:   pidMapper.ConnStateHandler,
-		ConnContext: request.SaveConnectionInContext,
-	}
-}
 
 type devLXDHandler struct {
 	path string
@@ -399,54 +380,6 @@ var handlers = []devLXDHandler{
 	devLXDUbuntuProTokenPost,
 }
 
-func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
-		request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
-
-		conn := ucred.GetConnFromContext(r.Context())
-
-		cred := pidMapper.GetConnUcred(conn.(*net.UnixConn))
-		if cred == nil {
-			http.Error(w, errPIDNotInContainer.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		s := d.State()
-
-		c, err := findContainerForPid(cred.Pid, s)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		// Access control
-		rootUID := uint32(0)
-
-		idmapset, err := c.CurrentIdmap()
-		if err == nil && idmapset != nil {
-			uid, _ := idmapset.ShiftIntoNs(0, 0)
-			rootUID = uint32(uid)
-		}
-
-		if rootUID != cred.Uid {
-			http.Error(w, "Access denied for non-root user", http.StatusUnauthorized)
-			return
-		}
-
-		resp := f(d, c, w, r)
-		if resp != nil {
-			err = resp.Render(w, r)
-			if err != nil {
-				writeErr := response.DevLXDErrorResponse(err, false).Render(w, r)
-				if writeErr != nil {
-					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
-				}
-			}
-		}
-	}
-}
-
 func devLXDAPI(d *Daemon, f hoistFunc) http.Handler {
 	m := mux.NewRouter()
 	m.UseEncodedPath() // Allow encoded values in path segments.
@@ -456,205 +389,4 @@ func devLXDAPI(d *Daemon, f hoistFunc) http.Handler {
 	}
 
 	return m
-}
-
-/*
- * Everything below here is the guts of the unix socket bits. Unfortunately,
- * golang's API does not make this easy. What happens is:
- *
- * 1. We install a ConnState listener on the http.Server, which does the
- *    initial unix socket credential exchange. When we get a connection started
- *    event, we use SO_PEERCRED to extract the creds for the socket.
- *
- * 2. We store a map from the connection pointer to the pid for that
- *    connection, so that once the HTTP negotiation occurrs and we get a
- *    ResponseWriter, we know (because we negotiated on the first byte) which
- *    pid the connection belogs to.
- *
- * 3. Regular HTTP negotiation and dispatch occurs via net/http.
- *
- * 4. When rendering the response via ResponseWriter, we match its underlying
- *    connection against what we stored in step (2) to figure out which container
- *    it came from.
- */
-
-/*
- * We keep this in a global so that we can reference it from the server and
- * from our http handlers, since there appears to be no way to pass information
- * around here.
- */
-var pidMapper = ConnPidMapper{m: map[*net.UnixConn]*unix.Ucred{}}
-
-// ConnPidMapper is threadsafe cache of unix connections to process IDs. We use this in hoistReq to determine
-// the instance that the connection has been made from.
-type ConnPidMapper struct {
-	m     map[*net.UnixConn]*unix.Ucred
-	mLock sync.Mutex
-}
-
-// ConnStateHandler is used in the `ConnState` field of the devLXD http.Server so that we can cache the process ID of the
-// caller when a new connection is made and delete it when the connection is closed.
-func (m *ConnPidMapper) ConnStateHandler(conn net.Conn, state http.ConnState) {
-	unixConn, _ := conn.(*net.UnixConn)
-	if unixConn == nil {
-		logger.Error("Invalid type for devlxd connection", logger.Ctx{"conn_type": fmt.Sprintf("%T", conn)})
-		return
-	}
-
-	switch state {
-	case http.StateNew:
-		cred, err := ucred.GetCred(unixConn)
-		if err != nil {
-			logger.Debug("Error getting ucred for devlxd connection", logger.Ctx{"err": err})
-		} else {
-			m.mLock.Lock()
-			m.m[unixConn] = cred
-			m.mLock.Unlock()
-		}
-
-	case http.StateActive:
-		return
-	case http.StateIdle:
-		return
-	case http.StateHijacked:
-		/*
-		 * The "Hijacked" state indicates that the connection has been
-		 * taken over from net/http. This is useful for things like
-		 * developing websocket libraries, who want to upgrade the
-		 * connection to a websocket one, and not use net/http any
-		 * more. Whatever the case, we want to forget about it since we
-		 * won't see it either.
-		 */
-		m.mLock.Lock()
-		delete(m.m, unixConn)
-		m.mLock.Unlock()
-	case http.StateClosed:
-		m.mLock.Lock()
-		delete(m.m, unixConn)
-		m.mLock.Unlock()
-	default:
-		logger.Debug("Unknown state for devlxd connection", logger.Ctx{"state": state.String()})
-	}
-}
-
-// GetConnUcred returns a previously stored ucred associated to a connection.
-// Returns nil if no ucred found for the connection.
-func (m *ConnPidMapper) GetConnUcred(conn *net.UnixConn) *unix.Ucred {
-	m.mLock.Lock()
-	defer m.mLock.Unlock()
-	return pidMapper.m[conn]
-}
-
-var errPIDNotInContainer = errors.New("Process ID not found in container")
-
-func findContainerForPid(pid int32, s *state.State) (instance.Container, error) {
-	/*
-	 * Try and figure out which container a pid is in. There is probably a
-	 * better way to do this. Based on rharper's initial performance
-	 * metrics, looping over every container and calling newLxdContainer is
-	 * expensive, so I wanted to avoid that if possible, so this happens in
-	 * a two step process:
-	 *
-	 * 1. Walk up the process tree until you see something that looks like
-	 *    an lxc monitor process and extract its name from there.
-	 *
-	 * 2. If this fails, it may be that someone did an `lxc exec foo -- bash`,
-	 *    so the process isn't actually a descendant of the container's
-	 *    init. In this case we just look through all the containers until
-	 *    we find an init with a matching pid namespace. This is probably
-	 *    uncommon, so hopefully the slowness won't hurt us.
-	 */
-
-	origpid := pid
-
-	for pid > 1 {
-		procPID := "/proc/" + fmt.Sprint(pid)
-		cmdline, err := os.ReadFile(procPID + "/cmdline")
-		if err != nil {
-			return nil, err
-		}
-
-		if strings.HasPrefix(string(cmdline), "[lxc monitor]") {
-			// container names can't have spaces
-			parts := strings.Split(string(cmdline), " ")
-			name := strings.TrimSuffix(parts[len(parts)-1], "\x00")
-
-			projectName := api.ProjectDefaultName
-			if strings.Contains(name, "_") {
-				projectName, name, _ = strings.Cut(name, "_")
-			}
-
-			inst, err := instance.LoadByProjectAndName(s, projectName, name)
-			if err != nil {
-				return nil, err
-			}
-
-			if inst.Type() != instancetype.Container {
-				return nil, fmt.Errorf("Instance is not container type")
-			}
-
-			// Explicitly ignore type assertion check. We've just checked that it's a container.
-			c, _ := inst.(instance.Container)
-			return c, nil
-		}
-
-		status, err := os.ReadFile(procPID + "/status")
-		if err != nil {
-			return nil, err
-		}
-
-		for _, line := range strings.Split(string(status), "\n") {
-			ppidStr, found := strings.CutPrefix(line, "PPid:")
-			if !found {
-				continue
-			}
-
-			// ParseUint avoid scanning for `-` sign.
-			ppid, err := strconv.ParseUint(strings.TrimSpace(ppidStr), 10, 32)
-			if err != nil {
-				return nil, err
-			}
-
-			if ppid > math.MaxInt32 {
-				return nil, fmt.Errorf("PPid value too large: Upper bound exceeded")
-			}
-
-			pid = int32(ppid)
-			break
-		}
-	}
-
-	origPidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", origpid))
-	if err != nil {
-		return nil, err
-	}
-
-	instances, err := instance.LoadNodeAll(s, instancetype.Container)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, inst := range instances {
-		if inst.Type() != instancetype.Container {
-			continue
-		}
-
-		if !inst.IsRunning() {
-			continue
-		}
-
-		initpid := inst.InitPID()
-		pidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", initpid))
-		if err != nil {
-			return nil, err
-		}
-
-		if origPidNs == pidNs {
-			// Explicitly ignore type assertion check. The instance must be a container if we've found it via the process ID.
-			c, _ := inst.(instance.Container)
-			return c, nil
-		}
-	}
-
-	return nil, errPIDNotInContainer
 }

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cloudinit"
 	"github.com/canonical/lxd/lxd/events"
 	"github.com/canonical/lxd/lxd/instance"
@@ -454,6 +455,9 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 
 	// Function that handles the request by calling the appropriate handler.
 	handleFunc := func(w http.ResponseWriter, r *http.Request) {
+		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
+		request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
+
 		handleRequest := func(action devLXDAPIEndpointAction) response.Response {
 			if action.Handler == nil {
 				return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusNotImplemented), rawResponse)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -404,10 +404,6 @@ func devLXDUbuntuProGetHandler(d *Daemon, r *http.Request) response.Response {
 		return response.DevLXDErrorResponse(err, inst != nil && inst.Type() == instancetype.VM)
 	}
 
-	if r.Method != http.MethodGet {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), inst.Type() == instancetype.VM)
-	}
-
 	settings := d.State().UbuntuPro.GuestAttachSettings(inst.ExpandedConfig()["ubuntu_pro.guest_attach"])
 
 	// Otherwise, return the value from the instance configuration.
@@ -423,10 +419,6 @@ func devLXDUbuntuProTokenPostHandler(d *Daemon, r *http.Request) response.Respon
 	inst, err := getInstanceFromContextAndCheckSecurityFlags(r.Context(), devLXDSecurityKey)
 	if err != nil {
 		return response.DevLXDErrorResponse(err, inst != nil && inst.Type() == instancetype.VM)
-	}
-
-	if r.Method != http.MethodPost {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), inst.Type() == instancetype.VM)
 	}
 
 	// Return http.StatusForbidden if the host does not have guest attachment enabled.

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -35,19 +35,19 @@ import (
 
 type hoistFunc func(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request)
 
-type devlxdHandlerFunc func(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response
+type devLXDHandlerFunc func(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response
 
-// DevLxdServer creates an http.Server capable of handling requests against the
+// devLXDServer creates an http.Server capable of handling requests against the
 // /dev/lxd Unix socket endpoint created inside containers.
-func devLxdServer(d *Daemon) *http.Server {
+func devLXDServer(d *Daemon) *http.Server {
 	return &http.Server{
-		Handler:     devLxdAPI(d, hoistReq),
+		Handler:     devLXDAPI(d, hoistReq),
 		ConnState:   pidMapper.ConnStateHandler,
 		ConnContext: request.SaveConnectionInContext,
 	}
 }
 
-type devLxdHandler struct {
+type devLXDHandler struct {
 	path string
 
 	/*
@@ -56,15 +56,15 @@ type devLxdHandler struct {
 	 * server side right now either, I went the simple route to avoid
 	 * needless noise.
 	 */
-	handlerFunc devlxdHandlerFunc
+	handlerFunc devLXDHandlerFunc
 }
 
-var devlxdConfigGet = devLxdHandler{
+var devLXDConfigGet = devLXDHandler{
 	path:        "/1.0/config",
-	handlerFunc: devlxdConfigGetHandler,
+	handlerFunc: devLXDConfigGetHandler,
 }
 
-func devlxdConfigGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDConfigGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
@@ -111,12 +111,12 @@ func devlxdConfigGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrite
 	return response.DevLxdResponse(http.StatusOK, filtered, "json", c.Type() == instancetype.VM)
 }
 
-var devlxdConfigKeyGet = devLxdHandler{
+var devLXDConfigKeyGet = devLXDHandler{
 	path:        "/1.0/config/{key}",
-	handlerFunc: devlxdConfigKeyGetHandler,
+	handlerFunc: devLXDConfigKeyGetHandler,
 }
 
-func devlxdConfigKeyGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDConfigKeyGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
@@ -156,12 +156,12 @@ func devlxdConfigKeyGetHandler(d *Daemon, c instance.Instance, w http.ResponseWr
 	return response.DevLxdResponse(http.StatusOK, value, "raw", c.Type() == instancetype.VM)
 }
 
-var devlxdImageExport = devLxdHandler{
+var devLXDImageExport = devLXDHandler{
 	path:        "/1.0/images/{fingerprint}/export",
-	handlerFunc: devlxdImageExportHandler,
+	handlerFunc: devLXDImageExportHandler,
 }
 
-func devlxdImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
@@ -173,12 +173,12 @@ func devlxdImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWri
 	return imageExport(d, r)
 }
 
-var devlxdMetadataGet = devLxdHandler{
+var devLXDMetadataGet = devLXDHandler{
 	path:        "/1.0/meta-data",
-	handlerFunc: devlxdMetadataGetHandler,
+	handlerFunc: devLXDMetadataGetHandler,
 }
 
-func devlxdMetadataGetHandler(d *Daemon, inst instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDMetadataGetHandler(d *Daemon, inst instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
@@ -188,12 +188,12 @@ func devlxdMetadataGetHandler(d *Daemon, inst instance.Instance, w http.Response
 	return response.DevLxdResponse(http.StatusOK, "instance-id: "+inst.CloudInitID()+"\nlocal-hostname: "+inst.Name()+"\n"+value, "raw", inst.Type() == instancetype.VM)
 }
 
-var devlxdEventsGet = devLxdHandler{
+var devLXDEventsGet = devLXDHandler{
 	path:        "/1.0/events",
-	handlerFunc: devlxdEventsGetHandler,
+	handlerFunc: devLXDEventsGetHandler,
 }
 
-func devlxdEventsGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDEventsGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
@@ -250,12 +250,12 @@ func devlxdEventsGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrite
 	return resp
 }
 
-var devlxdAPIHandler = devLxdHandler{
+var devLXDAPIHandler = devLXDHandler{
 	path:        "/1.0",
-	handlerFunc: devlxdAPIHandlerFunc,
+	handlerFunc: devLXDAPIHandlerFunc,
 }
 
-func devlxdAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	s := d.State()
 
 	if r.Method == "GET" {
@@ -313,12 +313,12 @@ func devlxdAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter,
 	return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusMethodNotAllowed, "method %q not allowed", r.Method), c.Type() == instancetype.VM)
 }
 
-var devlxdDevicesGet = devLxdHandler{
+var devLXDDevicesGet = devLXDHandler{
 	path:        "/1.0/devices",
-	handlerFunc: devlxdDevicesGetHandler,
+	handlerFunc: devLXDDevicesGetHandler,
 }
 
-func devlxdDevicesGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDDevicesGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
@@ -337,12 +337,12 @@ func devlxdDevicesGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrit
 	return response.DevLxdResponse(http.StatusOK, c.ExpandedDevices(), "json", c.Type() == instancetype.VM)
 }
 
-var devlxdUbuntuProGet = devLxdHandler{
+var devLXDUbuntuProGet = devLXDHandler{
 	path:        "/1.0/ubuntu-pro",
-	handlerFunc: devlxdUbuntuProGetHandler,
+	handlerFunc: devLXDUbuntuProGetHandler,
 }
 
-func devlxdUbuntuProGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDUbuntuProGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
 	}
@@ -357,12 +357,12 @@ func devlxdUbuntuProGetHandler(d *Daemon, c instance.Instance, w http.ResponseWr
 	return response.DevLxdResponse(http.StatusOK, settings, "json", c.Type() == instancetype.VM)
 }
 
-var devlxdUbuntuProTokenPost = devLxdHandler{
+var devLXDUbuntuProTokenPost = devLXDHandler{
 	path:        "/1.0/ubuntu-pro/token",
-	handlerFunc: devlxdUbuntuProTokenPostHandler,
+	handlerFunc: devLXDUbuntuProTokenPostHandler,
 }
 
-func devlxdUbuntuProTokenPostHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+func devLXDUbuntuProTokenPostHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
 	}
@@ -381,27 +381,27 @@ func devlxdUbuntuProTokenPostHandler(d *Daemon, c instance.Instance, w http.Resp
 	return response.DevLxdResponse(http.StatusOK, tokenJSON, "json", c.Type() == instancetype.VM)
 }
 
-var handlers = []devLxdHandler{
+var handlers = []devLXDHandler{
 	{
 		path: "/",
 		handlerFunc: func(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 			return response.DevLxdResponse(http.StatusOK, []string{"/1.0"}, "json", c.Type() == instancetype.VM)
 		},
 	},
-	devlxdAPIHandler,
-	devlxdConfigGet,
-	devlxdConfigKeyGet,
-	devlxdMetadataGet,
-	devlxdEventsGet,
-	devlxdImageExport,
-	devlxdDevicesGet,
-	devlxdUbuntuProGet,
-	devlxdUbuntuProTokenPost,
+	devLXDAPIHandler,
+	devLXDConfigGet,
+	devLXDConfigKeyGet,
+	devLXDMetadataGet,
+	devLXDEventsGet,
+	devLXDImageExport,
+	devLXDDevicesGet,
+	devLXDUbuntuProGet,
+	devLXDUbuntuProTokenPost,
 }
 
 func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Set devlxd auth method to identify this request as coming from the /dev/lxd socket.
+		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
 		request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
 
 		conn := ucred.GetConnFromContext(r.Context())
@@ -447,7 +447,7 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 	}
 }
 
-func devLxdAPI(d *Daemon, f hoistFunc) http.Handler {
+func devLXDAPI(d *Daemon, f hoistFunc) http.Handler {
 	m := mux.NewRouter()
 	m.UseEncodedPath() // Allow encoded values in path segments.
 
@@ -492,7 +492,7 @@ type ConnPidMapper struct {
 	mLock sync.Mutex
 }
 
-// ConnStateHandler is used in the `ConnState` field of the devlxd http.Server so that we can cache the process ID of the
+// ConnStateHandler is used in the `ConnState` field of the devLXD http.Server so that we can cache the process ID of the
 // caller when a new connection is made and delete it when the connection is closed.
 func (m *ConnPidMapper) ConnStateHandler(conn net.Conn, state http.ConnState) {
 	unixConn, _ := conn.(*net.UnixConn)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -66,7 +66,7 @@ var devLXDConfigGet = devLXDHandler{
 
 func devLXDConfigGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
 	filtered := []string{}
@@ -108,7 +108,7 @@ func devLXDConfigGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrite
 		filtered = append(filtered, "/1.0/config/user.user-data")
 	}
 
-	return response.DevLxdResponse(http.StatusOK, filtered, "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, filtered, "json", c.Type() == instancetype.VM)
 }
 
 var devLXDConfigKeyGet = devLXDHandler{
@@ -118,16 +118,16 @@ var devLXDConfigKeyGet = devLXDHandler{
 
 func devLXDConfigKeyGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
 	key, err := url.PathUnescape(mux.Vars(r)["key"])
 	if err != nil {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusBadRequest, "bad request"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "bad request"), c.Type() == instancetype.VM)
 	}
 
 	if !strings.HasPrefix(key, "user.") && !strings.HasPrefix(key, "cloud-init.") {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
 	var value string
@@ -150,10 +150,10 @@ func devLXDConfigKeyGetHandler(d *Daemon, c instance.Instance, w http.ResponseWr
 
 	// If the resulting value is empty, return Not Found.
 	if value == "" {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusNotFound, "not found"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusNotFound, "not found"), c.Type() == instancetype.VM)
 	}
 
-	return response.DevLxdResponse(http.StatusOK, value, "raw", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, value, "raw", c.Type() == instancetype.VM)
 }
 
 var devLXDImageExport = devLXDHandler{
@@ -163,11 +163,11 @@ var devLXDImageExport = devLXDHandler{
 
 func devLXDImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
 	if shared.IsFalseOrEmpty(c.ExpandedConfig()["security.devlxd.images"]) {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
 	return imageExport(d, r)
@@ -180,12 +180,12 @@ var devLXDMetadataGet = devLXDHandler{
 
 func devLXDMetadataGetHandler(d *Daemon, inst instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
 	value := inst.ExpandedConfig()["user.meta-data"]
 
-	return response.DevLxdResponse(http.StatusOK, "instance-id: "+inst.CloudInitID()+"\nlocal-hostname: "+inst.Name()+"\n"+value, "raw", inst.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, "instance-id: "+inst.CloudInitID()+"\nlocal-hostname: "+inst.Name()+"\n"+value, "raw", inst.Type() == instancetype.VM)
 }
 
 var devLXDEventsGet = devLXDHandler{
@@ -195,7 +195,7 @@ var devLXDEventsGet = devLXDHandler{
 
 func devLXDEventsGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
 	typeStr := r.FormValue("type")
@@ -210,38 +210,38 @@ func devLXDEventsGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrite
 	if r.Header.Get("Upgrade") == "websocket" {
 		conn, err := ws.Upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 		}
 
 		defer func() { _ = conn.Close() }() // Ensure listener below ends when this function ends.
 
 		listenerConnection = events.NewWebsocketListenerConnection(conn)
 
-		resp = response.DevLxdResponse(http.StatusOK, "websocket", "websocket", c.Type() == instancetype.VM)
+		resp = response.DevLXDResponse(http.StatusOK, "websocket", "websocket", c.Type() == instancetype.VM)
 	} else {
 		h, ok := w.(http.Hijacker)
 		if !ok {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 		}
 
 		conn, _, err := h.Hijack()
 		if err != nil {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 		}
 
 		defer func() { _ = conn.Close() }() // Ensure listener below ends when this function ends.
 
 		listenerConnection, err = events.NewStreamListenerConnection(conn)
 		if err != nil {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 		}
 
-		resp = response.DevLxdResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)
+		resp = response.DevLXDResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)
 	}
 
 	listener, err := d.State().DevlxdEvents.AddListener(c.ID(), listenerConnection, strings.Split(typeStr, ","))
 	if err != nil {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 	}
 
 	logger.Debug("New container event listener", logger.Ctx{"instance": c.Name(), "project": c.Project().Name, "listener_id": listener.ID})
@@ -267,7 +267,7 @@ func devLXDAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter,
 
 			location, err = os.Hostname()
 			if err != nil {
-				return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
+				return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 			}
 		}
 
@@ -279,38 +279,38 @@ func devLXDAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter,
 			state = api.Started
 		}
 
-		return response.DevLxdResponse(http.StatusOK, api.DevLXDGet{APIVersion: version.APIVersion, Location: location, InstanceType: c.Type().String(), DevLXDPut: api.DevLXDPut{State: state.String()}}, "json", c.Type() == instancetype.VM)
+		return response.DevLXDResponse(http.StatusOK, api.DevLXDGet{APIVersion: version.APIVersion, Location: location, InstanceType: c.Type().String(), DevLXDPut: api.DevLXDPut{State: state.String()}}, "json", c.Type() == instancetype.VM)
 	} else if r.Method == "PATCH" {
 		if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 		}
 
 		req := api.DevLXDPut{}
 
 		err := json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid request body: %w", err), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid request body: %w", err), c.Type() == instancetype.VM)
 		}
 
 		state := api.StatusCodeFromString(req.State)
 
 		if state != api.Started && state != api.Ready {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid state %q", req.State), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid state %q", req.State), c.Type() == instancetype.VM)
 		}
 
 		err = c.VolatileSet(map[string]string{"volatile.last_state.ready": strconv.FormatBool(state == api.Ready)})
 		if err != nil {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "Failed to set instance state: %w", err), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "Failed to set instance state: %w", err), c.Type() == instancetype.VM)
 		}
 
 		if state == api.Ready {
 			s.Events.SendLifecycle(c.Project().Name, lifecycle.InstanceReady.Event(c, nil))
 		}
 
-		return response.DevLxdResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)
+		return response.DevLXDResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)
 	}
 
-	return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusMethodNotAllowed, "method %q not allowed", r.Method), c.Type() == instancetype.VM)
+	return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusMethodNotAllowed, "method %q not allowed", r.Method), c.Type() == instancetype.VM)
 }
 
 var devLXDDevicesGet = devLXDHandler{
@@ -320,7 +320,7 @@ var devLXDDevicesGet = devLXDHandler{
 
 func devLXDDevicesGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
 	// Populate NIC hwaddr from volatile if not explicitly specified.
@@ -334,7 +334,7 @@ func devLXDDevicesGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrit
 		}
 	}
 
-	return response.DevLxdResponse(http.StatusOK, c.ExpandedDevices(), "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, c.ExpandedDevices(), "json", c.Type() == instancetype.VM)
 }
 
 var devLXDUbuntuProGet = devLXDHandler{
@@ -344,17 +344,17 @@ var devLXDUbuntuProGet = devLXDHandler{
 
 func devLXDUbuntuProGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
 	}
 
 	if r.Method != http.MethodGet {
-		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
 	}
 
 	settings := d.State().UbuntuPro.GuestAttachSettings(c.ExpandedConfig()["ubuntu_pro.guest_attach"])
 
 	// Otherwise, return the value from the instance configuration.
-	return response.DevLxdResponse(http.StatusOK, settings, "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, settings, "json", c.Type() == instancetype.VM)
 }
 
 var devLXDUbuntuProTokenPost = devLXDHandler{
@@ -364,28 +364,28 @@ var devLXDUbuntuProTokenPost = devLXDHandler{
 
 func devLXDUbuntuProTokenPostHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
 	}
 
 	if r.Method != http.MethodPost {
-		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
 	}
 
 	// Return http.StatusForbidden if the host does not have guest attachment enabled.
 	tokenJSON, err := d.State().UbuntuPro.GetGuestToken(r.Context(), c.ExpandedConfig()["ubuntu_pro.guest_attach"])
 	if err != nil {
-		return response.DevLxdErrorResponse(fmt.Errorf("Failed to get an Ubuntu Pro guest token: %w", err), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(fmt.Errorf("Failed to get an Ubuntu Pro guest token: %w", err), c.Type() == instancetype.VM)
 	}
 
 	// Pass it back to the guest.
-	return response.DevLxdResponse(http.StatusOK, tokenJSON, "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, tokenJSON, "json", c.Type() == instancetype.VM)
 }
 
 var handlers = []devLXDHandler{
 	{
 		path: "/",
 		handlerFunc: func(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
-			return response.DevLxdResponse(http.StatusOK, []string{"/1.0"}, "json", c.Type() == instancetype.VM)
+			return response.DevLXDResponse(http.StatusOK, []string{"/1.0"}, "json", c.Type() == instancetype.VM)
 		},
 	},
 	devLXDAPIHandler,
@@ -438,7 +438,7 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 		if resp != nil {
 			err = resp.Render(w, r)
 			if err != nil {
-				writeErr := response.DevLxdErrorResponse(err, false).Render(w, r)
+				writeErr := response.DevLXDErrorResponse(err, false).Render(w, r)
 				if writeErr != nil {
 					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
 				}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -24,6 +24,17 @@ import (
 	"github.com/canonical/lxd/shared/ws"
 )
 
+// DevLXDSecurityKey are instance configuration keys used to enable devLXD features.
+type DevLXDSecurityKey string
+
+const (
+	// The security.devlxd key is used to enable devLXD for an instance.
+	devLXDSecurityKey DevLXDSecurityKey = "security.devlxd"
+
+	// The security.devlxd.images key is used to enable devLXD image export.
+	devLXDSecurityImagesKey DevLXDSecurityKey = "security.devlxd.images"
+)
+
 type hoistFunc func(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request)
 
 type devLXDHandlerFunc func(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -64,8 +64,8 @@ var apiDevLXD = []devLXDAPIEndpoint{
 	{
 		Path: "/",
 		Get: devLXDAPIEndpointAction{
-			Handler: func(d *Daemon, c instance.Instance, r *http.Request) response.Response {
-				return response.DevLXDResponse(http.StatusOK, []string{"/1.0"}, "json", c.Type() == instancetype.VM)
+			Handler: func(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
+				return response.DevLXDResponse(http.StatusOK, []string{"/1.0"}, "json", inst.Type() == instancetype.VM)
 			},
 		},
 	},
@@ -86,61 +86,61 @@ var devLXD10Endpoint = devLXDAPIEndpoint{
 	Patch: devLXDAPIEndpointAction{Handler: devLXDAPIPatchHandler},
 }
 
-func devLXDAPIGetHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
+func devLXDAPIGetHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
 	var location string
 
 	if d.serverClustered {
-		location = c.Location()
+		location = inst.Location()
 	} else {
 		var err error
 
 		location, err = os.Hostname()
 		if err != nil {
-			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
+			return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), inst.Type() == instancetype.VM)
 		}
 	}
 
 	var state api.StatusCode
 
-	if shared.IsTrue(c.LocalConfig()["volatile.last_state.ready"]) {
+	if shared.IsTrue(inst.LocalConfig()["volatile.last_state.ready"]) {
 		state = api.Ready
 	} else {
 		state = api.Started
 	}
 
-	return response.DevLXDResponse(http.StatusOK, api.DevLXDGet{APIVersion: version.APIVersion, Location: location, InstanceType: c.Type().String(), DevLXDPut: api.DevLXDPut{State: state.String()}}, "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, api.DevLXDGet{APIVersion: version.APIVersion, Location: location, InstanceType: inst.Type().String(), DevLXDPut: api.DevLXDPut{State: state.String()}}, "json", inst.Type() == instancetype.VM)
 }
 
-func devLXDAPIPatchHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
+func devLXDAPIPatchHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
 	s := d.State()
 
-	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
 	req := api.DevLXDPut{}
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid request body: %w", err), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid request body: %w", err), inst.Type() == instancetype.VM)
 	}
 
 	state := api.StatusCodeFromString(req.State)
 
 	if state != api.Started && state != api.Ready {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid state %q", req.State), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid state %q", req.State), inst.Type() == instancetype.VM)
 	}
 
-	err = c.VolatileSet(map[string]string{"volatile.last_state.ready": strconv.FormatBool(state == api.Ready)})
+	err = inst.VolatileSet(map[string]string{"volatile.last_state.ready": strconv.FormatBool(state == api.Ready)})
 	if err != nil {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "Failed to set instance state: %w", err), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "Failed to set instance state: %w", err), inst.Type() == instancetype.VM)
 	}
 
 	if state == api.Ready {
-		s.Events.SendLifecycle(c.Project().Name, lifecycle.InstanceReady.Event(c, nil))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceReady.Event(inst, nil))
 	}
 
-	return response.DevLXDResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, "", "raw", inst.Type() == instancetype.VM)
 }
 
 var devLXDConfigEndpoint = devLXDAPIEndpoint{
@@ -148,16 +148,16 @@ var devLXDConfigEndpoint = devLXDAPIEndpoint{
 	Get:  devLXDAPIEndpointAction{Handler: devLXDConfigGetHandler},
 }
 
-func devLXDConfigGetHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
-	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+func devLXDConfigGetHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
+	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
 	filtered := []string{}
 	hasSSHKeys := false
 	hasVendorData := false
 	hasUserData := false
-	for k := range c.ExpandedConfig() {
+	for k := range inst.ExpandedConfig() {
 		if !(strings.HasPrefix(k, "user.") || strings.HasPrefix(k, "cloud-init.")) {
 			continue
 		}
@@ -192,7 +192,7 @@ func devLXDConfigGetHandler(d *Daemon, c instance.Instance, r *http.Request) res
 		filtered = append(filtered, "/1.0/config/user.user-data")
 	}
 
-	return response.DevLXDResponse(http.StatusOK, filtered, "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, filtered, "json", inst.Type() == instancetype.VM)
 }
 
 var devLXDConfigKeyEndpoint = devLXDAPIEndpoint{
@@ -200,18 +200,18 @@ var devLXDConfigKeyEndpoint = devLXDAPIEndpoint{
 	Get:  devLXDAPIEndpointAction{Handler: devLXDConfigKeyGetHandler},
 }
 
-func devLXDConfigKeyGetHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
-	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+func devLXDConfigKeyGetHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
+	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
 	key, err := url.PathUnescape(mux.Vars(r)["key"])
 	if err != nil {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "bad request"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusBadRequest, "bad request"), inst.Type() == instancetype.VM)
 	}
 
 	if !strings.HasPrefix(key, "user.") && !strings.HasPrefix(key, "cloud-init.") {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
 	var value string
@@ -222,22 +222,22 @@ func devLXDConfigKeyGetHandler(d *Daemon, c instance.Instance, r *http.Request) 
 	// For values containing cloud-init seed data, try to merge into them additional SSH keys present on the instance config.
 	// If parsing the config is not possible, abstain from merging the additional keys.
 	if isVendorDataKey || isUserDataKey {
-		cloudInitData := cloudinit.GetEffectiveConfig(c.ExpandedConfig(), key, c.Name(), c.Project().Name)
+		cloudInitData := cloudinit.GetEffectiveConfig(inst.ExpandedConfig(), key, inst.Name(), inst.Project().Name)
 		if isVendorDataKey {
 			value = cloudInitData.VendorData
 		} else {
 			value = cloudInitData.UserData
 		}
 	} else {
-		value = c.ExpandedConfig()[key]
+		value = inst.ExpandedConfig()[key]
 	}
 
 	// If the resulting value is empty, return Not Found.
 	if value == "" {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusNotFound, "not found"), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusNotFound, "not found"), inst.Type() == instancetype.VM)
 	}
 
-	return response.DevLXDResponse(http.StatusOK, value, "raw", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, value, "raw", inst.Type() == instancetype.VM)
 }
 
 var devLXDImageExportEndpoint = devLXDAPIEndpoint{
@@ -245,13 +245,13 @@ var devLXDImageExportEndpoint = devLXDAPIEndpoint{
 	Get:  devLXDAPIEndpointAction{Handler: devLXDImageExportHandler},
 }
 
-func devLXDImageExportHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
-	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+func devLXDImageExportHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
+	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
-	if shared.IsFalseOrEmpty(c.ExpandedConfig()["security.devlxd.images"]) {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+	if shared.IsFalseOrEmpty(inst.ExpandedConfig()["security.devlxd.images"]) {
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
 	return imageExport(d, r)
@@ -341,23 +341,23 @@ var devLXDDevicesEndpoint = devLXDAPIEndpoint{
 	Get:  devLXDAPIEndpointAction{Handler: devLXDDevicesGetHandler},
 }
 
-func devLXDDevicesGetHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
-	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
+func devLXDDevicesGetHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
+	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), inst.Type() == instancetype.VM)
 	}
 
 	// Populate NIC hwaddr from volatile if not explicitly specified.
 	// This is so cloud-init running inside the instance can identify the NIC when the interface name is
 	// different than the LXD device name (such as when run inside a VM).
-	localConfig := c.LocalConfig()
-	devices := c.ExpandedDevices()
+	localConfig := inst.LocalConfig()
+	devices := inst.ExpandedDevices()
 	for devName, devConfig := range devices {
 		if devConfig["type"] == "nic" && devConfig["hwaddr"] == "" && localConfig["volatile."+devName+".hwaddr"] != "" {
 			devices[devName]["hwaddr"] = localConfig["volatile."+devName+".hwaddr"]
 		}
 	}
 
-	return response.DevLXDResponse(http.StatusOK, c.ExpandedDevices(), "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, inst.ExpandedDevices(), "json", inst.Type() == instancetype.VM)
 }
 
 var devLXDUbuntuProEndpoint = devLXDAPIEndpoint{
@@ -365,19 +365,19 @@ var devLXDUbuntuProEndpoint = devLXDAPIEndpoint{
 	Get:  devLXDAPIEndpointAction{Handler: devLXDUbuntuProGetHandler},
 }
 
-func devLXDUbuntuProGetHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
-	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
+func devLXDUbuntuProGetHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
+	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusForbidden), inst.Type() == instancetype.VM)
 	}
 
 	if r.Method != http.MethodGet {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), inst.Type() == instancetype.VM)
 	}
 
-	settings := d.State().UbuntuPro.GuestAttachSettings(c.ExpandedConfig()["ubuntu_pro.guest_attach"])
+	settings := d.State().UbuntuPro.GuestAttachSettings(inst.ExpandedConfig()["ubuntu_pro.guest_attach"])
 
 	// Otherwise, return the value from the instance configuration.
-	return response.DevLXDResponse(http.StatusOK, settings, "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, settings, "json", inst.Type() == instancetype.VM)
 }
 
 var devLXDUbuntuProTokenEndpoint = devLXDAPIEndpoint{
@@ -385,23 +385,23 @@ var devLXDUbuntuProTokenEndpoint = devLXDAPIEndpoint{
 	Post: devLXDAPIEndpointAction{Handler: devLXDUbuntuProTokenPostHandler},
 }
 
-func devLXDUbuntuProTokenPostHandler(d *Daemon, c instance.Instance, r *http.Request) response.Response {
-	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
+func devLXDUbuntuProTokenPostHandler(d *Daemon, inst instance.Instance, r *http.Request) response.Response {
+	if shared.IsFalse(inst.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusForbidden), inst.Type() == instancetype.VM)
 	}
 
 	if r.Method != http.MethodPost {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), inst.Type() == instancetype.VM)
 	}
 
 	// Return http.StatusForbidden if the host does not have guest attachment enabled.
-	tokenJSON, err := d.State().UbuntuPro.GetGuestToken(r.Context(), c.ExpandedConfig()["ubuntu_pro.guest_attach"])
+	tokenJSON, err := d.State().UbuntuPro.GetGuestToken(r.Context(), inst.ExpandedConfig()["ubuntu_pro.guest_attach"])
 	if err != nil {
-		return response.DevLXDErrorResponse(fmt.Errorf("Failed to get an Ubuntu Pro guest token: %w", err), c.Type() == instancetype.VM)
+		return response.DevLXDErrorResponse(fmt.Errorf("Failed to get an Ubuntu Pro guest token: %w", err), inst.Type() == instancetype.VM)
 	}
 
 	// Pass it back to the guest.
-	return response.DevLXDResponse(http.StatusOK, tokenJSON, "json", c.Type() == instancetype.VM)
+	return response.DevLXDResponse(http.StatusOK, tokenJSON, "json", inst.Type() == instancetype.VM)
 }
 
 func devLXDAPI(d *Daemon, f hoistFunc, rawResponse bool) http.Handler {

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -182,7 +182,7 @@ func devLXDConfigGetHandler(d *Daemon, r *http.Request) response.Response {
 	hasVendorData := false
 	hasUserData := false
 	for k := range inst.ExpandedConfig() {
-		if !(strings.HasPrefix(k, "user.") || strings.HasPrefix(k, "cloud-init.")) {
+		if !strings.HasPrefix(k, "user.") && !strings.HasPrefix(k, "cloud-init.") {
 			continue
 		}
 

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -155,13 +155,13 @@ func TestHttpRequest(t *testing.T) {
 
 	c := http.Client{Transport: &http.Transport{DialContext: DevLxdDialer{Path: fmt.Sprintf("%s/devlxd/sock", testDir)}.DevLxdDial}}
 
-	raw, err := c.Get("http://1.0")
+	raw, err := c.Get("http://lxd/1.0")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if raw.StatusCode != 500 {
-		t.Fatal(err)
+		t.Fatalf("Expected status code 500, got %d: %v", raw.StatusCode, err)
 	}
 
 	resp, err := io.ReadAll(raw.Body)

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -5,6 +5,9 @@ type CtxKey string
 
 // Context keys.
 const (
+	// CtxDevLXDInstance is the instance that made a request over the devLXD API.
+	CtxDevLXDInstance CtxKey = "devlxd_instance"
+
 	// CtxAccess is the access field in request context.
 	CtxAccess CtxKey = "access"
 

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -46,14 +46,14 @@ type Response interface {
 }
 
 // Devlxd response.
-type devLxdResponse struct {
+type devLXDResponse struct {
 	content     any
 	code        int
 	contentType string
 }
 
 // Render renders a response for requests against the /dev/lxd socket.
-func (r *devLxdResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
+func (r *devLXDResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
 	if r.code != http.StatusOK {
 		http.Error(w, fmt.Sprint(r.content), r.code)
 	} else if r.contentType == "json" {
@@ -74,7 +74,7 @@ func (r *devLxdResponse) Render(w http.ResponseWriter, req *http.Request) (err e
 	return err
 }
 
-func (r *devLxdResponse) String() string {
+func (r *devLXDResponse) String() string {
 	if r.code == http.StatusOK {
 		return "success"
 	}
@@ -82,27 +82,27 @@ func (r *devLxdResponse) String() string {
 	return "failure"
 }
 
-// DevLxdErrorResponse returns an error response. If rawResponse is true, a api.ResponseRaw will be sent instead of a minimal devLxdResponse.
-func DevLxdErrorResponse(err error, rawResponse bool) Response {
+// DevLXDErrorResponse returns an error response. If rawResponse is true, a api.ResponseRaw will be sent instead of a minimal devLxdResponse.
+func DevLXDErrorResponse(err error, rawResponse bool) Response {
 	if rawResponse {
 		return SmartError(err)
 	}
 
 	code, ok := api.StatusErrorMatch(err)
 	if ok {
-		return &devLxdResponse{content: err.Error(), code: code, contentType: "raw"}
+		return &devLXDResponse{content: err.Error(), code: code, contentType: "raw"}
 	}
 
-	return &devLxdResponse{content: err.Error(), code: http.StatusInternalServerError, contentType: "raw"}
+	return &devLXDResponse{content: err.Error(), code: http.StatusInternalServerError, contentType: "raw"}
 }
 
-// DevLxdResponse represents a devLxdResponse. If rawResponse is true, a api.ResponseRaw will be sent instead of a minimal devLxdResponse.
-func DevLxdResponse(code int, content any, contentType string, rawResponse bool) Response {
+// DevLXDResponse represents a devLxdResponse. If rawResponse is true, a api.ResponseRaw will be sent instead of a minimal devLxdResponse.
+func DevLXDResponse(code int, content any, contentType string, rawResponse bool) Response {
 	if rawResponse {
 		return SyncResponse(true, content)
 	}
 
-	return &devLxdResponse{content: content, code: code, contentType: contentType}
+	return &devLXDResponse{content: content, code: code, contentType: contentType}
 }
 
 // Sync response.

--- a/lxd/ucred/ucred.go
+++ b/lxd/ucred/ucred.go
@@ -39,7 +39,10 @@ func GetCred(conn *net.UnixConn) (*unix.Ucred, error) {
 
 // GetConnFromContext extracts the connection from the request context on a HTTP listener.
 func GetConnFromContext(ctx context.Context) net.Conn {
-	return ctx.Value(request.CtxConn).(net.Conn)
+	// Type assertion check prevents panic. If the context doesn't contain a value,
+	// or if the value is not of type net.Conn, a nil is returned.
+	conn, _ := ctx.Value(request.CtxConn).(net.Conn)
+	return conn
 }
 
 // GetCredFromContext extracts the unix credentials from the request context on a HTTP listener.

--- a/shared/api/devlxd.go
+++ b/shared/api/devlxd.go
@@ -1,5 +1,20 @@
 package api
 
+import (
+	"encoding/json"
+)
+
+// DevLXDResponse represents the response from the devLXD API.
+type DevLXDResponse struct {
+	Content    []byte `json:"content" yaml:"content"`
+	StatusCode int    `json:"status_code" yaml:"status_code"`
+}
+
+// ContentAsStruct unmarshals the response content.
+func (r DevLXDResponse) ContentAsStruct(target any) error {
+	return json.Unmarshal(r.Content, &target)
+}
+
 // DevLXDPut represents the modifiable data.
 type DevLXDPut struct {
 	// Instance state

--- a/shared/api/response.go
+++ b/shared/api/response.go
@@ -41,7 +41,7 @@ type Response struct {
 	Metadata json.RawMessage `json:"metadata" yaml:"metadata"`
 }
 
-// MetadataAsMap parses the Response metadata into a map.
+// MetadataAsMap unmarshals the Response metadata into a map.
 func (r *Response) MetadataAsMap() (map[string]any, error) {
 	ret := map[string]any{}
 	err := r.MetadataAsStruct(&ret)
@@ -63,7 +63,7 @@ func (r *Response) MetadataAsOperation() (*Operation, error) {
 	return &op, nil
 }
 
-// MetadataAsStringSlice parses the Response metadata into a slice of string.
+// MetadataAsStringSlice unmarshals the Response metadata into a slice of string.
 func (r *Response) MetadataAsStringSlice() ([]string, error) {
 	sl := []string{}
 	err := r.MetadataAsStruct(&sl)
@@ -74,7 +74,7 @@ func (r *Response) MetadataAsStringSlice() ([]string, error) {
 	return sl, nil
 }
 
-// MetadataAsStruct parses the Response metadata into a provided struct.
+// MetadataAsStruct unmarshals the Response metadata content.
 func (r *Response) MetadataAsStruct(target any) error {
 	return json.Unmarshal(r.Metadata, &target)
 }

--- a/test/godeps/client.list
+++ b/test/godeps/client.list
@@ -9,6 +9,7 @@ github.com/canonical/lxd/shared/simplestreams
 github.com/canonical/lxd/shared/tcp
 github.com/canonical/lxd/shared/termios
 github.com/canonical/lxd/shared/units
+github.com/canonical/lxd/shared/version
 github.com/canonical/lxd/shared/ws
 github.com/flosch/pongo2
 github.com/go-jose/go-jose/v4
@@ -69,10 +70,14 @@ golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials
 golang.org/x/oauth2/internal
 golang.org/x/sys/unix
+golang.org/x/text/cases
+golang.org/x/text/internal
 golang.org/x/text/internal/language
 golang.org/x/text/internal/language/compact
 golang.org/x/text/internal/tag
 golang.org/x/text/language
+golang.org/x/text/transform
+golang.org/x/text/unicode/norm
 vendor/golang.org/x/crypto/chacha20
 vendor/golang.org/x/crypto/chacha20poly1305
 vendor/golang.org/x/crypto/cryptobyte

--- a/test/godeps/lxc-config.list
+++ b/test/godeps/lxc-config.list
@@ -10,6 +10,7 @@ github.com/canonical/lxd/shared/simplestreams
 github.com/canonical/lxd/shared/tcp
 github.com/canonical/lxd/shared/termios
 github.com/canonical/lxd/shared/units
+github.com/canonical/lxd/shared/version
 github.com/canonical/lxd/shared/ws
 github.com/flosch/pongo2
 github.com/go-jose/go-jose/v4
@@ -70,10 +71,14 @@ golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials
 golang.org/x/oauth2/internal
 golang.org/x/sys/unix
+golang.org/x/text/cases
+golang.org/x/text/internal
 golang.org/x/text/internal/language
 golang.org/x/text/internal/language/compact
 golang.org/x/text/internal/tag
 golang.org/x/text/language
+golang.org/x/text/transform
+golang.org/x/text/unicode/norm
 gopkg.in/yaml.v2
 vendor/golang.org/x/crypto/chacha20
 vendor/golang.org/x/crypto/chacha20poly1305


### PR DESCRIPTION
Refactors the devlxd by introducing the API endpoints and register functions (similar to LXD REST API).

Additionally, it adds devlxd client that can be used in other tools for interacting with the devlxd endpoints from virtual machines and containers. This PR uses it test devlxd binary.