### PR TITLE
doc: hard code link titles (stable-5.0)

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -1,6 +1,6 @@
 ---
-discourse: 13114,15142
-relatedlinks: https://www.youtube.com/watch?v=6O0q3rSWr8A
+discourse: '[Token&#32;based&#32;remote&#32;connection](13114),[ACME&#32;support&#32;for&#32;server&#32;certificate](15142)'
+relatedlinks: '[LXD&#32;for&#32;multi-user&#32;systems&#32;-&#32;YouTube](https://www.youtube.com/watch?v=6O0q3rSWr8A)'
 ---
 
 (authentication)=

--- a/doc/backup.md
+++ b/doc/backup.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11296
+discourse: '[New&#32;disaster&#32;recovery&#32;tool](11296)'
 ---
 
 (backups)=

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -1,6 +1,6 @@
 ---
-discourse: 12559
-relatedlinks: https://cloudinit.readthedocs.org/
+discourse: '[First&#32;class&#32;cloud-init&#32;support](12559)'
+relatedlinks: '[Cloud-init&#32;documentation](https://cloudinit.readthedocs.org/)'
 ---
 
 (cloud-init)=

--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -1,5 +1,5 @@
 ---
-discourse: 9076
+discourse: '[LXD&#32;cluster&#32;on&#32;Raspberry&#32;Pi&#32;4](9076)'
 ---
 
 (clustering)=

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://www.youtube.com/watch?v=pqV0Z1qwbkg
+relatedlinks: "[LXD's&#32;development&#32;process&#32;-&#32;YouTube](https://www.youtube.com/watch?v=pqV0Z1qwbkg)"
 ---
 
 % Include content from [../CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/doc/database.md
+++ b/doc/database.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://github.com/canonical/dqlite
+relatedlinks: "[Canonical&#32;Dqlite](https://dqlite.io/), [Dqlite&#32;GitHub](https://github.com/canonical/dqlite)"
 ---
 
 # Database

--- a/doc/explanation/clustering.md
+++ b/doc/explanation/clustering.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15871
+relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
 ---
 
 (exp-clustering)=

--- a/doc/explanation/instances.md
+++ b/doc/explanation/instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: 8767,7519,9281
+discourse: '[Overview&#32;-&#32;GUI&#32;inside&#32;Containers](8767),lxc:[Running&#32;virtual&#32;machines&#32;with&#32;LXD&#32;4.0](7519),lxc:[Install&#32;any&#32;OS&#32;via&#32;ISO&#32;in&#32;a&#32;Virtual&#32;machine/VM](9281)'
 relatedlinks: '[LXD&#32;virtual&#32;machines:&#32;an&#32;overview](https://ubuntu.com/blog/lxd-virtual-machines-an-overview)'
 ---
 

--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://www.youtube.com/watch?v=QyXOOE_4cm0
+relatedlinks: '[Running&#32;LXD&#32;in&#32;production&#32;-&#32;YouTube](https://www.youtube.com/watch?v=QyXOOE_4cm0)'
 ---
 
 (performance-tuning)=

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://www.youtube.com/watch?v=QyXOOE_4cm0
+relatedlinks: "[Running&#32;LXD&#32;in&#32;production&#32;-&#32;YouTube](https://www.youtube.com/watch?v=QyXOOE_4cm0)"
 ---
 
 # Getting started

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15871
+relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
 ---
 
 (cluster-form)=

--- a/doc/howto/cluster_groups.md
+++ b/doc/howto/cluster_groups.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12716
+discourse: '[Cluster&#32;server&#32;grouping](12716)'
 ---
 
 (howto-cluster-groups)=

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11330
+discourse: '[Cluster&#32;member&#32;evacuation](11330)'
 ---
 
 (cluster-manage)=

--- a/doc/howto/import_machines_to_instances.md
+++ b/doc/howto/import_machines_to_instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: 14345
+discourse: '[Using&#32;lxd-migrate&#32;to&#32;convert&#32;a&#32;physical&#32;host&#32;to&#32;a&#32;container](14345)'
 ---
 
 (import-machines-to-instances)=

--- a/doc/howto/instances_console.md
+++ b/doc/howto/instances_console.md
@@ -1,5 +1,5 @@
 ---
-discourse: 9223
+discourse: '[GUI&#32;in&#32;Virtual&#32;Machines/VMs](9223)'
 ---
 
 (instances-console)=

--- a/doc/howto/instances_troubleshoot.md
+++ b/doc/howto/instances_troubleshoot.md
@@ -1,5 +1,5 @@
 ---
-discourse: 7362
+discourse: '[How&#32;to&#32;best&#32;ask&#32;questions&#32;on&#32;Discourse](7362)'
 ---
 
 (instances-troubleshoot)=

--- a/doc/howto/move_instances.md
+++ b/doc/howto/move_instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: 16635
+discourse: '[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](16635)'
 ---
 
 (move-instances)=

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -1,5 +1,5 @@
 ---
-discourse: 13223
+discourse: '[Network&#32;ACL&#32;logging](13223)'
 ---
 
 (network-acls)=

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11567
+discourse: '[BGP&#32;address/route&#32;advertisement](11567)'
 ---
 
 (network-bgp)=

--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -1,5 +1,5 @@
 ---
-discourse: 10034,9953
+discourse: "[Lxd&#32;bridge&#32;doesn't&#32;work&#32;with&#32;IPv4&#32;and&#32;UFW&#32;with&#32;nftables](10034),[LXD&#32;and&#32;Docker&#32;Firewall&#32;Redux&#32;-&#32;How&#32;to&#32;deal&#32;with&#32;FORWARD&#32;policy&#32;set&#32;to&#32;drop](9953)"
 ---
 
 (network-bridge-firewall)=

--- a/doc/howto/network_forwards.md
+++ b/doc/howto/network_forwards.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11801
+discourse: '[Floating&#32;IP&#32;addresses](11801)'
 ---
 
 (network-forwards)=

--- a/doc/howto/network_ovn_peers.md
+++ b/doc/howto/network_ovn_peers.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12165
+discourse: '[OVN&#32;network&#32;to&#32;network&#32;routing](12165)'
 ---
 
 (network-ovn-peers)=

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12033,13128
+discourse: '[Built-in&#32;DNS&#32;server](12033),[Custom&#32;DNS&#32;records&#32;in&#32;network&#32;zones](13128)'
 ---
 
 (network-zones)=

--- a/doc/howto/storage_move_volume.md
+++ b/doc/howto/storage_move_volume.md
@@ -1,5 +1,5 @@
 ---
-discourse: 10877
+discourse: '[Migrate&#32;from&#32;one&#32;storage&#32;pool&#32;to&#32;another](10877)'
 ---
 
 (howto-storage-move-volume)=

--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -1,5 +1,5 @@
 ---
-discourse: 1333
+discourse: '[How&#32;to&#32;resize&#32;ZFS&#32;used&#32;in&#32;LXD](1333)'
 ---
 
 (howto-storage-pools)=

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -1,6 +1,6 @@
 ---
-discourse: 12281,11735
-relatedlinks: https://grafana.com/grafana/dashboards/19131-lxd/
+discourse: '[Retrieve&#32;LXD&#32;metrics&#32;with&#32;Telegraf&#32;and&#32;InfluxDB&#32;2.x](12281),[Metric&#32;exporter&#32;for&#32;instances](11735)'
+relatedlinks: '[LXD&#32;|&#32;Grafana&#32;Labs](https://grafana.com/grafana/dashboards/19131-lxd/)'
 ---
 
 (metrics)=

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -1,5 +1,5 @@
 ---
-discourse: 13021
+discourse: '[How&#32;to&#32;use&#32;a&#32;second&#32;IP&#32;with&#32;a&#32;container&#32;and&#32;routed&#32;NIC](13021)'
 ---
 
 (networking)=

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://www.youtube.com/watch?v=6O0q3rSWr8A, [Introduction&#32;to&#32;LXD&#32;projects](https://ubuntu.com/tutorials/introduction-to-lxd-projects)
+relatedlinks: '[LXD&#32;for&#32;multi-user&#32;systems&#32;-&#32;YouTube](https://www.youtube.com/watch?v=6O0q3rSWr8A), [Introduction&#32;to&#32;LXD&#32;projects](https://ubuntu.com/tutorials/introduction-to-lxd-projects)'
 ---
 
 (projects)=

--- a/doc/reference/devices_proxy.md
+++ b/doc/reference/devices_proxy.md
@@ -1,5 +1,5 @@
 ---
-discourse: 8355
+discourse: '[Using&#32;proxy&#32;device&#32;to&#32;forward&#32;network&#32;connections&#32;from&#32;host&#32;to&#32;container&#32;in&#32;NAT&#32;mode](8355)'
 ---
 
 (devices-proxy)=

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -1,5 +1,5 @@
 ---
-discourse: 7322
+discourse: '[Getting&#32;universally&#32;routable&#32;IPv6&#32;Addresses&#32;for&#32;your&#32;Linux&#32;Containers&#32;on&#32;Ubuntu&#32;18.04&#32;with&#32;LXD&#32;4.0&#32;on&#32;a&#32;VPS](7322)'
 ---
 
 (network-bridge)=

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11033
+discourse: '[OVN&#32;high&#32;availability&#32;cluster&#32;tutorial](11033)'
 ---
 
 (network-ovn)=

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,6 +1,6 @@
 ---
 discourse: ubuntu:[New&#32;LXD&#32;image&#32;server&#32;available&#32;(images.lxd.canonical.com)](43824),[Image&#32;server&#32;infrastructure](16647)
-relatedlinks: https://www.youtube.com/watch?v=pM0EgUqj2a0
+relatedlinks: '[Deploying&#32;a&#32;new&#32;LXD&#32;image&#32;server&#32;-&#32;YouTube](https://www.youtube.com/watch?v=pM0EgUqj2a0)'
 ---
 
 (remote-image-servers)=

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15457
+discourse: '[Introducing&#32;MicroCeph](15457)'
 ---
 
 (storage-ceph)=

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15457
+discourse: '[Introducing&#32;MicroCeph](15457)'
 ---
 
 (storage-cephfs)=

--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://www.youtube.com/watch?v=z_OKwO5TskA
+relatedlinks: '[Benchmarking&#32;LXD&#32;storage&#32;drivers&#32;-&#32;YouTube](https://www.youtube.com/watch?v=z_OKwO5TskA)'
 ---
 
 (storage-drivers)=

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15872
+discourse: '[ZFS&#32;block&#32;mode](15872)'
 ---
 
 (storage-zfs)=

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -1,5 +1,5 @@
 ---
-discourse: 7735
+discourse: '[Share&#32;folders&#32;and&#32;volumes&#32;between&#32;host&#32;and&#32;containers](7735)'
 ---
 
 (storage)=


### PR DESCRIPTION
This PR hard-codes all titles for `relatedlinks:` and `discourse:` links that exist in `stable-5.0` docs. This is intended to prevent failed live link title fetching at build time (typically due to external site downtime) from blocking builds.