### PR TITLE
doc: Force white background for swagger API (from Incus)

### DIFF
--- a/doc/.sphinx/_static/swagger-override.css
+++ b/doc/.sphinx/_static/swagger-override.css
@@ -1,3 +1,7 @@
+.swagger-ui {
+    background-color: white;
+}
+
 .swagger-ui .markdown p, .swagger-ui .markdown pre, .swagger-ui .renderedMarkdown p, .swagger-ui .renderedMarkdown pre {
     margin-left: 0em;
 }


### PR DESCRIPTION
Cherry pick from https://github.com/lxc/incus/pull/1599.
Forces white background for SwaggerUI-generated API reference at https://documentation.ubuntu.com/lxd/en/latest/api/ even if dark mode is selected, making it easier to read. 