### PR TITLE
VM: Fix regression when hotplugging qemu virtio-blk drives in addDriveConfig

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4101,7 +4101,8 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 			qemuDev["driver"] = "scsi-cd"
 		}
 	} else if shared.ValueInSlice(bus, []string{"nvme", "virtio-blk"}) {
-		if qemuDev["bus"] == "" {
+		qemuDevBus, ok := qemuDev["bus"].(string)
+		if !ok || qemuDevBus == "" {
 			// Figure out a hotplug slot.
 			pciDevID := qemuPCIDeviceIDStart
 


### PR DESCRIPTION


Fixes regression introduced by bbdc307da8b632b5eb2fae943f8dc224e8c741b4