### PR TITLE
Ubuntu Pro: Re-initialise watcher on guest request

### DIFF
--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -351,7 +351,10 @@ func devlxdUbuntuProGetHandler(d *Daemon, c instance.Instance, w http.ResponseWr
 		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
 	}
 
-	settings := d.State().UbuntuPro.GuestAttachSettings(c.ExpandedConfig()["ubuntu_pro.guest_attach"])
+	settings, err := d.State().UbuntuPro.GuestAttachSettings(c.ExpandedConfig()["ubuntu_pro.guest_attach"])
+	if err != nil {
+		return response.DevLxdErrorResponse(err, c.Type() == instancetype.VM)
+	}
 
 	// Otherwise, return the value from the instance configuration.
 	return response.DevLxdResponse(http.StatusOK, settings, "json", c.Type() == instancetype.VM)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -74,7 +74,7 @@ func devlxdConfigGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrite
 	hasVendorData := false
 	hasUserData := false
 	for k := range c.ExpandedConfig() {
-		if !(strings.HasPrefix(k, "user.") || strings.HasPrefix(k, "cloud-init.")) {
+		if !strings.HasPrefix(k, "user.") && !strings.HasPrefix(k, "cloud-init.") {
 			continue
 		}
 

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -258,7 +258,8 @@ var devlxdAPIHandler = devLxdHandler{
 func devlxdAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
 	s := d.State()
 
-	if r.Method == "GET" {
+	switch r.Method {
+	case http.MethodGet:
 		var location string
 		if d.serverClustered {
 			location = c.Location()
@@ -280,7 +281,7 @@ func devlxdAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter,
 		}
 
 		return response.DevLxdResponse(http.StatusOK, api.DevLXDGet{APIVersion: version.APIVersion, Location: location, InstanceType: c.Type().String(), DevLXDPut: api.DevLXDPut{State: state.String()}}, "json", c.Type() == instancetype.VM)
-	} else if r.Method == "PATCH" {
+	case http.MethodPatch:
 		if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
 			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 		}

--- a/lxd/ubuntupro/client.go
+++ b/lxd/ubuntupro/client.go
@@ -40,6 +40,11 @@ const (
 	guestAttachSettingOn = "on"
 )
 
+const (
+	// guestSettingRequestCooldown determines the cooldown between guest requests that may re-trigger file watcher creation.
+	guestSettingRequestCooldown = 5 * time.Minute
+)
+
 // isValid returns an error if the GuestAttachSetting is not one of the pre-defined values.
 func validateGuestAttachSetting(guestAttachSetting string) error {
 	if !shared.ValueInSlice(guestAttachSetting, []string{guestAttachSettingOff, guestAttachSettingAvailable, guestAttachSettingOn}) {

--- a/lxd/ubuntupro/client.go
+++ b/lxd/ubuntupro/client.go
@@ -136,7 +136,10 @@ func (proCLI) getGuestToken(ctx context.Context) (*api.UbuntuProGuestTokenRespon
 func New(ctx context.Context, osName string) *Client {
 	if osName != "Ubuntu" {
 		// If we're not on Ubuntu, return a static Client.
-		return &Client{guestAttachSetting: guestAttachSettingOff}
+		return &Client{
+			guestAttachSetting: guestAttachSettingOff,
+			static:             true,
+		}
 	}
 
 	s := &Client{}
@@ -227,6 +230,7 @@ func (s *Client) watch(ctx context.Context, ubuntuProDir string) error {
 		<-ctx.Done()
 
 		// On cancel, set the guestAttachSetting back to "off" and unwatch the file.
+		s.static = true
 		s.guestAttachSetting = guestAttachSettingOff
 		err := monitor.Unwatch(path.Join(ubuntuProDir, "interfaces", "lxd-config.json"), "")
 		if err != nil {


### PR DESCRIPTION
The next release of the Ubuntu Pro client will use `/var/lib/ubuntu-pro` for new configuration. This is where the `interfaces/lxd-config.json` file will be placed, which LXD will watch for host configuration updated. Unfortunately, the new configuration directory isn't created until `pro config set lxd_guest_attach <value>` is actually called. Since LXD creates a file watcher on startup, it attempts to watch `/var/lib/ubuntu-pro` and this fails (doesn't exist yet). The only way to get guest attachment working is to restart the LXD daemon.

This PR works around this issue by allowing the guest to re-trigger a file watcher in limited scenarios. The tl;dr is as follows:
1. If the host is not ubuntu, then client is static and no file watcher will ever be triggered.
2. If the host is ubuntu, but no watcher is configured, and the watcher context has not been cancelled, when the guest calls `GET /1.0/ubuntu-pro` or `POST /1.0/ubuntu-pro/token` LXD will attempt to watch `/var/lib/ubuntu-pro` again to get the host config. If that fails, a cooldown of 5 minutes will prevent a guest from requesting either the setting or a token again.