### PR TITLE
storage: Support multi volume snapshot and restore

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2672,3 +2672,15 @@ This adds support for listing networks across all projects using the `all-projec
 ## `clustering_restore_skip_mode`
 
 Adds a `skip` mode to the restore request. This mode restores a cluster member's status to `ONLINE` without restarting any of its stopped local instances or migrating back instances that were evacuated to other cluster members.
+
+## `instance_snapshots_multi_volume`
+
+This API extension enables creating a snapshot and restoring an instance along with its attached volumes, while guaranteeing crash consistency across volumes. To support this, this extension adds a `disks` field to both `POST /1.0/instances/{name}/snapshots` and
+`PUT /1.0/instances/{name}` with the following possible values:
+
+1. `root`: Represents a snapshot of only the instance root disk. This same behavior is kept if `disks` is unset.
+1. `volumes`: Represents a multi-volume snapshot of the instance root volume and all non-shared attached volumes. Fails if any attached volumes are being shared.
+
+Also adds a `exclude_disks` field to both endpoints to allow a user to specify disk names whose volumes should not be included as part of the multi-volume snapshot.
+
+To track which volumes' snapshots are created together, this extension introduces a new volatile configuration key, {config:option}`instance-volatile:volatile.attached_volumes`, in the configuration of supported storage drivers for instance snapshots. This key contains a JSON-serialized map of attached volume UUIDs to the UUIDs of their corresponding snapshots.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2608,6 +2608,15 @@ The original VLAN used when moving a VF into an instance.
 The template with the given name is triggered upon next startup.
 ```
 
+```{config:option} volatile.attached_volumes instance-volatile
+:condition: "snapshot"
+:shortdesc: "JSON map of attached volumes to their respective snapshots."
+:type: "string"
+JSON-serialized map of attached volume UUIDs to the UUIDs of their corresponding
+snapshots, created as part of a multi-volume snapshot.
+
+```
+
 ```{config:option} volatile.base_image instance-volatile
 :shortdesc: "Hash of the base image"
 :type: "string"

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2256,11 +2256,28 @@ definitions:
                         type: disk
                 type: object
                 x-go-name: Devices
+            disks:
+                description: |-
+                    Which disks should be included in the multi-volume restore.
+                    Can be "root" or empty (for just the instance root volume),
+                    "volumes" (for all disks sourced by volumes; fails if an attached volumes snapshot was deleted or if a volume is being shared).
+                example: '"volumes"'
+                type: string
+                x-go-name: DisksMode
             ephemeral:
                 description: Whether the instance is ephemeral (deleted on shutdown)
                 example: false
                 type: boolean
                 x-go-name: Ephemeral
+            exclude_disks:
+                description: Disks whose volumes should not be included in a multi-volume restore.
+                example:
+                    - disk1
+                    - disk2
+                items:
+                    type: string
+                type: array
+                x-go-name: ExcludeDisks
             profiles:
                 description: List of profiles applied to the instance
                 example:
@@ -2423,6 +2440,23 @@ definitions:
         x-go-package: github.com/canonical/lxd/shared/api
     InstanceSnapshotsPost:
         properties:
+            disks:
+                description: |-
+                    Which disks should be included in the multi-volume snapshot.
+                    Can be "root" or empty (for just the instance root volume), and
+                    "volumes" (for all disks sourced by volumes; fails if an attached volume is being shared).
+                example: '"volumes"'
+                type: string
+                x-go-name: DisksMode
+            exclude_disks:
+                description: Disks sourced by volumes that should not be included in a multi-volume snapshot.
+                example:
+                    - disk1
+                    - disk2
+                items:
+                    type: string
+                type: array
+                x-go-name: ExcludeDisks
             expires_at:
                 description: When the snapshot expires (gets auto-deleted)
                 example: "2021-03-23T17:38:37.753398689-04:00"
@@ -2900,11 +2934,28 @@ definitions:
                         type: disk
                 type: object
                 x-go-name: Devices
+            disks:
+                description: |-
+                    Which disks should be included in the multi-volume restore.
+                    Can be "root" or empty (for just the instance root volume),
+                    "volumes" (for all disks sourced by volumes; fails if an attached volumes snapshot was deleted or if a volume is being shared).
+                example: '"volumes"'
+                type: string
+                x-go-name: DisksMode
             ephemeral:
                 description: Whether the instance is ephemeral (deleted on shutdown)
                 example: false
                 type: boolean
                 x-go-name: Ephemeral
+            exclude_disks:
+                description: Disks whose volumes should not be included in a multi-volume restore.
+                example:
+                    - disk1
+                    - disk2
+                items:
+                    type: string
+                type: array
+                x-go-name: ExcludeDisks
             instance_type:
                 description: Cloud instance type (AWS, GCP, Azure, ...) to emulate with limits
                 example: t1.micro

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/instance/operationlock"
@@ -516,7 +517,7 @@ func autoCreateInstanceSnapshots(ctx context.Context, s *state.State, instances 
 			return err
 		}
 
-		err = inst.Snapshot(snapshotName, expiry, false)
+		err = inst.Snapshot(snapshotName, expiry, false, deviceConfig.Devices{})
 		if err != nil {
 			l.Error("Error creating snapshot", logger.Ctx{"snapshot": snapshotName, "err": err})
 			return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2256,7 +2256,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	}
 
 	if snapName != "" && expiry != nil {
-		err := d.snapshot(snapName, *expiry, false)
+		err := d.snapshot(snapName, *expiry, false, deviceConfig.Devices{})
 		if err != nil {
 			return "", nil, fmt.Errorf("Failed taking startup snapshot: %w", err)
 		}
@@ -3452,7 +3452,7 @@ func (d *lxc) RenderState(hostInterfaces []net.Interface) (*api.InstanceState, e
 }
 
 // snapshot creates a snapshot of the instance.
-func (d *lxc) snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *lxc) snapshot(name string, expiry time.Time, stateful bool, disks deviceConfig.Devices) error {
 	// Deal with state.
 	if stateful {
 		// Quick checks.
@@ -3529,11 +3529,11 @@ func (d *lxc) snapshot(name string, expiry time.Time, stateful bool) error {
 	// Wait for any file operations to complete to have a more consistent snapshot.
 	d.stopForkfile(false)
 
-	return d.snapshotCommon(d, name, expiry, stateful)
+	return d.snapshotCommon(d, name, expiry, stateful, disks)
 }
 
 // Snapshot takes a new snapshot.
-func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool, disks deviceConfig.Devices) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -3541,7 +3541,7 @@ func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
 
 	defer unlock()
 
-	return d.snapshot(name, expiry, stateful)
+	return d.snapshot(name, expiry, stateful, disks)
 }
 
 // Restore restores a snapshot.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1449,7 +1449,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	}
 
 	if snapName != "" && expiry != nil {
-		err := d.snapshot(snapName, *expiry, false)
+		err := d.snapshot(snapName, *expiry, false, deviceConfig.Devices{})
 		if err != nil {
 			err = fmt.Errorf("Failed taking startup snapshot: %w", err)
 			op.Done(err)
@@ -5011,7 +5011,7 @@ func (d *qemu) IsPrivileged() bool {
 }
 
 // snapshot creates a snapshot of the instance.
-func (d *qemu) snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *qemu) snapshot(name string, expiry time.Time, stateful bool, disks deviceConfig.Devices) error {
 	var err error
 	var monitor *qmp.Monitor
 
@@ -5041,7 +5041,7 @@ func (d *qemu) snapshot(name string, expiry time.Time, stateful bool) error {
 	}
 
 	// Create the snapshot.
-	err = d.snapshotCommon(d, name, expiry, stateful)
+	err = d.snapshotCommon(d, name, expiry, stateful, disks)
 	if err != nil {
 		return err
 	}
@@ -5064,7 +5064,7 @@ func (d *qemu) snapshot(name string, expiry time.Time, stateful bool) error {
 }
 
 // Snapshot takes a new snapshot.
-func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool, disks deviceConfig.Devices) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -5072,7 +5072,7 @@ func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
 
 	defer unlock()
 
-	return d.snapshot(name, expiry, stateful)
+	return d.snapshot(name, expiry, stateful, disks)
 }
 
 // Restore restores an instance snapshot.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5076,66 +5076,15 @@ func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool, disks devi
 }
 
 // Restore restores an instance snapshot.
-func (d *qemu) Restore(source instance.Instance, stateful bool) error {
-	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestore, false, false)
+func (d *qemu) Restore(source instance.Instance, stateful bool, disks deviceConfig.Devices) error {
+	// Derive the relevant volumes.
+	targetSnapshots, pool, wasRunning, op, err := d.restoreCommon(d, source, disks)
 	if err != nil {
-		return fmt.Errorf("Failed to create instance restore operation: %w", err)
+		op.Done(err)
+		return err
 	}
 
-	defer op.Done(nil)
-
-	var ctxMap logger.Ctx
-
-	// Stop the instance.
-	wasRunning := false
-	if d.IsRunning() {
-		wasRunning = true
-
-		ephemeral := d.IsEphemeral()
-		if ephemeral {
-			// Unset ephemeral flag.
-			args := db.InstanceArgs{
-				Architecture: d.Architecture(),
-				Config:       d.LocalConfig(),
-				Description:  d.Description(),
-				Devices:      d.LocalDevices(),
-				Ephemeral:    false,
-				Profiles:     d.Profiles(),
-				Project:      d.Project().Name,
-				Type:         d.Type(),
-				Snapshot:     d.IsSnapshot(),
-			}
-
-			err := d.Update(args, false)
-			if err != nil {
-				op.Done(err)
-				return err
-			}
-
-			// On function return, set the flag back on.
-			defer func() {
-				args.Ephemeral = ephemeral
-				_ = d.Update(args, false)
-			}()
-		}
-
-		// This will unmount the instance storage.
-		err := d.Stop(false)
-		if err != nil {
-			op.Done(err)
-			return err
-		}
-
-		// Refresh the operation as that one is now complete.
-		op, err = operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestore, false, false)
-		if err != nil {
-			return fmt.Errorf("Failed to create instance restore operation: %w", err)
-		}
-
-		defer op.Done(nil)
-	}
-
-	ctxMap = logger.Ctx{
+	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
 		"used":      d.lastUsedDate,
@@ -5143,39 +5092,10 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 
 	d.logger.Info("Restoring instance", ctxMap)
 
-	// Load the storage driver.
-	pool, err := storagePools.LoadByInstance(d.state, d)
+	// Restore the relevant volumes.
+	err = pool.RestoreInstanceSnapshot(d, source, targetSnapshots, nil)
 	if err != nil {
-		op.Done(err)
-		return err
-	}
-
-	// Restore the rootfs.
-	err = pool.RestoreInstanceSnapshot(d, source, nil)
-	if err != nil {
-		op.Done(err)
-		return err
-	}
-
-	// Restore the configuration.
-	args := db.InstanceArgs{
-		Architecture: source.Architecture(),
-		Config:       source.LocalConfig(),
-		Description:  source.Description(),
-		Devices:      source.LocalDevices(),
-		Ephemeral:    source.IsEphemeral(),
-		Profiles:     source.Profiles(),
-		Project:      source.Project().Name,
-		Type:         source.Type(),
-		Snapshot:     source.IsSnapshot(),
-	}
-
-	// Don't pass as user-requested as there's no way to fix a bad config.
-	// This will call d.UpdateBackupFile() to ensure snapshot list is up to date.
-	err = d.Update(args, false)
-	if err != nil {
-		op.Done(err)
-		return err
+		return fmt.Errorf("Failed to restore snapshot: %w", err)
 	}
 
 	d.stateful = stateful

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -92,8 +92,8 @@ type Instance interface {
 	IsPrivileged() bool
 
 	// Snapshots & migration & backups.
-	Restore(source Instance, stateful bool) error
-	Snapshot(name string, expiry time.Time, stateful bool) error
+	Restore(source Instance, stateful bool, volumeDisks deviceConfig.Devices) error
+	Snapshot(name string, expiry time.Time, stateful bool, volumeDisks deviceConfig.Devices) error
 	Snapshots() ([]Instance, error)
 	Backups() ([]backup.InstanceBackup, error)
 	UpdateBackupFile() error

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -749,12 +749,12 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Ins
 		if args.Config["volatile.cloud-init.instance-id"] == "" {
 			args.Config["volatile.cloud-init.instance-id"] = uuid.New().String()
 		}
-	}
 
-	// Validate instance config.
-	err = ValidConfig(s.OS, args.Config, false, args.Type)
-	if err != nil {
-		return nil, nil, nil, err
+		// If not a snapshot, validate instance config.
+		err = ValidConfig(s.OS, args.Config, false, args.Type)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	// Leave validating devices to Create function call below.

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -437,6 +437,15 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	//  shortdesc: Template hook
 	"volatile.apply_template": validate.IsAny,
 
+	// lxdmeta:generate(entities=instance; group=volatile; key=volatile.attached_volumes)
+	// JSON-serialized map of attached volume UUIDs to the UUIDs of their corresponding
+	// snapshots, created as part of a multi-volume snapshot.
+	//
+	// ---
+	//   type: string
+	//   shortdesc: JSON map of attached volumes to their respective snapshots.
+	//   condition: snapshot
+
 	// lxdmeta:generate(entities=instance; group=volatile; key=volatile.base_image)
 	// The hash of the image that the instance was created from (empty if the instance was not created from an image).
 	// ---

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -351,9 +351,14 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
+	disks, err := instance.ParseSnapshotDisks(inst, req.DisksMode, req.ExcludeDisks)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
 	snapshot := func(op *operations.Operation) error {
 		inst.SetOperation(op)
-		return inst.Snapshot(req.Name, expiry, req.Stateful)
+		return inst.Snapshot(req.Name, expiry, req.Stateful, disks)
 	}
 
 	resources := map[string][]api.URL{}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2913,6 +2913,14 @@
 						}
 					},
 					{
+						"volatile.attached_volumes": {
+							"condition": "snapshot",
+							"longdesc": "JSON-serialized map of attached volume UUIDs to the UUIDs of their corresponding\nsnapshots, created as part of a multi-volume snapshot.\n",
+							"shortdesc": "JSON map of attached volumes to their respective snapshots.",
+							"type": "string"
+						}
+					},
+					{
 						"volatile.base_image": {
 							"longdesc": "The hash of the image that the instance was created from (empty if the instance was not created from an image).",
 							"shortdesc": "Hash of the base image",

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6582,7 +6582,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 }
 
 // CreateCustomVolumeSnapshot creates a snapshot of a custom volume.
-func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newDescription string, newExpiryDate time.Time, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newDescription string, newExpiryDate time.Time, newSnapshotUUID string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName, "newDescription": newDescription, "newExpiryDate": newExpiryDate})
 	l.Debug("CreateCustomVolumeSnapshot started")
 	defer l.Debug("CreateCustomVolumeSnapshot finished")
@@ -6649,6 +6649,11 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 
 	// Set the parent volume's UUID.
 	vol.SetParentUUID(parentUUID)
+
+	// Set UUID to the one provided if present.
+	if newSnapshotUUID != "" {
+		vol.Config()["volatile.uuid"] = newSnapshotUUID
+	}
 
 	revert := revert.New()
 	defer revert.Fail()

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -248,7 +248,7 @@ func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Ope
 }
 
 // CreateInstanceSnapshot ...
-func (b *mockBackend) CreateInstanceSnapshot(i instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, volumes []*api.StorageVolume, op *operations.Operation) error {
 	return nil
 }
 
@@ -263,7 +263,7 @@ func (b *mockBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operati
 }
 
 // RestoreInstanceSnapshot ...
-func (b *mockBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, volumeSnapshots []*api.StorageVolume, op *operations.Operation) error {
 	return nil
 }
 
@@ -398,7 +398,7 @@ func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConf
 }
 
 // CreateCustomVolumeSnapshot ...
-func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate time.Time, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate time.Time, newSnapshotUUID string, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -90,10 +90,10 @@ type Pool interface {
 	UnmountInstance(inst instance.Instance, op *operations.Operation) error
 
 	// Instance snapshots.
-	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
+	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, volumes []*api.StorageVolume, op *operations.Operation) error
 	RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
-	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
+	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, volumeSnapshots []*api.StorageVolume, op *operations.Operation) error
 	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
 	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
 	UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
@@ -129,7 +129,7 @@ type Pool interface {
 	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
 
 	// Custom volume snapshots.
-	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate time.Time, op *operations.Operation) error
+	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate time.Time, newSnapshotUUID string, op *operations.Operation) error
 	RenameCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
 	DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error
 	UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -913,11 +913,11 @@ func InstanceContentType(inst instance.Instance) drivers.ContentType {
 	return contentType
 }
 
-// volumeIsUsedByDevice; true when vol is referred to by dev, assumes the volume
+// VolumeIsUsedByDevice returns true when vol is referred to by dev, assumes the volume
 // belongs to the correct project to be referenced by the instance.
 // instanceType=instanceType.Any indicates the device is used by a profile.
 // The instanceName argument is only used if instanceType != instanceType.Any.
-func volumeIsUsedByDevice(vol api.StorageVolume, instanceType instancetype.Type, instanceName string, dev map[string]string) (bool, error) {
+func VolumeIsUsedByDevice(vol api.StorageVolume, instanceType instancetype.Type, instanceName string, dev map[string]string) (bool, error) {
 	if dev["type"] != cluster.TypeDisk.String() {
 		return false, nil
 	}
@@ -1051,7 +1051,7 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 		// Iterate through each of the profiles's devices, looking for disks in the same pool as volume.
 		// Then try and match the volume name against the profile device's "source" property.
 		for name, dev := range profile.Devices {
-			usesVol, err := volumeIsUsedByDevice(*vol, instancetype.Any, "", dev)
+			usesVol, err := VolumeIsUsedByDevice(*vol, instancetype.Any, "", dev)
 			if err != nil {
 				return err
 			}
@@ -1114,7 +1114,7 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 			// Iterate through each of the instance's devices, looking for disks in the same pool as volume.
 			// Then try and match the volume name against the instance device's "source" property.
 			for devName, dev := range devices {
-				usesVol, err := volumeIsUsedByDevice(*vol, inst.Type, inst.Name, dev)
+				usesVol, err := VolumeIsUsedByDevice(*vol, inst.Type, inst.Name, dev)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -223,7 +223,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 	// Create the snapshot.
 	snapshot := func(op *operations.Operation) error {
-		return details.pool.CreateCustomVolumeSnapshot(effectiveProjectName, details.volumeName, req.Name, req.Description, expiry, op)
+		return details.pool.CreateCustomVolumeSnapshot(effectiveProjectName, details.volumeName, req.Name, req.Description, expiry, "", op)
 	}
 
 	resources := map[string][]api.URL{}
@@ -1278,7 +1278,7 @@ func autoCreateCustomVolumeSnapshots(ctx context.Context, s *state.State, volume
 			return fmt.Errorf("Error loading pool for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}
 
-		err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, v.Description, expiry, nil)
+		err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, v.Description, expiry, "", nil)
 		if err != nil {
 			return fmt.Errorf("Error creating snapshot for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1194,6 +1194,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1442,11 +1454,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1763,7 +1775,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2832,7 +2844,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2842,7 +2854,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3035,7 +3047,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5068,11 +5080,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6608,14 +6620,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6879,7 +6902,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6888,7 +6911,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7679,7 +7702,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7689,7 +7712,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1499,6 +1499,18 @@ msgstr ""
 msgid "Columns"
 msgstr "Spalten"
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1763,12 +1775,12 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 #, fuzzy
 msgid "Create instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -2111,7 +2123,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3260,7 +3272,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3270,7 +3282,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3469,7 +3481,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid format: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
@@ -5657,12 +5669,12 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 #, fuzzy
 msgid "Restore instances from snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -7309,7 +7321,7 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 #, fuzzy
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
@@ -7318,10 +7330,21 @@ msgstr ""
 "Laufenden Zustand des Containers aus dem Sicherungspunkt (falls vorhanden) "
 "wiederherstellen oder nicht"
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 #, fuzzy
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
+msgstr ""
 
 #: lxc/rebuild.go:28
 msgid ""
@@ -7797,7 +7820,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
@@ -7816,7 +7839,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
@@ -9018,7 +9041,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9028,7 +9051,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -1201,6 +1201,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1449,11 +1461,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1778,7 +1790,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2871,7 +2883,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2881,7 +2893,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3074,7 +3086,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5142,11 +5154,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6725,14 +6737,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6996,7 +7019,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -7005,7 +7028,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7796,7 +7819,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7806,7 +7829,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1453,6 +1453,18 @@ msgstr ""
 msgid "Columns"
 msgstr "Columnas"
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr "Cliente de Linea de Comandos para LXD"
@@ -1710,12 +1722,12 @@ msgstr "Creado: %s"
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 #, fuzzy
 msgid "Create instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -2042,7 +2054,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3150,7 +3162,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3160,7 +3172,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3357,7 +3369,7 @@ msgstr "Versión del cliente: %s\n"
 msgid "Invalid format: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -5459,12 +5471,12 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 #, fuzzy
 msgid "Restore instances from snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -7055,14 +7067,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -7375,7 +7398,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7386,7 +7409,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <template>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8271,7 +8294,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -8281,7 +8304,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1493,6 +1493,18 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonnes"
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1767,12 +1779,12 @@ msgstr "Créé : %s"
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 #, fuzzy
 msgid "Create instance snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 #, fuzzy
 msgid ""
 "Create instance snapshots\n"
@@ -2137,7 +2149,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3298,7 +3310,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3311,7 +3323,7 @@ msgstr ""
 "Si c'est la première fois que vous lancez LXD, vous devriez aussi lancer : "
 "sudo lxd init"
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3515,7 +3527,7 @@ msgstr "Afficher la version du client"
 msgid "Invalid format: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -5765,12 +5777,12 @@ msgstr "Le pendant de `lxc pause` est `lxc start`."
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 #, fuzzy
 msgid "Restore instances from snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 #, fuzzy
 msgid ""
 "Restore instances from snapshots\n"
@@ -7454,7 +7466,7 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 #, fuzzy
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
@@ -7463,10 +7475,21 @@ msgstr ""
 "Restaurer ou pas l'état de fonctionnement du conteneur depuis l'instantané "
 "(s'il est disponible)"
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 #, fuzzy
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
+msgstr ""
 
 #: lxc/rebuild.go:28
 msgid ""
@@ -7975,7 +7998,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
@@ -8000,7 +8023,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
@@ -9299,7 +9322,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9309,7 +9332,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -1198,6 +1198,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1446,11 +1458,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1767,7 +1779,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2836,7 +2848,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2846,7 +2858,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3039,7 +3051,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5072,11 +5084,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6612,14 +6624,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6883,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6892,7 +6915,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7683,7 +7706,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7693,7 +7716,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1451,6 +1451,18 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonne"
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1705,12 +1717,12 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 #, fuzzy
 msgid "Create instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -2038,7 +2050,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3143,7 +3155,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3153,7 +3165,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3350,7 +3362,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid format: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
@@ -5461,12 +5473,12 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 #, fuzzy
 msgid "Restore instances from snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -7052,14 +7064,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -7375,7 +7398,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "Creazione del container in corso"
@@ -7386,7 +7409,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <template>"
 msgstr "Creazione del container in corso"
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "Creazione del container in corso"
@@ -8271,7 +8294,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -8281,7 +8304,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1467,6 +1467,18 @@ msgstr "クラスタリングが有効になりました"
 msgid "Columns"
 msgstr "カラムレイアウト"
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr "LXD のコマンドラインクライアント"
@@ -1740,11 +1752,11 @@ msgstr "プロファイルを作成します"
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr "インスタンスのスナップショットを作成します"
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -2068,7 +2080,7 @@ msgstr "警告を削除します"
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3214,7 +3226,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3226,7 +3238,7 @@ msgid ""
 "lxd init"
 msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行する必要があります"
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
@@ -3429,7 +3441,7 @@ msgstr "クライアントバージョン: %s\n"
 msgid "Invalid format: %s"
 msgstr "不正なフォーマット %s"
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
@@ -5708,11 +5720,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr "スナップショットからインスタンスをリストアします"
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -7377,7 +7389,7 @@ msgstr "処理が完全に終わるまで待ちます"
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "スナップショットを含めずにインスタンスのみをバックアップするかどうか"
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
@@ -7385,9 +7397,20 @@ msgstr ""
 "スナップショットからインスタンスの稼動状態をリストアするかどうか (取得可能な"
 "場合)"
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
+msgstr ""
 
 #: lxc/rebuild.go:28
 msgid ""
@@ -7663,7 +7686,7 @@ msgstr "[<remote>:]<instance> <profile>"
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "[<remote>:]<instance> <snapshot>"
 
@@ -7672,7 +7695,7 @@ msgstr "[<remote>:]<instance> <snapshot>"
 msgid "[<remote>:]<instance> <template>"
 msgstr "[<remote>:]<instance> <template>"
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "[<remote>:]<instance> [<snapshot name>]"
 
@@ -8666,7 +8689,7 @@ msgstr ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    ローカルのインスタンス \"c1\" を削除します。"
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 #, fuzzy
 msgid ""
 "lxc snapshot u1 snap0\n"
@@ -8681,7 +8704,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1194,6 +1194,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1442,11 +1454,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1763,7 +1775,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2832,7 +2844,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2842,7 +2854,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3035,7 +3047,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5068,11 +5080,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6608,14 +6620,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6879,7 +6902,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6888,7 +6911,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7679,7 +7702,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7689,7 +7712,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-04-29 07:41-0600\n"
+        "POT-Creation-Date: 2025-04-29 18:14-0300\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1121,6 +1121,14 @@ msgstr  ""
 msgid   "Columns"
 msgstr  ""
 
+#: lxc/restore.go:38
+msgid   "Comma-separated list of names for which disks should be ignored when performing a multi-volume restore"
+msgstr  ""
+
+#: lxc/snapshot.go:50
+msgid   "Comma-separated list of names for which disks should be ignored when performing a multi-volume snapshot"
+msgstr  ""
+
 #: lxc/main.go:83
 msgid   "Command line client for LXD"
 msgstr  ""
@@ -1353,11 +1361,11 @@ msgstr  ""
 msgid   "Create identity provider groups"
 msgstr  ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid   "Create instance snapshots"
 msgstr  ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid   "Create instance snapshots\n"
         "\n"
         "When --stateful is used, LXD attempts to checkpoint the instance's\n"
@@ -1580,7 +1588,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783 lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062 lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175 lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445 lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673 lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172 lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483 lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702 lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348 lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578 lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135 lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695 lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473 lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884 lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222 lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450 lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382 lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53 lxc/network_forward.go:34 lxc/network_forward.go:91 lxc/network_forward.go:180 lxc/network_forward.go:257 lxc/network_forward.go:413 lxc/network_forward.go:498 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548 lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286 lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644 lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030 lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:461 lxc/storage_bucket.go:555 lxc/storage_bucket.go:649 lxc/storage_bucket.go:718 lxc/storage_bucket.go:752 lxc/storage_bucket.go:793 lxc/storage_bucket.go:872 lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042 lxc/storage_bucket.go:1177 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:314 lxc/storage_volume.go:395 lxc/storage_volume.go:620 lxc/storage_volume.go:729 lxc/storage_volume.go:816 lxc/storage_volume.go:921 lxc/storage_volume.go:1025 lxc/storage_volume.go:1246 lxc/storage_volume.go:1377 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2264 lxc/storage_volume.go:2385 lxc/storage_volume.go:2447 lxc/storage_volume.go:2583 lxc/storage_volume.go:2667 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783 lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062 lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175 lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445 lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673 lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172 lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483 lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702 lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348 lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578 lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135 lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695 lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473 lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884 lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222 lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450 lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382 lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53 lxc/network_forward.go:34 lxc/network_forward.go:91 lxc/network_forward.go:180 lxc/network_forward.go:257 lxc/network_forward.go:413 lxc/network_forward.go:498 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548 lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286 lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644 lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030 lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:461 lxc/storage_bucket.go:555 lxc/storage_bucket.go:649 lxc/storage_bucket.go:718 lxc/storage_bucket.go:752 lxc/storage_bucket.go:793 lxc/storage_bucket.go:872 lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042 lxc/storage_bucket.go:1177 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:314 lxc/storage_volume.go:395 lxc/storage_volume.go:620 lxc/storage_volume.go:729 lxc/storage_volume.go:816 lxc/storage_volume.go:921 lxc/storage_volume.go:1025 lxc/storage_volume.go:1246 lxc/storage_volume.go:1377 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2264 lxc/storage_volume.go:2385 lxc/storage_volume.go:2447 lxc/storage_volume.go:2583 lxc/storage_volume.go:2667 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -2578,7 +2586,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2586,7 +2594,7 @@ msgstr  ""
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
@@ -2777,7 +2785,7 @@ msgstr  ""
 msgid   "Invalid format: %s"
 msgstr  ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid   "Invalid instance name: %s"
 msgstr  ""
@@ -4673,11 +4681,11 @@ msgstr  ""
 msgid   "Restore cluster member"
 msgstr  ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid   "Restore instances from snapshots"
 msgstr  ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid   "Restore instances from snapshots\n"
         "\n"
         "If --stateful is passed, then the running state will be restored too."
@@ -6149,12 +6157,20 @@ msgstr  ""
 msgid   "Whether or not to only backup the instance (without snapshots)"
 msgstr  ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid   "Whether or not to restore the instance's running state from snapshot (if available)"
 msgstr  ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid   "Whether or not to snapshot the instance's running state"
+msgstr  ""
+
+#: lxc/snapshot.go:49
+msgid   "Which disks should be included in the snapshot; can be \"root\" or \"volumes\""
+msgstr  ""
+
+#: lxc/restore.go:37
+msgid   "Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr  ""
 
 #: lxc/rebuild.go:28
@@ -6397,7 +6413,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid   "[<remote>:]<instance> <snapshot>"
 msgstr  ""
 
@@ -6405,7 +6421,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <template>"
 msgstr  ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid   "[<remote>:]<instance> [<snapshot name>]"
 msgstr  ""
 
@@ -7106,7 +7122,7 @@ msgid   "lxc query -X DELETE --wait /1.0/instances/c1\n"
         "    Delete local instance \"c1\"."
 msgstr  ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid   "lxc snapshot u1 snap0\n"
         "	Create a snapshot of \"u1\" called \"snap0\".\n"
         "\n"
@@ -7114,7 +7130,7 @@ msgid   "lxc snapshot u1 snap0\n"
         "		Create a snapshot of \"u1\" called \"snap0\" with the configuration from \"config.yaml\"."
 msgstr  ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid   "lxc snapshot u1 snap0\n"
         "    Create the snapshot.\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -1421,6 +1421,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1669,11 +1681,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1990,7 +2002,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3059,7 +3071,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3069,7 +3081,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3262,7 +3274,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5295,11 +5307,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6835,14 +6847,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -7106,7 +7129,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -7115,7 +7138,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7906,7 +7929,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7916,7 +7939,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1459,6 +1459,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1707,11 +1719,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -2028,7 +2040,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3097,7 +3109,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3107,7 +3119,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3300,7 +3312,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5333,11 +5345,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6873,14 +6885,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -7144,7 +7167,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -7153,7 +7176,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7944,7 +7967,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7954,7 +7977,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1194,6 +1194,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1442,11 +1454,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1763,7 +1775,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2832,7 +2844,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2842,7 +2854,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3035,7 +3047,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5068,11 +5080,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6608,14 +6620,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6879,7 +6902,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6888,7 +6911,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7679,7 +7702,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7689,7 +7712,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1477,6 +1477,18 @@ msgstr "Clustering ativado"
 msgid "Columns"
 msgstr "Colunas"
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr "Cliente de linha de comando para LXD"
@@ -1743,11 +1755,11 @@ msgstr "Criar perfis"
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 #, fuzzy
 msgid ""
 "Create instance snapshots\n"
@@ -2092,7 +2104,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3215,7 +3227,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3225,7 +3237,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3420,7 +3432,7 @@ msgstr "Versão do cliente: %s\n"
 msgid "Invalid format: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
@@ -5537,11 +5549,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 #, fuzzy
 msgid ""
 "Restore instances from snapshots\n"
@@ -7163,14 +7175,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -7462,7 +7485,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "Apagar nomes alternativos da imagem"
@@ -7473,7 +7496,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "[<remote>:]<instance> <template>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -8312,7 +8335,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -8322,7 +8345,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1477,6 +1477,18 @@ msgstr ""
 msgid "Columns"
 msgstr "Столбцы"
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1734,12 +1746,12 @@ msgstr "Копирование образа: %s"
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 #, fuzzy
 msgid "Create instance snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -2079,7 +2091,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -3197,7 +3209,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3207,7 +3219,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3407,7 +3419,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
@@ -5535,12 +5547,12 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 #, fuzzy
 msgid "Restore instances from snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -7143,14 +7155,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -7610,7 +7633,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
@@ -7627,7 +7650,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
@@ -8798,7 +8821,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -8808,7 +8831,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -1198,6 +1198,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1446,11 +1458,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1767,7 +1779,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2836,7 +2848,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2846,7 +2858,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3039,7 +3051,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5072,11 +5084,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6612,14 +6624,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6883,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6892,7 +6915,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7683,7 +7706,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7693,7 +7716,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1198,6 +1198,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1446,11 +1458,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1767,7 +1779,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2836,7 +2848,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2846,7 +2858,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3039,7 +3051,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5072,11 +5084,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6612,14 +6624,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6883,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6892,7 +6915,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7683,7 +7706,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7693,7 +7716,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1194,6 +1194,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1442,11 +1454,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1763,7 +1775,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2832,7 +2844,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2842,7 +2854,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3035,7 +3047,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5068,11 +5080,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6608,14 +6620,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6879,7 +6902,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6888,7 +6911,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7679,7 +7702,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7689,7 +7712,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -1198,6 +1198,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1446,11 +1458,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1767,7 +1779,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2836,7 +2848,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2846,7 +2858,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3039,7 +3051,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5072,11 +5084,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6612,14 +6624,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6883,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6892,7 +6915,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7683,7 +7706,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7693,7 +7716,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1358,6 +1358,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1606,11 +1618,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1927,7 +1939,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2996,7 +3008,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3006,7 +3018,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3199,7 +3211,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5232,11 +5244,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6772,14 +6784,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -7043,7 +7066,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -7052,7 +7075,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7843,7 +7866,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7853,7 +7876,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-04-29 18:14-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -1197,6 +1197,18 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
+#: lxc/restore.go:38
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume restore"
+msgstr ""
+
+#: lxc/snapshot.go:50
+msgid ""
+"Comma-separated list of names for which disks should be ignored when "
+"performing a multi-volume snapshot"
+msgstr ""
+
 #: lxc/main.go:83
 msgid "Command line client for LXD"
 msgstr ""
@@ -1445,11 +1457,11 @@ msgstr ""
 msgid "Create identity provider groups"
 msgstr ""
 
-#: lxc/snapshot.go:31
+#: lxc/snapshot.go:33
 msgid "Create instance snapshots"
 msgstr ""
 
-#: lxc/snapshot.go:32
+#: lxc/snapshot.go:34
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1766,7 +1778,7 @@ msgstr ""
 #: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:34
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2835,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:48 lxc/storage_volume.go:2457
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2845,7 +2857,7 @@ msgid ""
 "lxd init"
 msgstr ""
 
-#: lxc/snapshot.go:45
+#: lxc/snapshot.go:47
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
@@ -3038,7 +3050,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:95
+#: lxc/snapshot.go:99
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
@@ -5071,11 +5083,11 @@ msgstr ""
 msgid "Restore cluster member"
 msgstr ""
 
-#: lxc/restore.go:21
+#: lxc/restore.go:23
 msgid "Restore instances from snapshots"
 msgstr ""
 
-#: lxc/restore.go:22
+#: lxc/restore.go:24
 msgid ""
 "Restore instances from snapshots\n"
 "\n"
@@ -6611,14 +6623,25 @@ msgstr ""
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: lxc/restore.go:34
+#: lxc/restore.go:36
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: lxc/snapshot.go:44
+#: lxc/snapshot.go:46
 msgid "Whether or not to snapshot the instance's running state"
+msgstr ""
+
+#: lxc/snapshot.go:49
+msgid ""
+"Which disks should be included in the snapshot; can be \"root\" or "
+"\"volumes\""
+msgstr ""
+
+#: lxc/restore.go:37
+msgid ""
+"Which disks should be included when restoring; can be \"root\" or \"volumes\""
 msgstr ""
 
 #: lxc/rebuild.go:28
@@ -6882,7 +6905,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: lxc/restore.go:20
+#: lxc/restore.go:22
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
@@ -6891,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: lxc/snapshot.go:30
+#: lxc/snapshot.go:32
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
@@ -7682,7 +7705,7 @@ msgid ""
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: lxc/snapshot.go:37
+#: lxc/snapshot.go:39
 msgid ""
 "lxc snapshot u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -7692,7 +7715,7 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: lxc/restore.go:26
+#: lxc/restore.go:28
 msgid ""
 "lxc snapshot u1 snap0\n"
 "    Create the snapshot.\n"

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -202,6 +202,20 @@ type InstancePut struct {
 	// Example: snap0
 	Restore string `json:"restore,omitempty" yaml:"restore,omitempty"`
 
+	// Which disks should be included in the multi-volume restore.
+	// Can be "root" or empty (for just the instance root volume),
+	// "volumes" (for all disks sourced by volumes; fails if an attached volumes snapshot was deleted or if a volume is being shared).
+	// Example: "volumes"
+	//
+	// API extension: instance_snapshot_multi_volume
+	DisksMode string `json:"disks,omitempty" yaml:"disks,omitempty"`
+
+	// Disks whose volumes should not be included in a multi-volume restore.
+	// Example: ["disk1","disk2"]
+	//
+	// API extension: instance_snapshot_multi_volume
+	ExcludeDisks []string `json:"exclude_disks,omitempty" yaml:"exclude_disks,omitempty"`
+
 	// Whether the instance currently has saved state on disk
 	// Example: false
 	Stateful bool `json:"stateful" yaml:"stateful"`

--- a/shared/api/instance_snapshot.go
+++ b/shared/api/instance_snapshot.go
@@ -18,6 +18,20 @@ type InstanceSnapshotsPost struct {
 	// Example: false
 	Stateful bool `json:"stateful" yaml:"stateful"`
 
+	// Which disks should be included in the multi-volume snapshot.
+	// Can be "root" or empty (for just the instance root volume), and
+	// "volumes" (for all disks sourced by volumes; fails if an attached volume is being shared).
+	// Example: "volumes"
+	//
+	// API extension: instance_snapshot_multi_volume
+	DisksMode string `json:"disks,omitempty" yaml:"disks,omitempty"`
+
+	// Disks sourced by volumes that should not be included in a multi-volume snapshot.
+	// Example: ["disk1","disk2"]
+	//
+	// API extension: instance_snapshot_multi_volume
+	ExcludeDisks []string `json:"exclude_disks,omitempty" yaml:"exclude_disks,omitempty"`
+
 	// When the snapshot expires (gets auto-deleted)
 	// Example: 2021-03-23T17:38:37.753398689-04:00
 	//

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -450,6 +450,7 @@ var APIExtensions = []string{
 	"network_acls_all_projects",
 	"networks_all_projects",
 	"clustering_restore_skip_mode",
+	"instance_snapshots_multi_volume",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/main.sh
+++ b/test/main.sh
@@ -371,6 +371,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_snap_schedule "snapshot scheduling"
     run_test test_snap_volume_db_recovery "snapshot volume database record recovery"
     run_test test_snap_fail "snapshot creation failure"
+    run_test test_multi_volume_snap "multi volume snapshots"
     run_test test_config_profiles "profiles and configuration"
     run_test test_config_edit "container configuration edit"
     run_test test_property "container property"


### PR DESCRIPTION
This adds support for snapshotting an instance and its attached volumes while mantaining crash consistency across all relevant volumes.

This follows Phase 1 of the to be published specification: Sync instance and attached volume snapshots. 

Including shared volumes on a multi volume snapshot or restore is not allowed.