### PR TITLE
Device: Fix disk attachment of ceph instance volumes in default project

### DIFF
--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -25,6 +25,32 @@ type RunConfigItem struct {
 // - A Ceph RBD Image description.
 type DevSource any
 
+// DevSourcePath is a path on the LXD host.
+// See `deviceConfig.DevSource`.
+type DevSourcePath struct {
+	Path string
+}
+
+// DevSourceFD is a file descriptor held by the LXD process.
+// See `deviceConfig.DevSource`.
+type DevSourceFD struct {
+	FD   uintptr
+	Path string
+}
+
+// DevSourceRBD describes an RBD image.
+// See `deviceConfig.DevSource`.
+//
+// This structure roughly corresponds to a qmp BlockdevOptionsRbd:
+// https://www.qemu.org/docs/master/interop/qemu-storage-daemon-qmp-ref.html#qapidoc-708
+type DevSourceRBD struct {
+	ClusterName string
+	UserName    string
+	PoolName    string
+	ImageName   string
+	Snapshot    string
+}
+
 // MountEntryItem represents a single mount entry item.
 type MountEntryItem struct {
 	DevName    string      // The internal name for the device.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -24,32 +24,6 @@ import (
 	"github.com/canonical/lxd/shared/version"
 )
 
-// DevSourcePath is a path on the LXD host.
-// See `deviceConfig.DevSource`.
-type DevSourcePath struct {
-	Path string
-}
-
-// DevSourceFD is a file descriptor held by the LXD process.
-// See `deviceConfig.DevSource`.
-type DevSourceFD struct {
-	FD   uintptr
-	Path string
-}
-
-// DevSourceRBD describes an RBD image.
-// See `deviceConfig.DevSource`.
-//
-// This structure roughly corresponds to a qmp BlockdevOptionsRbd:
-// https://www.qemu.org/docs/master/interop/qemu-storage-daemon-qmp-ref.html#qapidoc-708
-type DevSourceRBD struct {
-	ClusterName string
-	UserName    string
-	PoolName    string
-	ImageName   string
-	Snapshot    string
-}
-
 // BlockFsDetect detects the type of block device.
 func BlockFsDetect(dev string) (string, error) {
 	out, err := shared.RunCommandContext(context.TODO(), "blkid", "-s", "TYPE", "-o", "value", dev)

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -30,11 +30,12 @@ func unixDeviceAttributes(path string) (dType string, major uint32, minor uint32
 	}
 
 	// Check what kind of file it is
-	if stat.Mode&unix.S_IFMT == unix.S_IFBLK {
+	switch stat.Mode & unix.S_IFMT {
+	case unix.S_IFBLK:
 		dType = "b"
-	} else if stat.Mode&unix.S_IFMT == unix.S_IFCHR {
+	case unix.S_IFCHR:
 		dType = "c"
-	} else {
+	default:
 		return "", 0, 0, fmt.Errorf("Not a device")
 	}
 

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -338,7 +338,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 
 	// Instruct LXD to perform the mount.
 	runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-		DevSource:  DevSourcePath{Path: d.HostPath},
+		DevSource:  deviceConfig.DevSourcePath{Path: d.HostPath},
 		TargetPath: d.RelativePath,
 		FSType:     "none",
 		Opts:       []string{"bind", "create=file"},

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -2637,7 +2637,7 @@ func (d *disk) generateVMConfigDrive() (string, error) {
 	// Single quotes included in the value itself are escaped by being replaced with `''`.
 	for key, value := range instanceConfig {
 		if strings.HasPrefix(key, "user.") && !shared.ValueInSlice(key, excludedKeys) {
-			metaDataBuilder.WriteString(key + ": '" + strings.Replace(value, "'", "''", -1) + "'\n")
+			metaDataBuilder.WriteString(key + ": '" + strings.ReplaceAll(value, "'", "''") + "'\n")
 		}
 	}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1198,9 +1198,14 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 
 					contentType := storagePools.VolumeDBContentTypeToContentType(dbContentType)
 
-					projectStorageVolumeName := project.StorageVolume(d.inst.Project().Name, volumeName)
+					var volStorageName string
+					if dbVolume.Type == cluster.StoragePoolVolumeTypeNameCustom {
+						volStorageName = project.StorageVolume(storageProjectName, volumeName)
+					} else {
+						volStorageName = project.Instance(storageProjectName, volumeName)
+					}
 
-					vol := d.pool.GetVolume(volumeType, contentType, projectStorageVolumeName, dbVolume.Config)
+					vol := d.pool.GetVolume(volumeType, contentType, volStorageName, dbVolume.Config)
 					rbdImageName, snapName := storageDrivers.CephGetRBDImageName(vol, false)
 
 					mount := deviceConfig.MountEntryItem{

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1955,7 +1955,7 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 		return err
 	}
 
-	poolVolumePut := dbVolume.StorageVolume.Writable()
+	poolVolumePut := dbVolume.Writable()
 
 	// Check if unmapped.
 	if shared.IsTrue(poolVolumePut.Config["security.unmapped"]) {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -465,7 +465,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	// Check ceph options are only used when ceph or cephfs type source is specified.
-	if !(d.sourceIsCeph() || d.sourceIsCephFs()) && (d.config["ceph.cluster_name"] != "" || d.config["ceph.user_name"] != "") {
+	if !d.sourceIsCeph() && !d.sourceIsCephFs() && (d.config["ceph.cluster_name"] != "" || d.config["ceph.user_name"] != "") {
 		return fmt.Errorf("Invalid options ceph.cluster_name/ceph.user_name for source %q", d.config["source"])
 	}
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -281,7 +281,7 @@ func (d *gpuPhysical) startCDIDevices(configDevices cdi.ConfigDevices, runConf *
 
 		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
 			DevName:    deviceName,
-			DevSource:  DevSourcePath{Path: devPath},
+			DevSource:  deviceConfig.DevSourcePath{Path: devPath},
 			TargetPath: relativeDestPath,
 			FSType:     "none",
 			Opts:       options,

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1454,7 +1454,7 @@ func (d *lxc) deviceStaticShiftMounts(mounts []deviceConfig.MountEntryItem) erro
 	// device files before they are mounted.
 	if idmapSet != nil && !d.state.OS.RunningInUserNS {
 		for _, mount := range mounts {
-			pathSource, isPath := mount.DevSource.(device.DevSourcePath)
+			pathSource, isPath := mount.DevSource.(deviceConfig.DevSourcePath)
 			if mount.DevSource != nil && !isPath {
 				return fmt.Errorf("Device source for device %q was not a host path (was %T)", mount.DevName, mount.DevSource)
 			}
@@ -1661,7 +1661,7 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 	defer reverter.Fail()
 
 	for _, mount := range mounts {
-		pathSource, isPath := mount.DevSource.(device.DevSourcePath)
+		pathSource, isPath := mount.DevSource.(deviceConfig.DevSourcePath)
 		if mount.DevSource != nil && !isPath {
 			return fmt.Errorf("Device source for device %q was not a host path (was %T)", mount.DevName, mount.DevSource)
 		}
@@ -2136,7 +2136,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		// Pass any mounts into LXC.
 		if len(runConf.Mounts) > 0 {
 			for _, mount := range runConf.Mounts {
-				pathSource, isPath := mount.DevSource.(device.DevSourcePath)
+				pathSource, isPath := mount.DevSource.(deviceConfig.DevSourcePath)
 				if mount.DevSource != nil && !isPath {
 					return "", nil, fmt.Errorf("Device source for device %q was not a host path (was %T)", mount.DevName, mount.DevSource)
 				}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3730,14 +3730,20 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]any, mountInfo *storagePool
 		return nil, fmt.Errorf("Non-root drive config supplied")
 	}
 
-	if !d.storagePool.Driver().Info().Remote && mountInfo.DiskPath == "" {
+	devSource, isPath := mountInfo.DevSource.(deviceConfig.DevSourcePath)
+
+	if !isPath {
+		return nil, fmt.Errorf("Unhandled DevSource type %T", mountInfo.DevSource)
+	}
+
+	if !d.storagePool.Driver().Info().Remote && devSource.Path == "" {
 		return nil, fmt.Errorf("No root disk path available from mount")
 	}
 
 	// Generate a new device config with the root device path expanded.
 	driveConf := deviceConfig.MountEntryItem{
 		DevName:    rootDriveConf.DevName,
-		DevSource:  deviceConfig.DevSourcePath{Path: mountInfo.DiskPath},
+		DevSource:  mountInfo.DevSource,
 		Opts:       rootDriveConf.Opts,
 		TargetPath: rootDriveConf.TargetPath,
 		Limits:     rootDriveConf.Limits,
@@ -6443,7 +6449,13 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 
 	defer func() { _ = os.RemoveAll(tmpPath) }()
 
-	if mountInfo.DiskPath == "" {
+	devSource, isPath := mountInfo.DevSource.(deviceConfig.DevSourcePath)
+
+	if !isPath {
+		return meta, fmt.Errorf("Unhandled DevSource type %T", mountInfo.DevSource)
+	}
+
+	if devSource.Path == "" {
 		return meta, fmt.Errorf("No disk path available from mount")
 	}
 
@@ -6459,7 +6471,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 	defer revert.Fail()
 
 	// Check for Direct I/O support.
-	from, err := os.OpenFile(mountInfo.DiskPath, unix.O_DIRECT|unix.O_RDONLY, 0)
+	from, err := os.OpenFile(devSource.Path, unix.O_DIRECT|unix.O_RDONLY, 0)
 	if err == nil {
 		cmd = append(cmd, "-T", "none")
 		_ = from.Close()
@@ -6473,9 +6485,9 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 
 	revert.Add(func() { _ = os.Remove(fPath) })
 
-	cmd = append(cmd, mountInfo.DiskPath, fPath)
+	cmd = append(cmd, devSource.Path, fPath)
 
-	_, err = apparmor.QemuImg(d.state.OS, cmd, mountInfo.DiskPath, fPath, tracker)
+	_, err = apparmor.QemuImg(d.state.OS, cmd, devSource.Path, fPath, tracker)
 	if err != nil {
 		return meta, fmt.Errorf("Failed converting instance to qcow2: %w", err)
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3737,7 +3737,7 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]any, mountInfo *storagePool
 	// Generate a new device config with the root device path expanded.
 	driveConf := deviceConfig.MountEntryItem{
 		DevName:    rootDriveConf.DevName,
-		DevSource:  device.DevSourcePath{Path: mountInfo.DiskPath},
+		DevSource:  deviceConfig.DevSourcePath{Path: mountInfo.DiskPath},
 		Opts:       rootDriveConf.Opts,
 		TargetPath: rootDriveConf.TargetPath,
 		Limits:     rootDriveConf.Limits,
@@ -3761,7 +3761,7 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]any, mountInfo *storagePool
 
 			rbdImageName, snapName := storageDrivers.CephGetRBDImageName(vol, false)
 
-			driveConf.DevSource = device.DevSourceRBD{
+			driveConf.DevSource = deviceConfig.DevSourceRBD{
 				ClusterName: clusterName,
 				UserName:    userName,
 				PoolName:    config["ceph.osd.pool_name"],
@@ -3842,7 +3842,7 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 	// Add 9p share config.
 	devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
 
-	fdSource, ok := driveConf.DevSource.(device.DevSourceFD)
+	fdSource, ok := driveConf.DevSource.(deviceConfig.DevSourceFD)
 	if !ok {
 		return fmt.Errorf("Drive config for %q was not a file descriptor", driveConf.DevName)
 	}
@@ -3872,9 +3872,9 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 	aioMode := "native" // Use native kernel async IO and O_DIRECT by default.
 	cacheMode := "none" // Bypass host cache, use O_DIRECT semantics by default.
 	media := "disk"
-	rbdSource, isRBDImage := driveConf.DevSource.(device.DevSourceRBD)
-	fdSource, isFd := driveConf.DevSource.(device.DevSourceFD)
-	pathSource, _ := driveConf.DevSource.(device.DevSourcePath)
+	rbdSource, isRBDImage := driveConf.DevSource.(deviceConfig.DevSourceRBD)
+	fdSource, isFd := driveConf.DevSource.(deviceConfig.DevSourceFD)
+	pathSource, _ := driveConf.DevSource.(deviceConfig.DevSourcePath)
 
 	// Check supported features.
 	// Use io_uring over native for added performance (if supported by QEMU and kernel is recent enough).

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/canonical/lxd/lxd/cluster/request"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/instancewriter"
@@ -3444,8 +3445,12 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 		return nil, fmt.Errorf("Failed getting disk path: %w", err)
 	}
 
-	mountInfo := &MountInfo{
-		DiskPath: diskPath,
+	var mountInfo MountInfo
+
+	if diskPath != "" {
+		mountInfo.DevSource = config.DevSourcePath{
+			Path: diskPath,
+		}
 	}
 
 	revert.Success() // From here on it is up to caller to call UnmountInstance() when done.
@@ -3464,7 +3469,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 		})
 	}
 
-	return mountInfo, nil
+	return &mountInfo, nil
 }
 
 // UnmountInstance unmounts the instance's root volume.
@@ -3991,11 +3996,15 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 		return nil, fmt.Errorf("Failed getting disk path: %w", err)
 	}
 
-	mountInfo := &MountInfo{
-		DiskPath: diskPath,
+	var mountInfo MountInfo
+
+	if diskPath != "" {
+		mountInfo.DevSource = config.DevSourcePath{
+			Path: diskPath,
+		}
 	}
 
-	return mountInfo, nil
+	return &mountInfo, nil
 }
 
 // UnmountInstanceSnapshot unmounts an instance snapshot.

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	backupConfig "github.com/canonical/lxd/lxd/backup/config"
 	"github.com/canonical/lxd/lxd/cluster/request"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
@@ -26,7 +27,7 @@ type VolumeUsage struct {
 
 // MountInfo represents info about the result of a mount operation.
 type MountInfo struct {
-	DiskPath  string                               // The location of the block disk (if supported).
+	DevSource deviceConfig.DevSource               // The location of the block disk (if supported).
 	PostHooks []func(inst instance.Instance) error // Hooks to be called following a mount.
 }
 


### PR DESCRIPTION
The startVM function was always using the project.StorageVolume() function to derive the underlying ceph rbd image name. This is incorrect when the volume being attached is from an instance in the default project because the `default_` prefix is only added for custom volumes, not instance volumes.

Additionally this function was also using the instance or volume's project name directly rather than using the existing `storageProjectName := project.StorageVolumeProjectFromRecord()` variable. This is a problem because for custom volumes it wasn't taking into account the value of `features.storage.volumes` set on the project (indicating the effective project for a custom volume).

So instead I switched to using the same invocation pattern we already have from disk.mountPoolVolume() function.

Also starts the process of pushing the generation of DevSource type values down into the storage subsystem.