### PR TITLE
Device: Include src path in MountInfo returned from mountPoolVolume() in `disk` device

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1215,21 +1215,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					vol := d.pool.GetVolume(volumeType, contentType, volStorageName, dbVolume.Config)
 					rbdImageName, snapName := storageDrivers.CephGetRBDImageName(vol, false)
 
-					mount := deviceConfig.MountEntryItem{
-						DevSource: deviceConfig.DevSourceRBD{
-							ClusterName: clusterName,
-							UserName:    userName,
-							PoolName:    poolName,
-							ImageName:   rbdImageName,
-							Snapshot:    snapName,
-						},
-						DevName: d.name,
-						Opts:    opts,
-						Limits:  diskLimits,
-					}
-
-					if dbContentType == cluster.StoragePoolVolumeContentTypeISO {
-						mount.FSType = "iso9660"
+					mount.DevSource = deviceConfig.DevSourceRBD{
+						ClusterName: clusterName,
+						UserName:    userName,
+						PoolName:    poolName,
+						ImageName:   rbdImageName,
+						Snapshot:    snapName,
 					}
 
 					runConf.Mounts = []deviceConfig.MountEntryItem{mount}


### PR DESCRIPTION
Part of the journey to push DeviceSource concept down into the storage subsystem.

Follows https://github.com/canonical/lxd/pull/15350