### PR TITLE
github: set artifact retention days

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}
+          retention-days: 1
         if: github.event_name == 'pull_request'
 
       - name: Install Go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,6 +199,7 @@ jobs:
         with:
           name: coverage-unit
           path: ${{env.GOCOVERDIR}}
+          retention-days: 1
         if: env.GOCOVERDIR != ''
 
       - name: Download minio/mc to add to system test dependencies
@@ -316,6 +317,7 @@ jobs:
         with:
           name: coverage-${{ matrix.suite }}-${{ matrix.backend }}
           path: ${{env.GOCOVERDIR}}
+          retention-days: 1
         if: env.GOCOVERDIR != ''
 
   tics:
@@ -483,6 +485,7 @@ jobs:
         with:
           name: coverage-clients-${{ runner.os }}
           path: ${{env.GOCOVERDIR}}
+          retention-days: 1
         if: env.GOCOVERDIR != ''
 
       - name: Upload lxc client artifacts
@@ -645,6 +648,7 @@ jobs:
         with:
           name: coverage-ui-e2e-tests
           path: ${{env.GOCOVERDIR}}
+          retention-days: 1
         if: env.GOCOVERDIR != ''
 
   documentation:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -698,6 +698,7 @@ jobs:
         with:
           name: documentation
           path: doc/_build
+          retention-days: 5
 
   documentation-linkcheck:
     name: Documentation link check


### PR DESCRIPTION
With this change, most use of `actions/upload-artifacts` have a `retention-days` specified to avoid the implied default of 90 days. 

The only exception are per-OS `lxd-clients` artifacts as those are only uploaded on `push` events and can be useful for those wanting binaries like `lxd-benchmark` and `lxd-migrate`.