### PR TITLE
storage: Instance and custom volume snapshot consistency

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6542,6 +6542,18 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 		return fmt.Errorf("Volume of content type %q does not support snapshots", contentType)
 	}
 
+	mountPath := drivers.GetVolumeMountPath(parentVol.Pool, drivers.VolumeType(parentVol.Type), project.StorageVolume(projectName, volName))
+
+	// If the volume is a filesystem and is mounted, attempt to sync the filesystem before taking the snapshot.
+	// If RunningCopyFreeze is false for the driver in use, it means the driver syncs the volume on snapshot,
+	// so we don't have to do it here.
+	if parentVol.ContentType == cluster.StoragePoolVolumeContentTypeNameFS && b.driver.Info().RunningCopyFreeze && filesystem.IsMountPoint(mountPath) {
+		err = filesystem.SyncFS(mountPath)
+		if err != nil {
+			l.Warn("Failed to flush writes to custom volume", logger.Ctx{"err": err})
+		}
+	}
+
 	parentUUID := parentVol.Config["volatile.uuid"]
 	if parentUUID == "" {
 		return fmt.Errorf(`Volume %q is missing the required "volatile.uuid" setting`, parentVol.Name)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1105,7 +1105,10 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		defer func() { _ = src.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		_ = filesystem.SyncFS(src.RootfsPath())
+		err = filesystem.SyncFS(src.RootfsPath())
+		if err != nil {
+			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
+		}
 	}
 
 	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
@@ -1666,7 +1669,10 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		defer func() { _ = src.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		_ = filesystem.SyncFS(src.RootfsPath())
+		err = filesystem.SyncFS(src.RootfsPath())
+		if err != nil {
+			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
+		}
 	}
 
 	if b.Name() == srcPool.Name() {
@@ -3108,7 +3114,10 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 		defer func() { _ = inst.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		_ = filesystem.SyncFS(inst.RootfsPath())
+		err = filesystem.SyncFS(inst.RootfsPath())
+		if err != nil {
+			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
+		}
 	}
 
 	// Set the parent volume UUID.
@@ -3607,7 +3616,10 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 		defer func() { _ = src.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		_ = filesystem.SyncFS(src.RootfsPath())
+		err = filesystem.SyncFS(src.RootfsPath())
+		if err != nil {
+			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
+		}
 	}
 
 	// Lock this operation to ensure that the only one snapshot is made at the time.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1105,7 +1105,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		defer func() { _ = src.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		err = filesystem.SyncFS(src.RootfsPath())
+		err = filesystem.SyncFS(src.Path())
 		if err != nil {
 			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
 		}
@@ -1669,7 +1669,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		defer func() { _ = src.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		err = filesystem.SyncFS(src.RootfsPath())
+		err = filesystem.SyncFS(src.Path())
 		if err != nil {
 			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
 		}
@@ -3114,7 +3114,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 		defer func() { _ = inst.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		err = filesystem.SyncFS(inst.RootfsPath())
+		err = filesystem.SyncFS(inst.Path())
 		if err != nil {
 			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
 		}
@@ -3616,7 +3616,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 		defer func() { _ = src.Unfreeze() }()
 
 		// Attempt to sync the filesystem.
-		err = filesystem.SyncFS(src.RootfsPath())
+		err = filesystem.SyncFS(src.Path())
 		if err != nil {
 			l.Warn("Failed to flush writes to instance volume", logger.Ctx{"err": err})
 		}


### PR DESCRIPTION
This implements `SyncFS` when snapshotting custom volumes, similarly to what we already do with instance volumes.

This also includes a warning it fit fails for either instance or custom volumes. In a different manner as `fsfreeze`, we do not expect `sync` to fail even if the filesystem is busy.

I was at odds on whether I should gate SyncFS on `RunningCopyFreeze` as even after some digging on the PRs that populated this field on each of the drivers, it was unclear on what specifically determined the value of  `RunningCopyFreeze` for each driver.

After some more research on each driver's inner workings, I got to the conclusion that `RunningCopyFreeze=false` indeed means the driver syncs the volume on snapshot (as snapshots generally follow a similar mechanism to the one used for copy).

As reference, I found useful sources for [btrfs](https://btrfs.readthedocs.io/en/latest/btrfs-subvolume.html#performance) and [cephfs](https://docs.ceph.com/en/quincy/dev/cephfs-snapshots/), both of which have `RunningCopyFreeze=false`. Unfortunately I found nothing for `zfs`, that also falls within this same category