### PR TITLE
doc: clarify wording about volatile key manipulation

### DIFF
--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -371,19 +371,14 @@ The following instance options control the creation and expiry of {ref}`instance
 (instance-options-volatile)=
 ## Volatile internal data
 
-The following volatile keys are currently used internally by LXD to store internal data specific to an instance:
-
-```{important}
-Setting these `volatile.*` keys might break LXD in non-obvious ways.
-Therefore, you should avoid setting any of these keys.
+```{warning}
+The `volatile.*` keys cannot be manipulated by the user. Do not attempt to modify these keys in any way. LXD modifies these keys, and attempting to manipulate them yourself might break LXD in non-obvious ways.
 ```
+
+The following volatile keys are currently used internally by LXD to store internal data specific to an instance:
 
 % Include content from [../metadata.txt](../metadata.txt)
 ```{include} ../metadata.txt
     :start-after: <!-- config group instance-volatile start -->
     :end-before: <!-- config group instance-volatile end -->
-```
-
-```{note}
-Volatile keys cannot be set by the user.
 ```


### PR DESCRIPTION
This PR addresses an issue raised by FE (@wideawakening)  regarding confusing wording about volatile keys (not only about setting but any kind of manipulation, which includes removing), and combines two annotations (info and note) into a single warning annotation. 