### PR TITLE
Storage: Fix missing mount reference counting when attaching ceph VM root volume to another VM

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1203,21 +1203,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					vol := d.pool.GetVolume(volumeType, contentType, volStorageName, dbVolume.Config)
 					rbdImageName, snapName := storageDrivers.CephGetRBDImageName(vol, false)
 
-					mount := deviceConfig.MountEntryItem{
-						DevSource: deviceConfig.DevSourceRBD{
-							ClusterName: clusterName,
-							UserName:    userName,
-							PoolName:    poolName,
-							ImageName:   rbdImageName,
-							Snapshot:    snapName,
-						},
-						DevName: d.name,
-						Opts:    opts,
-						Limits:  diskLimits,
-					}
-
-					if dbContentType == cluster.StoragePoolVolumeContentTypeISO {
-						mount.FSType = "iso9660"
+					mount.DevSource = deviceConfig.DevSourceRBD{
+						ClusterName: clusterName,
+						UserName:    userName,
+						PoolName:    poolName,
+						ImageName:   rbdImageName,
+						Snapshot:    snapName,
 					}
 
 					runConf.Mounts = []deviceConfig.MountEntryItem{mount}


### PR DESCRIPTION
This fixes an issue where detaching a running VM's (v1) root volume (using ceph) from another running VM (v2) (only allowed when `security.shared=true`) was incorrectly triggering an unmount of the attached VM's root volume from the running VM (v1) due to the mount reference counters not being correctly maintained when attaching/detaching v1's root volume from v2.

Reproducer:

```
lxc launch ubuntu:24.04 v1 --vm -s ceph
lxc launch ubuntu:24.04 v2 --vm -s dir

lxc storage volume set ceph virtual-machine/v1 security.shared=true
lxc config device add v2 v1-root disk source=v1 pool=ceph source.type=virtual-machine

# This would trigger an incorrect unmount of running v1's root volumes and fail due to them being in use.
lxc config device remove v2 v1-root 
```