### PR TITLE
Refactor storage pool and bucket client methods

### DIFF
--- a/client/lxd_storage_buckets.go
+++ b/client/lxd_storage_buckets.go
@@ -1,6 +1,8 @@
 package lxd
 
 import (
+	"net/http"
+
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -14,7 +16,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketNames(poolName string) ([]string, erro
 	// Fetch the raw URL values.
 	urls := []string{}
 	u := api.NewURL().Path("storage-pools", poolName, "buckets")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +36,7 @@ func (r *ProtocolLXD) GetStoragePoolBuckets(poolName string) ([]api.StorageBucke
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets").WithQuery("recursion", "1")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &buckets)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &buckets)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +55,7 @@ func (r *ProtocolLXD) GetStoragePoolBucket(poolName string, bucketName string) (
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName)
-	etag, err := r.queryStruct("GET", u.String(), nil, "", &bucket)
+	etag, err := r.queryStruct(http.MethodGet, u.String(), nil, "", &bucket)
 	if err != nil {
 		return nil, "", err
 	}
@@ -75,7 +77,7 @@ func (r *ProtocolLXD) CreateStoragePoolBucket(poolName string, bucket api.Storag
 	// Send the request and get the resulting key info (including generated keys).
 	if r.CheckExtension("storage_buckets_create_credentials") == nil {
 		var newKey api.StorageBucketKey
-		_, err = r.queryStruct("POST", u.String(), bucket, "", &newKey)
+		_, err = r.queryStruct(http.MethodPost, u.String(), bucket, "", &newKey)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +85,7 @@ func (r *ProtocolLXD) CreateStoragePoolBucket(poolName string, bucket api.Storag
 		return &newKey, nil
 	}
 
-	_, _, err = r.query("POST", u.String(), bucket, "")
+	_, _, err = r.query(http.MethodPost, u.String(), bucket, "")
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +102,7 @@ func (r *ProtocolLXD) UpdateStoragePoolBucket(poolName string, bucketName string
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName)
-	_, _, err = r.query("PUT", u.String(), bucket, ETag)
+	_, _, err = r.query(http.MethodPut, u.String(), bucket, ETag)
 	if err != nil {
 		return err
 	}
@@ -117,7 +119,7 @@ func (r *ProtocolLXD) DeleteStoragePoolBucket(poolName string, bucketName string
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName)
-	_, _, err = r.query("DELETE", u.String(), nil, "")
+	_, _, err = r.query(http.MethodDelete, u.String(), nil, "")
 	if err != nil {
 		return err
 	}
@@ -135,7 +137,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketKeyNames(poolName string, bucketName s
 	// Fetch the raw URL values.
 	urls := []string{}
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +157,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketKeys(poolName string, bucketName strin
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys").WithQuery("recursion", "1")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &bucketKeys)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &bucketKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +176,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketKey(poolName string, bucketName string
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys", keyName)
-	etag, err := r.queryStruct("GET", u.String(), nil, "", &bucketKey)
+	etag, err := r.queryStruct(http.MethodGet, u.String(), nil, "", &bucketKey)
 	if err != nil {
 		return nil, "", err
 	}
@@ -192,7 +194,7 @@ func (r *ProtocolLXD) CreateStoragePoolBucketKey(poolName string, bucketName str
 	// Send the request and get the resulting key info (including generated keys).
 	var newKey api.StorageBucketKey
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys")
-	_, err = r.queryStruct("POST", u.String(), key, "", &newKey)
+	_, err = r.queryStruct(http.MethodPost, u.String(), key, "", &newKey)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +211,7 @@ func (r *ProtocolLXD) UpdateStoragePoolBucketKey(poolName string, bucketName str
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys", keyName)
-	_, _, err = r.query("PUT", u.String(), key, ETag)
+	_, _, err = r.query(http.MethodPut, u.String(), key, ETag)
 	if err != nil {
 		return err
 	}
@@ -226,7 +228,7 @@ func (r *ProtocolLXD) DeleteStoragePoolBucketKey(poolName string, bucketName str
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys", keyName)
-	_, _, err = r.query("DELETE", u.String(), nil, "")
+	_, _, err = r.query(http.MethodDelete, u.String(), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_storage_pools.go
+++ b/client/lxd_storage_pools.go
@@ -1,8 +1,7 @@
 package lxd
 
 import (
-	"fmt"
-	"net/url"
+	"net/http"
 
 	"github.com/canonical/lxd/shared/api"
 )
@@ -18,8 +17,9 @@ func (r *ProtocolLXD) GetStoragePoolNames() ([]string, error) {
 
 	// Fetch the raw URL values.
 	urls := []string{}
-	baseURL := "/storage-pools"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	u := api.NewURL().Path("storage-pools")
+	baseURL := u.String()
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,8 @@ func (r *ProtocolLXD) GetStoragePools() ([]api.StoragePool, error) {
 	pools := []api.StoragePool{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/storage-pools?recursion=1", nil, "", &pools)
+	u := api.NewURL().Path("storage-pools").WithQuery("recursion", "1")
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &pools)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,8 @@ func (r *ProtocolLXD) GetStoragePool(name string) (*api.StoragePool, string, err
 	pool := api.StoragePool{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "", &pool)
+	u := api.NewURL().Path("storage-pools", name)
+	etag, err := r.queryStruct(http.MethodGet, u.String(), nil, "", &pool)
 	if err != nil {
 		return nil, "", err
 	}
@@ -79,7 +81,8 @@ func (r *ProtocolLXD) CreateStoragePool(pool api.StoragePoolsPost) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("POST", "/storage-pools", pool, "")
+	u := api.NewURL().Path("storage-pools")
+	_, _, err = r.query(http.MethodPost, u.String(), pool, "")
 	if err != nil {
 		return err
 	}
@@ -95,7 +98,8 @@ func (r *ProtocolLXD) UpdateStoragePool(name string, pool api.StoragePoolPut, ET
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), pool, ETag)
+	u := api.NewURL().Path("storage-pools", name)
+	_, _, err = r.query(http.MethodPut, u.String(), pool, ETag)
 	if err != nil {
 		return err
 	}
@@ -111,7 +115,8 @@ func (r *ProtocolLXD) DeleteStoragePool(name string) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "")
+	u := api.NewURL().Path("storage-pools", name)
+	_, _, err = r.query(http.MethodDelete, u.String(), nil, "")
 	if err != nil {
 		return err
 	}
@@ -129,7 +134,8 @@ func (r *ProtocolLXD) GetStoragePoolResources(name string) (*api.ResourcesStorag
 	res := api.ResourcesStoragePool{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/resources", url.PathEscape(name)), nil, "", &res)
+	u := api.NewURL().Path("storage-pools", name, "resources")
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &res)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates storage pool and bucket client methods to construct URLs using `api.NewURL()` and replaces HTTP method literals with constants from `http` package.