### PR TITLE
Instance: Run CPU scheduler after DB changes made (from Incus)

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2534,14 +2534,14 @@ func (d *lxc) onStart(_ map[string]string) error {
 		return err
 	}
 
-	// Trigger a rebalance
-	cgroup.TaskSchedulerTrigger(d.dbType, d.name, "started")
-
 	// Record last start state.
 	err = d.recordLastState()
 	if err != nil {
 		return err
 	}
+
+	// Trigger a scheduler rebalance after DB changes made.
+	cgroup.TaskSchedulerTrigger(d.dbType, d.name, "started")
 
 	return nil
 }
@@ -3104,9 +3104,6 @@ func (d *lxc) onStop(args map[string]string) error {
 			return
 		}
 
-		// Trigger a rebalance
-		cgroup.TaskSchedulerTrigger(d.dbType, d.name, "stopped")
-
 		// Destroy ephemeral containers
 		if d.ephemeral {
 			err = d.delete(true)
@@ -3115,6 +3112,9 @@ func (d *lxc) onStop(args map[string]string) error {
 				return
 			}
 		}
+
+		// Trigger a scheduler rebalance after DB changes made.
+		cgroup.TaskSchedulerTrigger(d.dbType, d.name, "stopped")
 	}(d, target, op)
 
 	return nil
@@ -4927,7 +4927,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	undoChanges = false
 
 	if cpuLimitWasChanged {
-		// Trigger a scheduler re-run
+		// Trigger a scheduler rebalance after DB changes made.
 		cgroup.TaskSchedulerTrigger(d.dbType, d.name, "changed")
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4979,7 +4979,7 @@ func (d *qemu) Stop(stateful bool) error {
 		return err
 	}
 
-	// Trigger a rebalance
+	// Trigger a scheduler rebalance after DB changes made.
 	cgroup.TaskSchedulerTrigger(d.dbType, d.name, "stopped")
 
 	return nil
@@ -5905,7 +5905,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	revert.Success()
 
 	if cpuLimitWasChanged {
-		// Trigger a scheduler re-run
+		// Trigger a scheduler rebalance after DB changes made.
 		cgroup.TaskSchedulerTrigger(d.dbType, d.name, "changed")
 	}
 


### PR DESCRIPTION
This isn't a cherry-pick, but rather inspiration from a change in Incus.
At this point LXD's code base has diverged somewhat from Incus and the exact same bug was not present, however I have taken the point and run with it by making the scheduler re-run occur after 2 other places that might impact the scheduler.

Inspired by https://github.com/lxc/incus/pull/1938