### PR TITLE
doc: use external file to store redirects

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -5,6 +5,7 @@ import subprocess
 import yaml
 from git import Repo
 import filecmp
+from redirects import redirects
 
 # Custom configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.
@@ -142,12 +143,8 @@ slug = "lxd"
 # (see https://docs.readthedocs.io/en/stable/guides/redirects.html).
 # NOTE: If this variable is not defined, set to None, or the dictionary is empty,
 # the sphinx_reredirects extension will be disabled.
-redirects = {
-    'howto/instances_snapshots/index': '../instances_backup/',
-    'reference/network_external/index': '../networks/',
-    'explanation/containers_and_vms/index': '../instances/',
-    'explanation/clustering/index': '../clusters/'
-}
+# redirects = {}
+# minae: Redirects is imported from redirects.py
 
 ############################################################
 ### Link checker

--- a/doc/redirects.py
+++ b/doc/redirects.py
@@ -1,0 +1,6 @@
+redirects = {
+    'howto/instances_snapshots/index': '../instances_backup/',
+    'reference/network_external/index': '../networks/',
+    'explanation/containers_and_vms/index': '../instances/',
+    'explanation/clustering/index': '../clusters/',
+}


### PR DESCRIPTION
Currently there are ~40+ files in the `doc/` directory that should be inside one of the category directories (`doc/howto`, etc). When those files are moved, their URLs will change, so we will need to redirect them to preserve links from external sources.

Redirects are handled by Sphinx using a `redirects` dict currently defined in `custom_conf.py`. Adding ~40+ new redirects to this dict would clutter `custom_conf.py`. This PR prepares for the move by extracting that dict to a new `redirects.py`, which is then imported by `custom_conf.py`.