### PR TITLE
VM: Restore qemu guest /dev/disk/by-id naming stability (stable-5.21)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4090,6 +4090,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 
 	// Trim the serial down to 36 characters if longer than that, since this is the max size of a serial in QEMU.
 	// Do not hash as to not break older guests that were relying on QEMU to reduce the size of the device serial.
+	// Related to https://gitlab.com/qemu-project/qemu/-/commit/75997e182b695f2e3f0a2d649734952af5caf3ee
 	if len(qemuDeviceSerial) > 36 {
 		qemuDev["serial"] = qemuDeviceSerial[:36]
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4096,7 +4096,14 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 	}
 
 	if bus == "virtio-scsi" {
-		qemuDev["device_id"] = qemuDeviceNameOrID(qemuDeviceNamePrefix, driveConf.DevName, "", qemuDeviceNameMaxLength)
+		qemuDev["device_id"] = qemuDeviceSerial
+
+		// Maintain existing /dev/disk/by-id naming behaviour in guest.
+		// Related to https://gitlab.com/qemu-project/qemu/-/commit/75997e182b695f2e3f0a2d649734952af5caf3ee
+		if len(qemuDeviceSerial) > 20 {
+			qemuDev["device_id"] = qemuDeviceSerial[:20]
+		}
+
 		qemuDev["channel"] = 0
 		qemuDev["lun"] = 1
 		qemuDev["bus"] = "qemu_scsi.0"


### PR DESCRIPTION
This restores the previous behaviour that qemu had of setting the device_id to the serial concatenated to 20 chars.

We want to maintain this behaviour in 5.21 LTS so as not to break guests who rely on that naming scheme.

However it will change in LXD 6.4 and onwards.