### PR TITLE
Fix: Return cluster members in non-recursive mode

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1264,15 +1264,15 @@ func clusterNodesGet(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading failure domains names: %w", err)
 		}
 
+		members, err = tx.GetNodes(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed getting cluster members: %w", err)
+		}
+
 		if recursion {
 			memberFailureDomains, err := tx.GetNodesFailureDomains(ctx)
 			if err != nil {
 				return fmt.Errorf("Failed loading member failure domains: %w", err)
-			}
-
-			members, err = tx.GetNodes(ctx)
-			if err != nil {
-				return fmt.Errorf("Failed getting cluster members: %w", err)
 			}
 
 			args := db.NodeInfoArgs{

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -20,6 +20,12 @@ test_clustering_enable() {
 
     # Enable clustering.
     lxc cluster enable node1
+
+    # Test the non-recursive mode to list cluster members.
+    lxc query /1.0/cluster/members | jq '.[0]' | grep -q node1
+
+    # Test the recursive mode to list cluster members.
+    # The command implicitly sets the recursive=1 query paramter.
     lxc cluster list | grep -q node1
 
     # The container is still there and now shows up as


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/canonical/lxd/pull/15314/commits/cc14d2b45785a58b74315ef581ccd6753d5ed563.

When querying `GET /1.0/cluster/members` without `recursive=1` a simple list of cluster members should be returned.
This was causing errors in MicroCloud as it polls LXD until the API returns the first cluster member after enabling clustering. As an example see https://github.com/canonical/microcloud/actions/runs/14488020785/job/40637889229?pr=754#step:3:4054