### PR TITLE
Doc: Ignore link checking of https://www.schlachter.tech/solutions/pongo2-template-engine/

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -164,6 +164,8 @@ linkcheck_ignore = [
     'https://www.dell.com/',
     'https://www.dell.com/en-us/shop/powerflex/sf/powerflex',
     'https://www.gnu.org/licenses/agpl-3.0.en.html',
+    # 403 from GH runners
+    'https://www.schlachter.tech/solutions/pongo2-template-engine/',
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
Seems to be denied when running from Github (403 response).