### PR TITLE
github: rework how GOCOVERDIR is handled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,8 @@ on:
 
 env:
   LXD_REQUIRED_TESTS: "storage_buckets,network_ovn"
-  GOCOVERDIR: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && '"${GITHUB_WORKSPACE}/coverage"' || '' }}
+  GOCOVERAGE: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && '"${GITHUB_WORKSPACE}/coverage"' || '' }}
+  GOCOVERDIR: ''  # Later set to the fully qualified path if needed
 
 permissions:
   contents: read
@@ -94,6 +95,14 @@ jobs:
           DOC_GOMIN="$(sed -n 's/^LXD requires Go \([0-9.]\+\) .*/\1/p' doc/requirements.md)"
           [ "${GOMIN}" = "${DOC_GOMIN}" ]
 
+      - name: Make GOCOVERDIR
+        run: |
+          set -eux
+          mkdir -p coverage
+          cd coverage
+          echo "GOCOVERDIR=$(pwd)" >> "${GITHUB_ENV}"
+        if: env.GOCOVERAGE == 'true'
+
       - name: Make LXD tarball and unpack it
         env:
           CUSTOM_VERSION: "test"
@@ -172,10 +181,6 @@ jobs:
             echo "${UNEXPECTED_GO_VER}"
             exit 1
           fi
-
-      - name: Make GOCOVERDIR
-        run: mkdir -p "${GOCOVERDIR}"
-        if: env.GOCOVERDIR != ''
 
       - name: Run static analysis
         env:
@@ -289,8 +294,10 @@ jobs:
       - name: Make GOCOVERDIR
         run: |
           set -eux
-          mkdir -p "${GOCOVERDIR}"
-        if: env.GOCOVERDIR != ''
+          mkdir -p coverage
+          cd coverage
+          echo "GOCOVERDIR=$(pwd)" >> "${GITHUB_ENV}"
+        if: env.GOCOVERAGE == 'true'
 
       - name: "Run system tests (${{ matrix.suite }}, ${{ matrix.backend }})"
         run: |
@@ -350,6 +357,14 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: 'go.mod'
+
+      - name: Make GOCOVERDIR
+        run: |
+          set -eux
+          mkdir -p coverage
+          cd coverage
+          echo "GOCOVERDIR=$(pwd)" >> "${GITHUB_ENV}"
+        if: env.GOCOVERAGE == 'true'
 
       - name: Download coverage data
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -419,8 +434,12 @@ jobs:
           mkdir bin
 
       - name: Make GOCOVERDIR
-        run: mkdir -p "${GOCOVERDIR}"
-        if: env.GOCOVERDIR != ''
+        run: |
+          set -eux
+          mkdir -p coverage
+          cd coverage
+          echo "GOCOVERDIR=$(pwd)" >> "${GITHUB_ENV}"
+        if: env.GOCOVERAGE == 'true'
 
       - name: Build static lxc
         env:
@@ -568,8 +587,10 @@ jobs:
       - name: Make GOCOVERDIR
         run: |
           set -eux
-          mkdir -p "${GOCOVERDIR}"
-        if: env.GOCOVERDIR != ''
+          mkdir -p coverage
+          cd coverage
+          echo "GOCOVERDIR=$(pwd)" >> "${GITHUB_ENV}"
+        if: env.GOCOVERAGE == 'true'
 
       - name: Run LXD daemon
         run: |

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -4035,7 +4035,7 @@ test_clustering_events() {
   ns4="${prefix}4"
   spawn_lxd_and_join_cluster "${ns4}" "${bridge}" "${cert}" 4 1 "${LXD_FOUR_DIR}" "${LXD_ONE_DIR}"
 
-  # Spawn a fith node.
+  # Spawn a fifth node.
   setup_clustering_netns 5
   LXD_FIVE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_FIVE_DIR}"


### PR DESCRIPTION
Using `mkdir`, `cd` and `pwd` to assemble the GOCOVERDIR path
(`"${GITHUB_WORKSPACE}/coverage"`) should work on all platforms even Windows
and macOS.

Note that on Windows, despite being invoked seemingly correctly, no coverage data is produced:

```
# Make GOCOVERDIR
Run set -eux
  set -eux
  mkdir -p coverage
  cd coverage
  echo "GOCOVERDIR=$(pwd)" >> "${GITHUB_ENV}"
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    LXD_REQUIRED_TESTS: storage_buckets,network_ovn
    GOCOVERAGE: true
    GOCOVERDIR: 
+ mkdir -p coverage
+ cd coverage
++ pwd
+ echo GOCOVERDIR=/d/a/lxd/lxd/coverage
```

```
# Unit tests (client)
Run set -eux
  go test -v ./client/... -cover -test.gocoverdir="${GOCOVERDIR}"
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    LXD_REQUIRED_TESTS: storage_buckets,network_ovn
    GOCOVERAGE: true
    GOCOVERDIR: /d/a/lxd/lxd/coverage
    CGO_ENABLED: 0
    COVER: -cover -test.gocoverdir="${GOCOVERDIR}"
+ go test -v ./client/... -cover -test.gocoverdir=/d/a/lxd/lxd/coverage
	github.com/canonical/lxd/client		coverage: 0.0% of statements
```

```
# Upload coverage data
Run actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
  with:
    name: coverage-clients-Windows
    path: /d/a/lxd/lxd/coverage
    retention-days: 1
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
    include-hidden-files: false
  env:
    LXD_REQUIRED_TESTS: storage_buckets,network_ovn
    GOCOVERAGE: true
    GOCOVERDIR: /d/a/lxd/lxd/coverage
Warning: No files were found with the provided path: /d/a/lxd/lxd/coverage. No artifacts will be uploaded.
```