### PR TITLE
lxd/instance_instance_types: Update instanceRefreshTypes function to use all.yaml instance type file (stable-5.0)

### DIFF
--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -155,9 +155,8 @@ func instanceRefreshTypes(ctx context.Context, s *state.State) error {
 		_ = instanceLoadCache()
 	}
 
-	// Get the list of instance type sources
-	sources := map[string]string{}
-	err := downloadParse(".yaml", &sources)
+	// Parse the "all.yaml" file and update the global map
+	err := downloadParse("all.yaml", &instanceTypes)
 	if err != nil {
 		if err != ctx.Err() {
 			logger.Warnf("Failed to update instance types: %v", err)
@@ -165,22 +164,6 @@ func instanceRefreshTypes(ctx context.Context, s *state.State) error {
 
 		return err
 	}
-
-	// Parse the individual files
-	newInstanceTypes := map[string]map[string]*instanceType{}
-	for name, filename := range sources {
-		types := map[string]*instanceType{}
-		err = downloadParse(filename, &types)
-		if err != nil {
-			logger.Warnf("Failed to update instance types: %v", err)
-			return err
-		}
-
-		newInstanceTypes[name] = types
-	}
-
-	// Update the global map
-	instanceTypes = newInstanceTypes
 
 	// And save in the cache
 	err = instanceSaveCache()


### PR DESCRIPTION
Includes https://github.com/canonical/lxd/pull/15132.