### PR TITLE
doc/idmap: Clarify subuid/subgid configuration (from Incus)

### DIFF
--- a/doc/userns-idmap.md
+++ b/doc/userns-idmap.md
@@ -25,7 +25,7 @@ kernels but will refuse to start containers.
 ## Allowed ranges
 
 On most hosts, LXD will check `/etc/subuid` and `/etc/subgid` for
-allocations for the `lxd` user and on first start, set the default
+allocations for the `root` user and on first start, set the default
 profile to use the first 65536 UIDs and GIDs from that range.
 
 If the range is shorter than 65536 (which includes no range at all),
@@ -90,3 +90,7 @@ host, and the third entry is the range inside the container. These ranges must
 be the same size.
 
 This property requires a container reboot to take effect.
+
+Remember that you may need to add an entry for the `root` user into
+`/etc/subid` and/or `/etc/subgid` so the container is allowed to make
+use of it.


### PR DESCRIPTION
Cherry-picked from https://github.com/lxc/incus/pull/1353
Adapted during cherry-pick to use LXD terminology (say LXD where it says Incus)
Confirmed that the change from `lxd/incus` to `root` for user name occurred in [this 2017 commit](https://github.com/canonical/lxd/commit/1f6218101f16c1a1d5521dc5bfd97d532626d03b)