### PR TITLE
Replace http string literals with `http` package constants

### DIFF
--- a/client/lxd_certificates.go
+++ b/client/lxd_certificates.go
@@ -2,6 +2,7 @@ package lxd
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -14,7 +15,7 @@ func (r *ProtocolLXD) GetCertificateFingerprints() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/certificates"
-	_, err := r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +29,7 @@ func (r *ProtocolLXD) GetCertificates() ([]api.Certificate, error) {
 	certificates := []api.Certificate{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", "/certificates?recursion=1", nil, "", &certificates)
+	_, err := r.queryStruct(http.MethodGet, "/certificates?recursion=1", nil, "", &certificates)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +42,7 @@ func (r *ProtocolLXD) GetCertificate(fingerprint string) (*api.Certificate, stri
 	certificate := api.Certificate{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/certificates/"+url.PathEscape(fingerprint), nil, "", &certificate)
+	etag, err := r.queryStruct(http.MethodGet, "/certificates/"+url.PathEscape(fingerprint), nil, "", &certificate)
 	if err != nil {
 		return nil, "", err
 	}
@@ -52,7 +53,7 @@ func (r *ProtocolLXD) GetCertificate(fingerprint string) (*api.Certificate, stri
 // CreateCertificate adds a new certificate to the LXD trust store.
 func (r *ProtocolLXD) CreateCertificate(certificate api.CertificatesPost) error {
 	// Send the request
-	_, _, err := r.query("POST", "/certificates", certificate, "")
+	_, _, err := r.query(http.MethodPost, "/certificates", certificate, "")
 	if err != nil {
 		return err
 	}
@@ -68,7 +69,7 @@ func (r *ProtocolLXD) UpdateCertificate(fingerprint string, certificate api.Cert
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", "/certificates/"+url.PathEscape(fingerprint), certificate, ETag)
+	_, _, err = r.query(http.MethodPut, "/certificates/"+url.PathEscape(fingerprint), certificate, ETag)
 	if err != nil {
 		return err
 	}
@@ -79,7 +80,7 @@ func (r *ProtocolLXD) UpdateCertificate(fingerprint string, certificate api.Cert
 // DeleteCertificate removes a certificate from the LXD trust store.
 func (r *ProtocolLXD) DeleteCertificate(fingerprint string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", "/certificates/"+url.PathEscape(fingerprint), nil, "")
+	_, _, err := r.query(http.MethodDelete, "/certificates/"+url.PathEscape(fingerprint), nil, "")
 	if err != nil {
 		return err
 	}
@@ -99,7 +100,7 @@ func (r *ProtocolLXD) CreateCertificateToken(certificate api.CertificatesPost) (
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/certificates", certificate, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/certificates", certificate, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -32,7 +32,7 @@ func (r *ProtocolLXD) GetContainerNames() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/containers"
-	_, err := r.queryStruct("GET", "/containers", nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, "/containers", nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (r *ProtocolLXD) GetContainers() ([]api.Container, error) {
 	containers := []api.Container{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", "/containers?recursion=1", nil, "", &containers)
+	_, err := r.queryStruct(http.MethodGet, "/containers?recursion=1", nil, "", &containers)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (r *ProtocolLXD) GetContainersFull() ([]api.ContainerFull, error) {
 	}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/containers?recursion=2", nil, "", &containers)
+	_, err = r.queryStruct(http.MethodGet, "/containers?recursion=2", nil, "", &containers)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (r *ProtocolLXD) GetContainer(name string) (*api.Container, string, error) 
 	container := api.Container{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/containers/"+url.PathEscape(name), nil, "", &container)
+	etag, err := r.queryStruct(http.MethodGet, "/containers/"+url.PathEscape(name), nil, "", &container)
 	if err != nil {
 		return nil, "", err
 	}
@@ -103,7 +103,7 @@ func (r *ProtocolLXD) CreateContainerFromBackup(args ContainerBackupArgs) (Opera
 
 	if args.PoolName == "" {
 		// Send the request
-		op, _, err := r.queryOperation("POST", "/containers", args.BackupFile, "", true)
+		op, _, err := r.queryOperation(http.MethodPost, "/containers", args.BackupFile, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +122,7 @@ func (r *ProtocolLXD) CreateContainerFromBackup(args ContainerBackupArgs) (Opera
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", reqURL, args.BackupFile)
+	req, err := http.NewRequest(http.MethodPost, reqURL, args.BackupFile)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (r *ProtocolLXD) CreateContainer(container api.ContainersPost) (Operation, 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers", container, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers", container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 // Deprecated: Use UpdateInstance instead.
 func (r *ProtocolLXD) UpdateContainer(name string, container api.ContainerPut, ETag string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("PUT", "/containers/"+url.PathEscape(name), container, ETag, true)
+	op, _, err := r.queryOperation(http.MethodPut, "/containers/"+url.PathEscape(name), container, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (r *ProtocolLXD) RenameContainer(name string, container api.ContainerPost) 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(name), container, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(name), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -636,7 +636,7 @@ func (r *ProtocolLXD) MigrateContainer(name string, container api.ContainerPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(name), container, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(name), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -649,7 +649,7 @@ func (r *ProtocolLXD) MigrateContainer(name string, container api.ContainerPost)
 // Deprecated: Use DeleteInstance instead.
 func (r *ProtocolLXD) DeleteContainer(name string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", "/containers/"+url.PathEscape(name), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, "/containers/"+url.PathEscape(name), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -676,7 +676,7 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(containerName)+"/exec", exec, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(containerName)+"/exec", exec, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -830,7 +830,7 @@ func (r *ProtocolLXD) GetContainerFile(containerName string, path string) (io.Re
 		return nil, nil, err
 	}
 
-	req, err := http.NewRequest("GET", requestURL, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -920,7 +920,7 @@ func (r *ProtocolLXD) CreateContainerFile(containerName string, path string, arg
 		return err
 	}
 
-	req, err := http.NewRequest("POST", requestURL, args.Content)
+	req, err := http.NewRequest(http.MethodPost, requestURL, args.Content)
 	if err != nil {
 		return err
 	}
@@ -971,7 +971,7 @@ func (r *ProtocolLXD) DeleteContainerFile(containerName string, path string) err
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", "/containers/"+url.PathEscape(containerName)+"/files?path="+url.QueryEscape(path), nil, "")
+	_, _, err = r.query(http.MethodDelete, "/containers/"+url.PathEscape(containerName)+"/files?path="+url.QueryEscape(path), nil, "")
 	if err != nil {
 		return err
 	}
@@ -986,7 +986,7 @@ func (r *ProtocolLXD) GetContainerSnapshotNames(containerName string) ([]string,
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/containers/" + url.PathEscape(containerName) + "/snapshots"
-	_, err := r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1002,7 @@ func (r *ProtocolLXD) GetContainerSnapshots(containerName string) ([]api.Contain
 	snapshots := []api.ContainerSnapshot{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", "/containers/"+url.PathEscape(containerName)+"/snapshots?recursion=1", nil, "", &snapshots)
+	_, err := r.queryStruct(http.MethodGet, "/containers/"+url.PathEscape(containerName)+"/snapshots?recursion=1", nil, "", &snapshots)
 	if err != nil {
 		return nil, err
 	}
@@ -1017,7 +1017,7 @@ func (r *ProtocolLXD) GetContainerSnapshot(containerName string, name string) (*
 	snapshot := api.ContainerSnapshot{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), nil, "", &snapshot)
+	etag, err := r.queryStruct(http.MethodGet, "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), nil, "", &snapshot)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1038,7 +1038,7 @@ func (r *ProtocolLXD) CreateContainerSnapshot(containerName string, snapshot api
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(containerName)+"/snapshots", snapshot, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(containerName)+"/snapshots", snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1285,7 +1285,7 @@ func (r *ProtocolLXD) RenameContainerSnapshot(containerName string, name string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), container, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1360,7 +1360,7 @@ func (r *ProtocolLXD) MigrateContainerSnapshot(containerName string, name string
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), container, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1373,7 +1373,7 @@ func (r *ProtocolLXD) MigrateContainerSnapshot(containerName string, name string
 // Deprecated: Use DeleteInstanceSnapshot instead.
 func (r *ProtocolLXD) DeleteContainerSnapshot(containerName string, name string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1391,7 +1391,7 @@ func (r *ProtocolLXD) UpdateContainerSnapshot(containerName string, name string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), container, ETag, true)
+	op, _, err := r.queryOperation(http.MethodPut, "/containers/"+url.PathEscape(containerName)+"/snapshots/"+url.PathEscape(name), container, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1406,7 +1406,7 @@ func (r *ProtocolLXD) GetContainerState(name string) (*api.ContainerState, strin
 	state := api.ContainerState{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/containers/"+url.PathEscape(name)+"/state", nil, "", &state)
+	etag, err := r.queryStruct(http.MethodGet, "/containers/"+url.PathEscape(name)+"/state", nil, "", &state)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1419,7 +1419,7 @@ func (r *ProtocolLXD) GetContainerState(name string) (*api.ContainerState, strin
 // Deprecated: Use UpdateInstanceState instead.
 func (r *ProtocolLXD) UpdateContainerState(name string, state api.ContainerStatePut, ETag string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("PUT", "/containers/"+url.PathEscape(name)+"/state", state, ETag, true)
+	op, _, err := r.queryOperation(http.MethodPut, "/containers/"+url.PathEscape(name)+"/state", state, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1434,7 +1434,7 @@ func (r *ProtocolLXD) GetContainerLogfiles(name string) ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/containers/" + url.PathEscape(name) + "/logs"
-	_, err := r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -1457,7 +1457,7 @@ func (r *ProtocolLXD) GetContainerLogfile(name string, filename string) (io.Read
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1484,7 +1484,7 @@ func (r *ProtocolLXD) GetContainerLogfile(name string, filename string) (io.Read
 // Deprecated: Use DeleteInstanceLogfile instead.
 func (r *ProtocolLXD) DeleteContainerLogfile(name string, filename string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", "/containers/"+url.PathEscape(name)+"/logs/"+url.PathEscape(filename), nil, "")
+	_, _, err := r.query(http.MethodDelete, "/containers/"+url.PathEscape(name)+"/logs/"+url.PathEscape(filename), nil, "")
 	if err != nil {
 		return err
 	}
@@ -1504,7 +1504,7 @@ func (r *ProtocolLXD) GetContainerMetadata(name string) (*api.ImageMetadata, str
 	metadata := api.ImageMetadata{}
 
 	url := "/containers/" + url.PathEscape(name) + "/metadata"
-	etag, err := r.queryStruct("GET", url, nil, "", &metadata)
+	etag, err := r.queryStruct(http.MethodGet, url, nil, "", &metadata)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1522,7 +1522,7 @@ func (r *ProtocolLXD) SetContainerMetadata(name string, metadata api.ImageMetada
 	}
 
 	url := "/containers/" + url.PathEscape(name) + "/metadata"
-	_, _, err = r.query("PUT", url, metadata, ETag)
+	_, _, err = r.query(http.MethodPut, url, metadata, ETag)
 	if err != nil {
 		return err
 	}
@@ -1542,7 +1542,7 @@ func (r *ProtocolLXD) GetContainerTemplateFiles(containerName string) ([]string,
 	templates := []string{}
 
 	url := "/containers/" + url.PathEscape(containerName) + "/metadata/templates"
-	_, err = r.queryStruct("GET", url, nil, "", &templates)
+	_, err = r.queryStruct(http.MethodGet, url, nil, "", &templates)
 	if err != nil {
 		return nil, err
 	}
@@ -1566,7 +1566,7 @@ func (r *ProtocolLXD) GetContainerTemplateFile(containerName string, templateNam
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1604,7 +1604,7 @@ func (r *ProtocolLXD) CreateContainerTemplateFile(containerName string, template
 		return err
 	}
 
-	req, err := http.NewRequest("POST", url, content)
+	req, err := http.NewRequest(http.MethodPost, url, content)
 	if err != nil {
 		return err
 	}
@@ -1639,7 +1639,7 @@ func (r *ProtocolLXD) DeleteContainerTemplateFile(name string, templateName stri
 		return err
 	}
 
-	_, _, err = r.query("DELETE", "/containers/"+url.PathEscape(name)+"/metadata/templates?path="+url.QueryEscape(templateName), nil, "")
+	_, _, err = r.query(http.MethodDelete, "/containers/"+url.PathEscape(name)+"/metadata/templates?path="+url.QueryEscape(templateName), nil, "")
 	return err
 }
 
@@ -1653,7 +1653,7 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(containerName)+"/console", console, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(containerName)+"/console", console, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1738,7 +1738,7 @@ func (r *ProtocolLXD) GetContainerConsoleLog(containerName string, args *Contain
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1770,7 +1770,7 @@ func (r *ProtocolLXD) DeleteContainerConsoleLog(containerName string, args *Cont
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", "/containers/"+url.PathEscape(containerName)+"/console", nil, "")
+	_, _, err = r.query(http.MethodDelete, "/containers/"+url.PathEscape(containerName)+"/console", nil, "")
 	if err != nil {
 		return err
 	}
@@ -1790,7 +1790,7 @@ func (r *ProtocolLXD) GetContainerBackupNames(containerName string) ([]string, e
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/containers/" + url.PathEscape(containerName) + "/backups"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -1811,7 +1811,7 @@ func (r *ProtocolLXD) GetContainerBackups(containerName string) ([]api.Container
 	// Fetch the raw value
 	backups := []api.ContainerBackup{}
 
-	_, err = r.queryStruct("GET", "/containers/"+url.PathEscape(containerName)+"/backups?recursion=1", nil, "", &backups)
+	_, err = r.queryStruct(http.MethodGet, "/containers/"+url.PathEscape(containerName)+"/backups?recursion=1", nil, "", &backups)
 	if err != nil {
 		return nil, err
 	}
@@ -1830,7 +1830,7 @@ func (r *ProtocolLXD) GetContainerBackup(containerName string, name string) (*ap
 
 	// Fetch the raw value
 	backup := api.ContainerBackup{}
-	etag, err := r.queryStruct("GET", "/containers/"+url.PathEscape(containerName)+"/backups/"+url.PathEscape(name), nil, "", &backup)
+	etag, err := r.queryStruct(http.MethodGet, "/containers/"+url.PathEscape(containerName)+"/backups/"+url.PathEscape(name), nil, "", &backup)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1848,7 +1848,7 @@ func (r *ProtocolLXD) CreateContainerBackup(containerName string, backup api.Con
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(containerName)+"/backups", backup, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(containerName)+"/backups", backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1866,7 +1866,7 @@ func (r *ProtocolLXD) RenameContainerBackup(containerName string, name string, b
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers/"+url.PathEscape(containerName)+"/backups/"+url.PathEscape(name), backup, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/containers/"+url.PathEscape(containerName)+"/backups/"+url.PathEscape(name), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1884,7 +1884,7 @@ func (r *ProtocolLXD) DeleteContainerBackup(containerName string, name string) (
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", "/containers/"+url.PathEscape(containerName)+"/backups/"+url.PathEscape(name), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, "/containers/"+url.PathEscape(containerName)+"/backups/"+url.PathEscape(name), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1908,7 +1908,7 @@ func (r *ProtocolLXD) GetContainerBackupFile(containerName string, name string, 
 	}
 
 	// Prepare the download request
-	request, err := http.NewRequest("GET", uri, nil)
+	request, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -1073,7 +1073,7 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 			return nil, err
 		}
 
-		req.ContainerPut.Stateful = snapshot.Stateful
+		req.Stateful = snapshot.Stateful
 		req.Source.Live = false // Snapshots are never running and so we don't need live migration.
 	}
 

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -26,7 +26,7 @@ import (
 func (r *ProtocolLXD) GetImages() ([]api.Image, error) {
 	images := []api.Image{}
 
-	_, err := r.queryStruct("GET", "/images?recursion=1", nil, "", &images)
+	_, err := r.queryStruct(http.MethodGet, "/images?recursion=1", nil, "", &images)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (r *ProtocolLXD) GetImagesAllProjects() ([]api.Image, error) {
 	}
 
 	u := api.NewURL().Path("images").WithQuery("recursion", "1").WithQuery("all-projects", "true")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &images)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &images)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (r *ProtocolLXD) GetImagesAllProjectsWithFilter(filters []string) ([]api.Im
 	}
 
 	u := api.NewURL().Path("images").WithQuery("recursion", "1").WithQuery("all-projects", "true").WithQuery("filter", parseFilters(filters))
-	_, err = r.queryStruct("GET", u.String(), nil, "", &images)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &images)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (r *ProtocolLXD) GetImagesWithFilter(filters []string) ([]api.Image, error)
 	v.Set("recursion", "1")
 	v.Set("filter", parseFilters(filters))
 
-	_, err = r.queryStruct("GET", "/images?"+v.Encode(), nil, "", &images)
+	_, err = r.queryStruct(http.MethodGet, "/images?"+v.Encode(), nil, "", &images)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (r *ProtocolLXD) GetImageFingerprints() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/images"
-	_, err := r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (r *ProtocolLXD) GetPrivateImage(fingerprint string, secret string) (*api.I
 	}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", path, nil, "", &image)
+	etag, err := r.queryStruct(http.MethodGet, path, nil, "", &image)
 	if err != nil {
 		return nil, "", err
 	}
@@ -218,7 +218,7 @@ func lxdDownloadImage(fingerprint string, uri string, userAgent string, do func(
 	resp := ImageFileResponse{}
 
 	// Prepare the download request
-	request, err := http.NewRequest("GET", uri, nil)
+	request, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func (r *ProtocolLXD) GetImageAliases() ([]api.ImageAliasesEntry, error) {
 	aliases := []api.ImageAliasesEntry{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", "/images/aliases?recursion=1", nil, "", &aliases)
+	_, err := r.queryStruct(http.MethodGet, "/images/aliases?recursion=1", nil, "", &aliases)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (r *ProtocolLXD) GetImageAliasNames() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/images/aliases"
-	_, err := r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (r *ProtocolLXD) GetImageAlias(name string) (*api.ImageAliasesEntry, string
 	alias := api.ImageAliasesEntry{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/images/aliases/"+url.PathEscape(name), nil, "", &alias)
+	etag, err := r.queryStruct(http.MethodGet, "/images/aliases/"+url.PathEscape(name), nil, "", &alias)
 	if err != nil {
 		return nil, "", err
 	}
@@ -442,7 +442,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 
 	// Send the JSON based request
 	if args == nil {
-		op, _, err := r.queryOperation("POST", "/images", image, "", true)
+		op, _, err := r.queryOperation(http.MethodPost, "/images", image, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -541,7 +541,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", reqURL, body)
+	req, err := http.NewRequest(http.MethodPost, reqURL, body)
 	if err != nil {
 		return nil, err
 	}
@@ -954,7 +954,7 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 // UpdateImage updates the image definition.
 func (r *ProtocolLXD) UpdateImage(fingerprint string, image api.ImagePut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", "/images/"+url.PathEscape(fingerprint), image, ETag)
+	_, _, err := r.query(http.MethodPut, "/images/"+url.PathEscape(fingerprint), image, ETag)
 	if err != nil {
 		return err
 	}
@@ -965,7 +965,7 @@ func (r *ProtocolLXD) UpdateImage(fingerprint string, image api.ImagePut, ETag s
 // DeleteImage requests that LXD removes an image from the store.
 func (r *ProtocolLXD) DeleteImage(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", "/images/"+url.PathEscape(fingerprint), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, "/images/"+url.PathEscape(fingerprint), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -981,7 +981,7 @@ func (r *ProtocolLXD) RefreshImage(fingerprint string) (Operation, error) {
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/images/"+url.PathEscape(fingerprint)+"/refresh", nil, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/images/"+url.PathEscape(fingerprint)+"/refresh", nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -992,7 +992,7 @@ func (r *ProtocolLXD) RefreshImage(fingerprint string) (Operation, error) {
 // CreateImageSecret requests that LXD issues a temporary image secret.
 func (r *ProtocolLXD) CreateImageSecret(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/images/"+url.PathEscape(fingerprint)+"/secret", nil, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/images/"+url.PathEscape(fingerprint)+"/secret", nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1003,7 +1003,7 @@ func (r *ProtocolLXD) CreateImageSecret(fingerprint string) (Operation, error) {
 // CreateImageAlias sets up a new image alias.
 func (r *ProtocolLXD) CreateImageAlias(alias api.ImageAliasesPost) error {
 	// Send the request
-	_, _, err := r.query("POST", "/images/aliases", alias, "")
+	_, _, err := r.query(http.MethodPost, "/images/aliases", alias, "")
 	if err != nil {
 		return err
 	}
@@ -1014,7 +1014,7 @@ func (r *ProtocolLXD) CreateImageAlias(alias api.ImageAliasesPost) error {
 // UpdateImageAlias updates the image alias definition.
 func (r *ProtocolLXD) UpdateImageAlias(name string, alias api.ImageAliasesEntryPut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", "/images/aliases/"+url.PathEscape(name), alias, ETag)
+	_, _, err := r.query(http.MethodPut, "/images/aliases/"+url.PathEscape(name), alias, ETag)
 	if err != nil {
 		return err
 	}
@@ -1025,7 +1025,7 @@ func (r *ProtocolLXD) UpdateImageAlias(name string, alias api.ImageAliasesEntryP
 // RenameImageAlias renames an existing image alias.
 func (r *ProtocolLXD) RenameImageAlias(name string, alias api.ImageAliasesEntryPost) error {
 	// Send the request
-	_, _, err := r.query("POST", "/images/aliases/"+url.PathEscape(name), alias, "")
+	_, _, err := r.query(http.MethodPost, "/images/aliases/"+url.PathEscape(name), alias, "")
 	if err != nil {
 		return err
 	}
@@ -1036,7 +1036,7 @@ func (r *ProtocolLXD) RenameImageAlias(name string, alias api.ImageAliasesEntryP
 // DeleteImageAlias removes an alias from the LXD image store.
 func (r *ProtocolLXD) DeleteImageAlias(name string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", "/images/aliases/"+url.PathEscape(name), nil, "")
+	_, _, err := r.query(http.MethodDelete, "/images/aliases/"+url.PathEscape(name), nil, "")
 	if err != nil {
 		return err
 	}
@@ -1052,7 +1052,7 @@ func (r *ProtocolLXD) ExportImage(fingerprint string, image api.ImageExportPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/images/"+url.PathEscape(fingerprint)+"/export", &image, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/images/"+url.PathEscape(fingerprint)+"/export", &image, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -62,7 +62,7 @@ func (r *ProtocolLXD) GetInstanceNames(instanceType api.InstanceType) ([]string,
 
 	// Fetch the raw URL values.
 	urls := []string{}
-	_, err = r.queryStruct("GET", baseURL+"?"+v.Encode(), nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL+"?"+v.Encode(), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (r *ProtocolLXD) GetInstanceNamesAllProjects(instanceType api.InstanceType)
 	v.Set("all-projects", "true")
 
 	// Fetch the raw URL values.
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (r *ProtocolLXD) GetInstances(instanceType api.InstanceType) ([]api.Instanc
 	v.Set("recursion", "1")
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (r *ProtocolLXD) GetInstancesWithFilter(instanceType api.InstanceType, filt
 	v.Set("filter", parseFilters(filters))
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (r *ProtocolLXD) GetInstancesAllProjects(instanceType api.InstanceType) ([]
 	}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (r *ProtocolLXD) GetInstancesAllProjectsWithFilter(instanceType api.Instanc
 	}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (r *ProtocolLXD) UpdateInstances(state api.InstancesPut, ETag string) (Oper
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", path+"?"+v.Encode(), state, ETag, true)
+	op, _, err := r.queryOperation(http.MethodPut, path+"?"+v.Encode(), state, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (r *ProtocolLXD) rebuildInstance(instanceName string, instance api.Instance
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/rebuild", instance, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/rebuild", instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (r *ProtocolLXD) GetInstancesFull(instanceType api.InstanceType) ([]api.Ins
 	}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func (r *ProtocolLXD) GetInstancesFullWithFilter(instanceType api.InstanceType, 
 	}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func (r *ProtocolLXD) GetInstancesFullAllProjects(instanceType api.InstanceType)
 	}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +459,7 @@ func (r *ProtocolLXD) GetInstancesFullAllProjectsWithFilter(instanceType api.Ins
 	}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &instances)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &instances)
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func (r *ProtocolLXD) GetInstance(name string) (*api.Instance, string, error) {
 	}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", path+"/"+url.PathEscape(name), nil, "", &instance)
+	etag, err := r.queryStruct(http.MethodGet, path+"/"+url.PathEscape(name), nil, "", &instance)
 	if err != nil {
 		return nil, "", err
 	}
@@ -500,7 +500,7 @@ func (r *ProtocolLXD) GetInstanceUEFIVars(name string) (*api.InstanceUEFIVars, s
 	}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", path+"/"+url.PathEscape(name)+"/uefi-vars", nil, "", &instanceUEFI)
+	etag, err := r.queryStruct(http.MethodGet, path+"/"+url.PathEscape(name)+"/uefi-vars", nil, "", &instanceUEFI)
 	if err != nil {
 		return nil, "", err
 	}
@@ -521,7 +521,7 @@ func (r *ProtocolLXD) UpdateInstanceUEFIVars(name string, instanceUEFI api.Insta
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", path+"/"+url.PathEscape(name)+"/uefi-vars", instanceUEFI, ETag)
+	_, _, err = r.query(http.MethodPut, path+"/"+url.PathEscape(name)+"/uefi-vars", instanceUEFI, ETag)
 	if err != nil {
 		return err
 	}
@@ -569,7 +569,7 @@ func (r *ProtocolLXD) GetInstanceFull(name string) (*api.InstanceFull, string, e
 	}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", path+"/"+url.PathEscape(name)+"?recursion=1", nil, "", &instance)
+	etag, err := r.queryStruct(http.MethodGet, path+"/"+url.PathEscape(name)+"?recursion=1", nil, "", &instance)
 	if err != nil {
 		return nil, "", err
 	}
@@ -592,7 +592,7 @@ func (r *ProtocolLXD) CreateInstanceFromBackup(args InstanceBackupArgs) (Operati
 
 	if args.PoolName == "" && args.Name == "" && len(args.Devices) == 0 {
 		// Send the request
-		op, _, err := r.queryOperation("POST", path, args.BackupFile, "", true)
+		op, _, err := r.queryOperation(http.MethodPost, path, args.BackupFile, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +628,7 @@ func (r *ProtocolLXD) CreateInstanceFromBackup(args InstanceBackupArgs) (Operati
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", reqURL, args.BackupFile)
+	req, err := http.NewRequest(http.MethodPost, reqURL, args.BackupFile)
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +705,7 @@ func (r *ProtocolLXD) CreateInstance(instance api.InstancesPost) (Operation, err
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, instance, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path, instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1092,7 +1092,7 @@ func (r *ProtocolLXD) UpdateInstance(name string, instance api.InstancePut, ETag
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", path+"/"+url.PathEscape(name), instance, ETag, true)
+	op, _, err := r.queryOperation(http.MethodPut, path+"/"+url.PathEscape(name), instance, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1113,7 +1113,7 @@ func (r *ProtocolLXD) RenameInstance(name string, instance api.InstancePost) (Op
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(name), instance, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(name), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1248,7 +1248,7 @@ func (r *ProtocolLXD) MigrateInstance(name string, instance api.InstancePost) (O
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(name), instance, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(name), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1264,7 +1264,7 @@ func (r *ProtocolLXD) DeleteInstance(name string) (Operation, error) {
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", path+"/"+url.PathEscape(name), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, path+"/"+url.PathEscape(name), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1307,7 +1307,7 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", uri, exec, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, uri, exec, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1562,7 +1562,7 @@ func (r *ProtocolLXD) GetInstanceFile(instanceName string, filePath string) (io.
 		return nil, nil, err
 	}
 
-	req, err := http.NewRequest("GET", requestURL, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1661,7 +1661,7 @@ func (r *ProtocolLXD) CreateInstanceFile(instanceName string, filePath string, a
 		return err
 	}
 
-	req, err := http.NewRequest("POST", requestURL, args.Content)
+	req, err := http.NewRequest(http.MethodPost, requestURL, args.Content)
 	if err != nil {
 		return err
 	}
@@ -1747,7 +1747,7 @@ func (r *ProtocolLXD) DeleteInstanceFile(instanceName string, filePath string) e
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", requestURL, nil, "")
+	_, _, err = r.query(http.MethodDelete, requestURL, nil, "")
 	if err != nil {
 		return err
 	}
@@ -1866,7 +1866,7 @@ func (r *ProtocolLXD) GetInstanceSnapshotNames(instanceName string) ([]string, e
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := path + "/" + url.PathEscape(instanceName) + "/snapshots"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -1885,7 +1885,7 @@ func (r *ProtocolLXD) GetInstanceSnapshots(instanceName string) ([]api.InstanceS
 	snapshots := []api.InstanceSnapshot{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", path+"/"+url.PathEscape(instanceName)+"/snapshots?recursion=1", nil, "", &snapshots)
+	_, err = r.queryStruct(http.MethodGet, path+"/"+url.PathEscape(instanceName)+"/snapshots?recursion=1", nil, "", &snapshots)
 	if err != nil {
 		return nil, err
 	}
@@ -1903,7 +1903,7 @@ func (r *ProtocolLXD) GetInstanceSnapshot(instanceName string, name string) (*ap
 	snapshot := api.InstanceSnapshot{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), nil, "", &snapshot)
+	etag, err := r.queryStruct(http.MethodGet, path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), nil, "", &snapshot)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1927,7 +1927,7 @@ func (r *ProtocolLXD) CreateInstanceSnapshot(instanceName string, snapshot api.I
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/snapshots", snapshot, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/snapshots", snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2192,7 +2192,7 @@ func (r *ProtocolLXD) RenameInstanceSnapshot(instanceName string, name string, i
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), instance, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2268,7 +2268,7 @@ func (r *ProtocolLXD) MigrateInstanceSnapshot(instanceName string, name string, 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), instance, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2284,7 +2284,7 @@ func (r *ProtocolLXD) DeleteInstanceSnapshot(instanceName string, name string) (
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2305,7 +2305,7 @@ func (r *ProtocolLXD) UpdateInstanceSnapshot(instanceName string, name string, i
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), instance, ETag, true)
+	op, _, err := r.queryOperation(http.MethodPut, path+"/"+url.PathEscape(instanceName)+"/snapshots/"+url.PathEscape(name), instance, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -2331,7 +2331,7 @@ func (r *ProtocolLXD) GetInstanceState(name string) (*api.InstanceState, string,
 	state := api.InstanceState{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", uri, nil, "", &state)
+	etag, err := r.queryStruct(http.MethodGet, uri, nil, "", &state)
 	if err != nil {
 		return nil, "", err
 	}
@@ -2347,7 +2347,7 @@ func (r *ProtocolLXD) UpdateInstanceState(name string, state api.InstanceStatePu
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", path+"/"+url.PathEscape(name)+"/state", state, ETag, true)
+	op, _, err := r.queryOperation(http.MethodPut, path+"/"+url.PathEscape(name)+"/state", state, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -2365,7 +2365,7 @@ func (r *ProtocolLXD) GetInstanceLogfiles(name string) ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := path + "/" + url.PathEscape(name) + "/logs"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -2391,7 +2391,7 @@ func (r *ProtocolLXD) GetInstanceLogfile(name string, filename string) (io.ReadC
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2421,7 +2421,7 @@ func (r *ProtocolLXD) DeleteInstanceLogfile(name string, filename string) error 
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", path+"/"+url.PathEscape(name)+"/logs/"+url.PathEscape(filename), nil, "")
+	_, _, err = r.query(http.MethodDelete, path+"/"+url.PathEscape(name)+"/logs/"+url.PathEscape(filename), nil, "")
 	if err != nil {
 		return err
 	}
@@ -2451,7 +2451,7 @@ func (r *ProtocolLXD) getInstanceExecOutputLogFile(name string, filename string)
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2486,7 +2486,7 @@ func (r *ProtocolLXD) deleteInstanceExecOutputLogFile(instanceName string, filen
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", path+"/"+url.PathEscape(instanceName)+"/logs/exec-output/"+url.PathEscape(filename), nil, "")
+	_, _, err = r.query(http.MethodDelete, path+"/"+url.PathEscape(instanceName)+"/logs/exec-output/"+url.PathEscape(filename), nil, "")
 	if err != nil {
 		return err
 	}
@@ -2509,7 +2509,7 @@ func (r *ProtocolLXD) GetInstanceMetadata(name string) (*api.ImageMetadata, stri
 	metadata := api.ImageMetadata{}
 
 	url := path + "/" + url.PathEscape(name) + "/metadata"
-	etag, err := r.queryStruct("GET", url, nil, "", &metadata)
+	etag, err := r.queryStruct(http.MethodGet, url, nil, "", &metadata)
 	if err != nil {
 		return nil, "", err
 	}
@@ -2530,7 +2530,7 @@ func (r *ProtocolLXD) UpdateInstanceMetadata(name string, metadata api.ImageMeta
 	}
 
 	url := path + "/" + url.PathEscape(name) + "/metadata"
-	_, _, err = r.query("PUT", url, metadata, ETag)
+	_, _, err = r.query(http.MethodPut, url, metadata, ETag)
 	if err != nil {
 		return err
 	}
@@ -2553,7 +2553,7 @@ func (r *ProtocolLXD) GetInstanceTemplateFiles(instanceName string) ([]string, e
 	templates := []string{}
 
 	url := path + "/" + url.PathEscape(instanceName) + "/metadata/templates"
-	_, err = r.queryStruct("GET", url, nil, "", &templates)
+	_, err = r.queryStruct(http.MethodGet, url, nil, "", &templates)
 	if err != nil {
 		return nil, err
 	}
@@ -2580,7 +2580,7 @@ func (r *ProtocolLXD) GetInstanceTemplateFile(instanceName string, templateName 
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2621,7 +2621,7 @@ func (r *ProtocolLXD) CreateInstanceTemplateFile(instanceName string, templateNa
 		return err
 	}
 
-	req, err := http.NewRequest("POST", url, content)
+	req, err := http.NewRequest(http.MethodPost, url, content)
 	if err != nil {
 		return err
 	}
@@ -2652,7 +2652,7 @@ func (r *ProtocolLXD) DeleteInstanceTemplateFile(name string, templateName strin
 		return err
 	}
 
-	_, _, err = r.query("DELETE", path+"/"+url.PathEscape(name)+"/metadata/templates?path="+url.QueryEscape(templateName), nil, "")
+	_, _, err = r.query(http.MethodDelete, path+"/"+url.PathEscape(name)+"/metadata/templates?path="+url.QueryEscape(templateName), nil, "")
 	return err
 }
 
@@ -2681,7 +2681,7 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 
 	// Send the request
 	useEventListener := r.CheckExtension("operation_wait") != nil
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/console", console, "", useEventListener)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/console", console, "", useEventListener)
 	if err != nil {
 		return nil, err
 	}
@@ -2780,7 +2780,7 @@ func (r *ProtocolLXD) ConsoleInstanceDynamic(instanceName string, console api.In
 	}
 
 	// Send the request.
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/console", console, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/console", console, "", true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2874,7 +2874,7 @@ func (r *ProtocolLXD) GetInstanceConsoleLog(instanceName string, args *InstanceC
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2909,7 +2909,7 @@ func (r *ProtocolLXD) DeleteInstanceConsoleLog(instanceName string, args *Instan
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", path+"/"+url.PathEscape(instanceName)+"/console", nil, "")
+	_, _, err = r.query(http.MethodDelete, path+"/"+url.PathEscape(instanceName)+"/console", nil, "")
 	if err != nil {
 		return err
 	}
@@ -2932,7 +2932,7 @@ func (r *ProtocolLXD) GetInstanceBackupNames(instanceName string) ([]string, err
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := path + "/" + url.PathEscape(instanceName) + "/backups"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -2956,7 +2956,7 @@ func (r *ProtocolLXD) GetInstanceBackups(instanceName string) ([]api.InstanceBac
 	// Fetch the raw value
 	backups := []api.InstanceBackup{}
 
-	_, err = r.queryStruct("GET", path+"/"+url.PathEscape(instanceName)+"/backups?recursion=1", nil, "", &backups)
+	_, err = r.queryStruct(http.MethodGet, path+"/"+url.PathEscape(instanceName)+"/backups?recursion=1", nil, "", &backups)
 	if err != nil {
 		return nil, err
 	}
@@ -2978,7 +2978,7 @@ func (r *ProtocolLXD) GetInstanceBackup(instanceName string, name string) (*api.
 
 	// Fetch the raw value
 	backup := api.InstanceBackup{}
-	etag, err := r.queryStruct("GET", path+"/"+url.PathEscape(instanceName)+"/backups/"+url.PathEscape(name), nil, "", &backup)
+	etag, err := r.queryStruct(http.MethodGet, path+"/"+url.PathEscape(instanceName)+"/backups/"+url.PathEscape(name), nil, "", &backup)
 	if err != nil {
 		return nil, "", err
 	}
@@ -2999,7 +2999,7 @@ func (r *ProtocolLXD) CreateInstanceBackup(instanceName string, backup api.Insta
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/backups", backup, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/backups", backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -3020,7 +3020,7 @@ func (r *ProtocolLXD) RenameInstanceBackup(instanceName string, name string, bac
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path+"/"+url.PathEscape(instanceName)+"/backups/"+url.PathEscape(name), backup, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path+"/"+url.PathEscape(instanceName)+"/backups/"+url.PathEscape(name), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -3041,7 +3041,7 @@ func (r *ProtocolLXD) DeleteInstanceBackup(instanceName string, name string) (Op
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", path+"/"+url.PathEscape(instanceName)+"/backups/"+url.PathEscape(name), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, path+"/"+url.PathEscape(instanceName)+"/backups/"+url.PathEscape(name), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -3068,7 +3068,7 @@ func (r *ProtocolLXD) GetInstanceBackupFile(instanceName string, name string, re
 	}
 
 	// Prepare the download request
-	request, err := http.NewRequest("GET", uri, nil)
+	request, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_network_acls.go
+++ b/client/lxd_network_acls.go
@@ -18,7 +18,7 @@ func (r *ProtocolLXD) GetNetworkACLNames() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/network-acls"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func (r *ProtocolLXD) GetNetworkACLs() ([]api.NetworkACL, error) {
 	acls := []api.NetworkACL{}
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", "/network-acls?recursion=1", nil, "", &acls)
+	_, err = r.queryStruct(http.MethodGet, "/network-acls?recursion=1", nil, "", &acls)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (r *ProtocolLXD) GetNetworkACL(name string) (*api.NetworkACL, string, error
 	acl := api.NetworkACL{}
 
 	// Fetch the raw value.
-	etag, err := r.queryStruct("GET", "/network-acls/"+url.PathEscape(name), nil, "", &acl)
+	etag, err := r.queryStruct(http.MethodGet, "/network-acls/"+url.PathEscape(name), nil, "", &acl)
 	if err != nil {
 		return nil, "", err
 	}
@@ -79,7 +79,7 @@ func (r *ProtocolLXD) GetNetworkACLLogfile(name string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (r *ProtocolLXD) CreateNetworkACL(acl api.NetworkACLsPost) error {
 	}
 
 	// Send the request.
-	_, _, err = r.query("POST", "/network-acls", acl, "")
+	_, _, err = r.query(http.MethodPost, "/network-acls", acl, "")
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (r *ProtocolLXD) UpdateNetworkACL(name string, acl api.NetworkACLPut, ETag 
 	}
 
 	// Send the request.
-	_, _, err = r.query("PUT", "/network-acls/"+url.PathEscape(name), acl, ETag)
+	_, _, err = r.query(http.MethodPut, "/network-acls/"+url.PathEscape(name), acl, ETag)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func (r *ProtocolLXD) RenameNetworkACL(name string, acl api.NetworkACLPost) erro
 	}
 
 	// Send the request.
-	_, _, err = r.query("POST", "/network-acls/"+url.PathEscape(name), acl, "")
+	_, _, err = r.query(http.MethodPost, "/network-acls/"+url.PathEscape(name), acl, "")
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (r *ProtocolLXD) DeleteNetworkACL(name string) error {
 	}
 
 	// Send the request.
-	_, _, err = r.query("DELETE", "/network-acls/"+url.PathEscape(name), nil, "")
+	_, _, err = r.query(http.MethodDelete, "/network-acls/"+url.PathEscape(name), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_network_allocations.go
+++ b/client/lxd_network_allocations.go
@@ -1,6 +1,8 @@
 package lxd
 
 import (
+	"net/http"
+
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -18,7 +20,7 @@ func (r *ProtocolLXD) GetNetworkAllocations(allProjects bool) ([]api.NetworkAllo
 	}
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", uri, nil, "", &netAllocations)
+	_, err = r.queryStruct(http.MethodGet, uri, nil, "", &netAllocations)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_network_forwards.go
+++ b/client/lxd_network_forwards.go
@@ -3,6 +3,7 @@ package lxd
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -18,7 +19,7 @@ func (r *ProtocolLXD) GetNetworkForwardAddresses(networkName string) ([]string, 
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/networks/" + url.PathEscape(networkName) + "/forwards"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +38,7 @@ func (r *ProtocolLXD) GetNetworkForwards(networkName string) ([]api.NetworkForwa
 	forwards := []api.NetworkForward{}
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", "/networks/"+url.PathEscape(networkName)+"/forwards?recursion=1", nil, "", &forwards)
+	_, err = r.queryStruct(http.MethodGet, "/networks/"+url.PathEscape(networkName)+"/forwards?recursion=1", nil, "", &forwards)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func (r *ProtocolLXD) GetNetworkForward(networkName string, listenAddress string
 	forward := api.NetworkForward{}
 
 	// Fetch the raw value.
-	etag, err := r.queryStruct("GET", "/networks/"+url.PathEscape(networkName)+"/forwards/"+url.PathEscape(listenAddress), nil, "", &forward)
+	etag, err := r.queryStruct(http.MethodGet, "/networks/"+url.PathEscape(networkName)+"/forwards/"+url.PathEscape(listenAddress), nil, "", &forward)
 	if err != nil {
 		return nil, "", err
 	}
@@ -83,7 +84,7 @@ func (r *ProtocolLXD) CreateNetworkForward(networkName string, forward api.Netwo
 	}
 
 	// Send the request.
-	_, _, err = r.query("POST", "/networks/"+url.PathEscape(networkName)+"/forwards", forward, "")
+	_, _, err = r.query(http.MethodPost, "/networks/"+url.PathEscape(networkName)+"/forwards", forward, "")
 	if err != nil {
 		return err
 	}
@@ -99,7 +100,7 @@ func (r *ProtocolLXD) UpdateNetworkForward(networkName string, listenAddress str
 	}
 
 	// Send the request.
-	_, _, err = r.query("PUT", "/networks/"+url.PathEscape(networkName)+"/forwards/"+url.PathEscape(listenAddress), forward, ETag)
+	_, _, err = r.query(http.MethodPut, "/networks/"+url.PathEscape(networkName)+"/forwards/"+url.PathEscape(listenAddress), forward, ETag)
 	if err != nil {
 		return err
 	}
@@ -115,7 +116,7 @@ func (r *ProtocolLXD) DeleteNetworkForward(networkName string, listenAddress str
 	}
 
 	// Send the request.
-	_, _, err = r.query("DELETE", "/networks/"+url.PathEscape(networkName)+"/forwards/"+url.PathEscape(listenAddress), nil, "")
+	_, _, err = r.query(http.MethodDelete, "/networks/"+url.PathEscape(networkName)+"/forwards/"+url.PathEscape(listenAddress), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_network_load_balancers.go
+++ b/client/lxd_network_load_balancers.go
@@ -3,6 +3,7 @@ package lxd
 import (
 	"fmt"
 	"net"
+	"net/http"
 
 	"github.com/canonical/lxd/shared/api"
 )
@@ -17,7 +18,7 @@ func (r *ProtocolLXD) GetNetworkLoadBalancerAddresses(networkName string) ([]str
 	// Fetch the raw URL values.
 	urls := []string{}
 	u := api.NewURL().Path("networks", networkName, "load-balancers")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +38,7 @@ func (r *ProtocolLXD) GetNetworkLoadBalancers(networkName string) ([]api.Network
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("networks", networkName, "load-balancers").WithQuery("recursion", "1")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &loadBalancers)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &loadBalancers)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func (r *ProtocolLXD) GetNetworkLoadBalancer(networkName string, listenAddress s
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("networks", networkName, "load-balancers", listenAddress)
-	etag, err := r.queryStruct("GET", u.String(), nil, "", &loadBalancer)
+	etag, err := r.queryStruct(http.MethodGet, u.String(), nil, "", &loadBalancer)
 	if err != nil {
 		return nil, "", err
 	}
@@ -85,7 +86,7 @@ func (r *ProtocolLXD) CreateNetworkLoadBalancer(networkName string, loadBalancer
 
 	// Send the request.
 	u := api.NewURL().Path("networks", networkName, "load-balancers")
-	_, _, err = r.query("POST", u.String(), loadBalancer, "")
+	_, _, err = r.query(http.MethodPost, u.String(), loadBalancer, "")
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func (r *ProtocolLXD) UpdateNetworkLoadBalancer(networkName string, listenAddres
 
 	// Send the request.
 	u := api.NewURL().Path("networks", networkName, "load-balancers", listenAddress)
-	_, _, err = r.query("PUT", u.String(), loadBalancer, ETag)
+	_, _, err = r.query(http.MethodPut, u.String(), loadBalancer, ETag)
 	if err != nil {
 		return err
 	}
@@ -119,7 +120,7 @@ func (r *ProtocolLXD) DeleteNetworkLoadBalancer(networkName string, listenAddres
 
 	// Send the request.
 	u := api.NewURL().Path("networks", networkName, "load-balancers", listenAddress)
-	_, _, err = r.query("DELETE", u.String(), nil, "")
+	_, _, err = r.query(http.MethodDelete, u.String(), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_network_peer.go
+++ b/client/lxd_network_peer.go
@@ -1,6 +1,7 @@
 package lxd
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -16,7 +17,7 @@ func (r *ProtocolLXD) GetNetworkPeerNames(networkName string) ([]string, error) 
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/networks/" + url.PathEscape(networkName) + "/peers"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +36,7 @@ func (r *ProtocolLXD) GetNetworkPeers(networkName string) ([]api.NetworkPeer, er
 	peers := []api.NetworkPeer{}
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", "/networks/"+url.PathEscape(networkName)+"/peers?recursion=1", nil, "", &peers)
+	_, err = r.queryStruct(http.MethodGet, "/networks/"+url.PathEscape(networkName)+"/peers?recursion=1", nil, "", &peers)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +54,7 @@ func (r *ProtocolLXD) GetNetworkPeer(networkName string, peerName string) (*api.
 	peer := api.NetworkPeer{}
 
 	// Fetch the raw value.
-	etag, err := r.queryStruct("GET", "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), nil, "", &peer)
+	etag, err := r.queryStruct(http.MethodGet, "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), nil, "", &peer)
 	if err != nil {
 		return nil, "", err
 	}
@@ -70,7 +71,7 @@ func (r *ProtocolLXD) CreateNetworkPeer(networkName string, peer api.NetworkPeer
 	}
 
 	// Send the request.
-	_, _, err = r.query("POST", "/networks/"+url.PathEscape(networkName)+"/peers", peer, "")
+	_, _, err = r.query(http.MethodPost, "/networks/"+url.PathEscape(networkName)+"/peers", peer, "")
 	if err != nil {
 		return err
 	}
@@ -86,7 +87,7 @@ func (r *ProtocolLXD) UpdateNetworkPeer(networkName string, peerName string, pee
 	}
 
 	// Send the request.
-	_, _, err = r.query("PUT", "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), peer, ETag)
+	_, _, err = r.query(http.MethodPut, "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), peer, ETag)
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func (r *ProtocolLXD) DeleteNetworkPeer(networkName string, peerName string) err
 	}
 
 	// Send the request.
-	_, _, err = r.query("DELETE", "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), nil, "")
+	_, _, err = r.query(http.MethodDelete, "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_network_zones.go
+++ b/client/lxd_network_zones.go
@@ -2,6 +2,7 @@ package lxd
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -17,7 +18,7 @@ func (r *ProtocolLXD) GetNetworkZoneNames() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/network-zones"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func (r *ProtocolLXD) GetNetworkZones() ([]api.NetworkZone, error) {
 	zones := []api.NetworkZone{}
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", "/network-zones?recursion=1", nil, "", &zones)
+	_, err = r.queryStruct(http.MethodGet, "/network-zones?recursion=1", nil, "", &zones)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func (r *ProtocolLXD) GetNetworkZonesAllProjects() ([]api.NetworkZone, error) {
 	zones := []api.NetworkZone{}
 
 	u := api.NewURL().Path("network-zones").WithQuery("recursion", "1").WithQuery("all-projects", "true")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &zones)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &zones)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func (r *ProtocolLXD) GetNetworkZone(name string) (*api.NetworkZone, string, err
 	zone := api.NetworkZone{}
 
 	// Fetch the raw value.
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/network-zones/%s", url.PathEscape(name)), nil, "", &zone)
+	etag, err := r.queryStruct(http.MethodGet, fmt.Sprintf("/network-zones/%s", url.PathEscape(name)), nil, "", &zone)
 	if err != nil {
 		return nil, "", err
 	}
@@ -88,7 +89,7 @@ func (r *ProtocolLXD) CreateNetworkZone(zone api.NetworkZonesPost) error {
 	}
 
 	// Send the request.
-	_, _, err = r.query("POST", "/network-zones", zone, "")
+	_, _, err = r.query(http.MethodPost, "/network-zones", zone, "")
 	if err != nil {
 		return err
 	}
@@ -104,7 +105,7 @@ func (r *ProtocolLXD) UpdateNetworkZone(name string, zone api.NetworkZonePut, ET
 	}
 
 	// Send the request.
-	_, _, err = r.query("PUT", fmt.Sprintf("/network-zones/%s", url.PathEscape(name)), zone, ETag)
+	_, _, err = r.query(http.MethodPut, fmt.Sprintf("/network-zones/%s", url.PathEscape(name)), zone, ETag)
 	if err != nil {
 		return err
 	}
@@ -120,7 +121,7 @@ func (r *ProtocolLXD) DeleteNetworkZone(name string) error {
 	}
 
 	// Send the request.
-	_, _, err = r.query("DELETE", fmt.Sprintf("/network-zones/%s", url.PathEscape(name)), nil, "")
+	_, _, err = r.query(http.MethodDelete, fmt.Sprintf("/network-zones/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}
@@ -138,7 +139,7 @@ func (r *ProtocolLXD) GetNetworkZoneRecordNames(zone string) ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := fmt.Sprintf("/network-zones/%s/records", url.PathEscape(zone))
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (r *ProtocolLXD) GetNetworkZoneRecords(zone string) ([]api.NetworkZoneRecor
 	records := []api.NetworkZoneRecord{}
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", fmt.Sprintf("/network-zones/%s/records?recursion=1", url.PathEscape(zone)), nil, "", &records)
+	_, err = r.queryStruct(http.MethodGet, fmt.Sprintf("/network-zones/%s/records?recursion=1", url.PathEscape(zone)), nil, "", &records)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +176,7 @@ func (r *ProtocolLXD) GetNetworkZoneRecord(zone string, name string) (*api.Netwo
 	record := api.NetworkZoneRecord{}
 
 	// Fetch the raw value.
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), nil, "", &record)
+	etag, err := r.queryStruct(http.MethodGet, fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), nil, "", &record)
 	if err != nil {
 		return nil, "", err
 	}
@@ -191,7 +192,7 @@ func (r *ProtocolLXD) CreateNetworkZoneRecord(zone string, record api.NetworkZon
 	}
 
 	// Send the request.
-	_, _, err = r.query("POST", fmt.Sprintf("/network-zones/%s/records", url.PathEscape(zone)), record, "")
+	_, _, err = r.query(http.MethodPost, fmt.Sprintf("/network-zones/%s/records", url.PathEscape(zone)), record, "")
 	if err != nil {
 		return err
 	}
@@ -207,7 +208,7 @@ func (r *ProtocolLXD) UpdateNetworkZoneRecord(zone string, name string, record a
 	}
 
 	// Send the request.
-	_, _, err = r.query("PUT", fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), record, ETag)
+	_, _, err = r.query(http.MethodPut, fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), record, ETag)
 	if err != nil {
 		return err
 	}
@@ -223,7 +224,7 @@ func (r *ProtocolLXD) DeleteNetworkZoneRecord(zone string, name string) error {
 	}
 
 	// Send the request.
-	_, _, err = r.query("DELETE", fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), nil, "")
+	_, _, err = r.query(http.MethodDelete, fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_networks.go
+++ b/client/lxd_networks.go
@@ -2,6 +2,7 @@ package lxd
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -17,7 +18,7 @@ func (r *ProtocolLXD) GetNetworkNames() ([]string, error) {
 	// Fetch the raw values.
 	urls := []string{}
 	baseURL := "/networks"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func (r *ProtocolLXD) GetNetworks() ([]api.Network, error) {
 	networks := []api.Network{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/networks?recursion=1", nil, "", &networks)
+	_, err = r.queryStruct(http.MethodGet, "/networks?recursion=1", nil, "", &networks)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func (r *ProtocolLXD) GetNetwork(name string) (*api.Network, string, error) {
 	network := api.Network{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/networks/%s", url.PathEscape(name)), nil, "", &network)
+	etag, err := r.queryStruct(http.MethodGet, fmt.Sprintf("/networks/%s", url.PathEscape(name)), nil, "", &network)
 	if err != nil {
 		return nil, "", err
 	}
@@ -72,7 +73,7 @@ func (r *ProtocolLXD) GetNetworkLeases(name string) ([]api.NetworkLease, error) 
 	leases := []api.NetworkLease{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", fmt.Sprintf("/networks/%s/leases", url.PathEscape(name)), nil, "", &leases)
+	_, err = r.queryStruct(http.MethodGet, fmt.Sprintf("/networks/%s/leases", url.PathEscape(name)), nil, "", &leases)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (r *ProtocolLXD) GetNetworkState(name string) (*api.NetworkState, error) {
 	state := api.NetworkState{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", fmt.Sprintf("/networks/%s/state", url.PathEscape(name)), nil, "", &state)
+	_, err = r.queryStruct(http.MethodGet, fmt.Sprintf("/networks/%s/state", url.PathEscape(name)), nil, "", &state)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (r *ProtocolLXD) CreateNetwork(network api.NetworksPost) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("POST", "/networks", network, "")
+	_, _, err = r.query(http.MethodPost, "/networks", network, "")
 	if err != nil {
 		return err
 	}
@@ -122,7 +123,7 @@ func (r *ProtocolLXD) UpdateNetwork(name string, network api.NetworkPut, ETag st
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", fmt.Sprintf("/networks/%s", url.PathEscape(name)), network, ETag)
+	_, _, err = r.query(http.MethodPut, fmt.Sprintf("/networks/%s", url.PathEscape(name)), network, ETag)
 	if err != nil {
 		return err
 	}
@@ -138,7 +139,7 @@ func (r *ProtocolLXD) RenameNetwork(name string, network api.NetworkPost) error 
 	}
 
 	// Send the request
-	_, _, err = r.query("POST", fmt.Sprintf("/networks/%s", url.PathEscape(name)), network, "")
+	_, _, err = r.query(http.MethodPost, fmt.Sprintf("/networks/%s", url.PathEscape(name)), network, "")
 	if err != nil {
 		return err
 	}
@@ -154,7 +155,7 @@ func (r *ProtocolLXD) DeleteNetwork(name string) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", fmt.Sprintf("/networks/%s", url.PathEscape(name)), nil, "")
+	_, _, err = r.query(http.MethodDelete, fmt.Sprintf("/networks/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_operations.go
+++ b/client/lxd_operations.go
@@ -1,6 +1,7 @@
 package lxd
 
 import (
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -14,7 +15,7 @@ func (r *ProtocolLXD) GetOperationUUIDs() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/operations"
-	_, err := r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +29,7 @@ func (r *ProtocolLXD) GetOperations() ([]api.Operation, error) {
 	apiOperations := map[string][]api.Operation{}
 
 	// Fetch the raw value.
-	_, err := r.queryStruct("GET", "/operations?recursion=1", nil, "", &apiOperations)
+	_, err := r.queryStruct(http.MethodGet, "/operations?recursion=1", nil, "", &apiOperations)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (r *ProtocolLXD) GetOperationsAllProjects() ([]api.Operation, error) {
 	v.Set("all-projects", "true")
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", path+"?"+v.Encode(), nil, "", &apiOperations)
+	_, err = r.queryStruct(http.MethodGet, path+"?"+v.Encode(), nil, "", &apiOperations)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +78,7 @@ func (r *ProtocolLXD) GetOperation(uuid string) (*api.Operation, string, error) 
 	op := api.Operation{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/operations/"+url.PathEscape(uuid), nil, "", &op)
+	etag, err := r.queryStruct(http.MethodGet, "/operations/"+url.PathEscape(uuid), nil, "", &op)
 	if err != nil {
 		return nil, "", err
 	}
@@ -98,7 +99,7 @@ func (r *ProtocolLXD) GetOperationWait(uuid string, timeout int) (*api.Operation
 	transport.ResponseHeaderTimeout = 0
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/operations/"+url.PathEscape(uuid)+"/wait?timeout="+strconv.FormatInt(int64(timeout), 10), nil, "", &op)
+	etag, err := r.queryStruct(http.MethodGet, "/operations/"+url.PathEscape(uuid)+"/wait?timeout="+strconv.FormatInt(int64(timeout), 10), nil, "", &op)
 	if err != nil {
 		return nil, "", err
 	}
@@ -111,7 +112,7 @@ func (r *ProtocolLXD) GetOperationWaitSecret(uuid string, secret string, timeout
 	op := api.Operation{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/operations/"+url.PathEscape(uuid)+"/wait?secret="+url.PathEscape(secret)+"&timeout="+strconv.FormatInt(int64(timeout), 10), nil, "", &op)
+	etag, err := r.queryStruct(http.MethodGet, "/operations/"+url.PathEscape(uuid)+"/wait?secret="+url.PathEscape(secret)+"&timeout="+strconv.FormatInt(int64(timeout), 10), nil, "", &op)
 	if err != nil {
 		return nil, "", err
 	}
@@ -132,7 +133,7 @@ func (r *ProtocolLXD) GetOperationWebsocket(uuid string, secret string) (*websoc
 // DeleteOperation deletes (cancels) a running operation.
 func (r *ProtocolLXD) DeleteOperation(uuid string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", "/operations/"+url.PathEscape(uuid), nil, "")
+	_, _, err := r.query(http.MethodDelete, "/operations/"+url.PathEscape(uuid), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_profiles.go
+++ b/client/lxd_profiles.go
@@ -1,6 +1,7 @@
 package lxd
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -13,7 +14,7 @@ func (r *ProtocolLXD) GetProfileNames() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/profiles"
-	_, err := r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err := r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +28,7 @@ func (r *ProtocolLXD) GetProfiles() ([]api.Profile, error) {
 	profiles := []api.Profile{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", "/profiles?recursion=1", nil, "", &profiles)
+	_, err := r.queryStruct(http.MethodGet, "/profiles?recursion=1", nil, "", &profiles)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +45,7 @@ func (r *ProtocolLXD) GetProfilesAllProjects() ([]api.Profile, error) {
 	}
 
 	u := api.NewURL().Path("profiles").WithQuery("recursion", "1").WithQuery("all-projects", "true")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &profiles)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &profiles)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (r *ProtocolLXD) GetProfile(name string) (*api.Profile, string, error) {
 	profile := api.Profile{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/profiles/"+url.PathEscape(name), nil, "", &profile)
+	etag, err := r.queryStruct(http.MethodGet, "/profiles/"+url.PathEscape(name), nil, "", &profile)
 	if err != nil {
 		return nil, "", err
 	}
@@ -68,7 +69,7 @@ func (r *ProtocolLXD) GetProfile(name string) (*api.Profile, string, error) {
 // CreateProfile defines a new container profile.
 func (r *ProtocolLXD) CreateProfile(profile api.ProfilesPost) error {
 	// Send the request
-	_, _, err := r.query("POST", "/profiles", profile, "")
+	_, _, err := r.query(http.MethodPost, "/profiles", profile, "")
 	if err != nil {
 		return err
 	}
@@ -79,7 +80,7 @@ func (r *ProtocolLXD) CreateProfile(profile api.ProfilesPost) error {
 // UpdateProfile updates the profile to match the provided Profile struct.
 func (r *ProtocolLXD) UpdateProfile(name string, profile api.ProfilePut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", "/profiles/"+url.PathEscape(name), profile, ETag)
+	_, _, err := r.query(http.MethodPut, "/profiles/"+url.PathEscape(name), profile, ETag)
 	if err != nil {
 		return err
 	}
@@ -90,7 +91,7 @@ func (r *ProtocolLXD) UpdateProfile(name string, profile api.ProfilePut, ETag st
 // RenameProfile renames an existing profile entry.
 func (r *ProtocolLXD) RenameProfile(name string, profile api.ProfilePost) error {
 	// Send the request
-	_, _, err := r.query("POST", "/profiles/"+url.PathEscape(name), profile, "")
+	_, _, err := r.query(http.MethodPost, "/profiles/"+url.PathEscape(name), profile, "")
 	if err != nil {
 		return err
 	}
@@ -101,7 +102,7 @@ func (r *ProtocolLXD) RenameProfile(name string, profile api.ProfilePost) error 
 // DeleteProfile deletes a profile.
 func (r *ProtocolLXD) DeleteProfile(name string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", "/profiles/"+url.PathEscape(name), nil, "")
+	_, _, err := r.query(http.MethodDelete, "/profiles/"+url.PathEscape(name), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_projects.go
+++ b/client/lxd_projects.go
@@ -1,6 +1,7 @@
 package lxd
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -18,7 +19,7 @@ func (r *ProtocolLXD) GetProjectNames() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/projects"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +38,7 @@ func (r *ProtocolLXD) GetProjects() ([]api.Project, error) {
 	projects := []api.Project{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/projects?recursion=1", nil, "", &projects)
+	_, err = r.queryStruct(http.MethodGet, "/projects?recursion=1", nil, "", &projects)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func (r *ProtocolLXD) GetProject(name string) (*api.Project, string, error) {
 	project := api.Project{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "/projects/"+url.PathEscape(name), nil, "", &project)
+	etag, err := r.queryStruct(http.MethodGet, "/projects/"+url.PathEscape(name), nil, "", &project)
 	if err != nil {
 		return nil, "", err
 	}
@@ -73,7 +74,7 @@ func (r *ProtocolLXD) GetProjectState(name string) (*api.ProjectState, error) {
 	projectState := api.ProjectState{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/projects/"+url.PathEscape(name)+"/state", nil, "", &projectState)
+	_, err = r.queryStruct(http.MethodGet, "/projects/"+url.PathEscape(name)+"/state", nil, "", &projectState)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +90,7 @@ func (r *ProtocolLXD) CreateProject(project api.ProjectsPost) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("POST", "/projects", project, "")
+	_, _, err = r.query(http.MethodPost, "/projects", project, "")
 	if err != nil {
 		return err
 	}
@@ -105,7 +106,7 @@ func (r *ProtocolLXD) UpdateProject(name string, project api.ProjectPut, ETag st
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", "/projects/"+url.PathEscape(name), project, ETag)
+	_, _, err = r.query(http.MethodPut, "/projects/"+url.PathEscape(name), project, ETag)
 	if err != nil {
 		return err
 	}
@@ -121,7 +122,7 @@ func (r *ProtocolLXD) RenameProject(name string, project api.ProjectPost) (Opera
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/projects/"+url.PathEscape(name), project, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/projects/"+url.PathEscape(name), project, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +138,7 @@ func (r *ProtocolLXD) DeleteProject(name string) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", "/projects/"+url.PathEscape(name), nil, "")
+	_, _, err = r.query(http.MethodDelete, "/projects/"+url.PathEscape(name), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -16,7 +16,7 @@ func (r *ProtocolLXD) GetServer() (*api.Server, string, error) {
 	server := api.Server{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", "", nil, "", &server)
+	etag, err := r.queryStruct(http.MethodGet, "", nil, "", &server)
 	if err != nil {
 		return nil, "", err
 	}
@@ -44,7 +44,7 @@ func (r *ProtocolLXD) GetServer() (*api.Server, string, error) {
 // UpdateServer updates the server status to match the provided Server struct.
 func (r *ProtocolLXD) UpdateServer(server api.ServerPut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", "", server, ETag)
+	_, _, err := r.query(http.MethodPut, "", server, ETag)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (r *ProtocolLXD) GetServerResources() (*api.Resources, error) {
 	resources := api.Resources{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/resources", nil, "", &resources)
+	_, err = r.queryStruct(http.MethodGet, "/resources", nil, "", &resources)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (r *ProtocolLXD) GetMetrics() (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("GET", requestURL, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return "", err
 	}

--- a/client/lxd_storage_buckets.go
+++ b/client/lxd_storage_buckets.go
@@ -1,6 +1,8 @@
 package lxd
 
 import (
+	"net/http"
+
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -14,7 +16,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketNames(poolName string) ([]string, erro
 	// Fetch the raw URL values.
 	urls := []string{}
 	u := api.NewURL().Path("storage-pools", poolName, "buckets")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +36,7 @@ func (r *ProtocolLXD) GetStoragePoolBuckets(poolName string) ([]api.StorageBucke
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets").WithQuery("recursion", "1")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &buckets)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &buckets)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +55,7 @@ func (r *ProtocolLXD) GetStoragePoolBucket(poolName string, bucketName string) (
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName)
-	etag, err := r.queryStruct("GET", u.String(), nil, "", &bucket)
+	etag, err := r.queryStruct(http.MethodGet, u.String(), nil, "", &bucket)
 	if err != nil {
 		return nil, "", err
 	}
@@ -75,7 +77,7 @@ func (r *ProtocolLXD) CreateStoragePoolBucket(poolName string, bucket api.Storag
 	// Send the request and get the resulting key info (including generated keys).
 	if r.CheckExtension("storage_buckets_create_credentials") == nil {
 		var newKey api.StorageBucketKey
-		_, err = r.queryStruct("POST", u.String(), bucket, "", &newKey)
+		_, err = r.queryStruct(http.MethodPost, u.String(), bucket, "", &newKey)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +85,7 @@ func (r *ProtocolLXD) CreateStoragePoolBucket(poolName string, bucket api.Storag
 		return &newKey, nil
 	}
 
-	_, _, err = r.query("POST", u.String(), bucket, "")
+	_, _, err = r.query(http.MethodPost, u.String(), bucket, "")
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +102,7 @@ func (r *ProtocolLXD) UpdateStoragePoolBucket(poolName string, bucketName string
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName)
-	_, _, err = r.query("PUT", u.String(), bucket, ETag)
+	_, _, err = r.query(http.MethodPut, u.String(), bucket, ETag)
 	if err != nil {
 		return err
 	}
@@ -117,7 +119,7 @@ func (r *ProtocolLXD) DeleteStoragePoolBucket(poolName string, bucketName string
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName)
-	_, _, err = r.query("DELETE", u.String(), nil, "")
+	_, _, err = r.query(http.MethodDelete, u.String(), nil, "")
 	if err != nil {
 		return err
 	}
@@ -135,7 +137,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketKeyNames(poolName string, bucketName s
 	// Fetch the raw URL values.
 	urls := []string{}
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +157,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketKeys(poolName string, bucketName strin
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys").WithQuery("recursion", "1")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &bucketKeys)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &bucketKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +176,7 @@ func (r *ProtocolLXD) GetStoragePoolBucketKey(poolName string, bucketName string
 
 	// Fetch the raw value.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys", keyName)
-	etag, err := r.queryStruct("GET", u.String(), nil, "", &bucketKey)
+	etag, err := r.queryStruct(http.MethodGet, u.String(), nil, "", &bucketKey)
 	if err != nil {
 		return nil, "", err
 	}
@@ -192,7 +194,7 @@ func (r *ProtocolLXD) CreateStoragePoolBucketKey(poolName string, bucketName str
 	// Send the request and get the resulting key info (including generated keys).
 	var newKey api.StorageBucketKey
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys")
-	_, err = r.queryStruct("POST", u.String(), key, "", &newKey)
+	_, err = r.queryStruct(http.MethodPost, u.String(), key, "", &newKey)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +211,7 @@ func (r *ProtocolLXD) UpdateStoragePoolBucketKey(poolName string, bucketName str
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys", keyName)
-	_, _, err = r.query("PUT", u.String(), key, ETag)
+	_, _, err = r.query(http.MethodPut, u.String(), key, ETag)
 	if err != nil {
 		return err
 	}
@@ -226,7 +228,7 @@ func (r *ProtocolLXD) DeleteStoragePoolBucketKey(poolName string, bucketName str
 
 	// Send the request.
 	u := api.NewURL().Path("storage-pools", poolName, "buckets", bucketName, "keys", keyName)
-	_, _, err = r.query("DELETE", u.String(), nil, "")
+	_, _, err = r.query(http.MethodDelete, u.String(), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_storage_pools.go
+++ b/client/lxd_storage_pools.go
@@ -2,6 +2,7 @@ package lxd
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -19,7 +20,7 @@ func (r *ProtocolLXD) GetStoragePoolNames() ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/storage-pools"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +39,7 @@ func (r *ProtocolLXD) GetStoragePools() ([]api.StoragePool, error) {
 	pools := []api.StoragePool{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/storage-pools?recursion=1", nil, "", &pools)
+	_, err = r.queryStruct(http.MethodGet, "/storage-pools?recursion=1", nil, "", &pools)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func (r *ProtocolLXD) GetStoragePool(name string) (*api.StoragePool, string, err
 	pool := api.StoragePool{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "", &pool)
+	etag, err := r.queryStruct(http.MethodGet, fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "", &pool)
 	if err != nil {
 		return nil, "", err
 	}
@@ -79,7 +80,7 @@ func (r *ProtocolLXD) CreateStoragePool(pool api.StoragePoolsPost) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("POST", "/storage-pools", pool, "")
+	_, _, err = r.query(http.MethodPost, "/storage-pools", pool, "")
 	if err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (r *ProtocolLXD) UpdateStoragePool(name string, pool api.StoragePoolPut, ET
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), pool, ETag)
+	_, _, err = r.query(http.MethodPut, fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), pool, ETag)
 	if err != nil {
 		return err
 	}
@@ -111,7 +112,7 @@ func (r *ProtocolLXD) DeleteStoragePool(name string) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "")
+	_, _, err = r.query(http.MethodDelete, fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}
@@ -129,7 +130,7 @@ func (r *ProtocolLXD) GetStoragePoolResources(name string) (*api.ResourcesStorag
 	res := api.ResourcesStoragePool{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/resources", url.PathEscape(name)), nil, "", &res)
+	_, err = r.queryStruct(http.MethodGet, fmt.Sprintf("/storage-pools/%s/resources", url.PathEscape(name)), nil, "", &res)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -27,7 +27,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeNames(pool string) ([]string, error) {
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/storage-pools/" + url.PathEscape(pool) + "/volumes"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeNamesAllProjects(pool string) (map[str
 	// Fetch the raw URL values.
 	urls := []string{}
 	u := api.NewURL().Path("storage-pools", pool, "volumes").WithQuery("all-projects", "true")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumes(pool string) ([]api.StorageVolume, e
 	volumes := []api.StorageVolume{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/storage-pools/"+url.PathEscape(pool)+"/volumes?recursion=1", nil, "", &volumes)
+	_, err = r.queryStruct(http.MethodGet, "/storage-pools/"+url.PathEscape(pool)+"/volumes?recursion=1", nil, "", &volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumesAllProjects(pool string) ([]api.Stora
 		WithQuery("all-projects", "true")
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", url.String(), nil, "", &volumes)
+	_, err = r.queryStruct(http.MethodGet, url.String(), nil, "", &volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumesWithFilter(pool string, filters []str
 	v.Set("recursion", "1")
 	v.Set("filter", parseFilters(filters))
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", "/storage-pools/"+url.PathEscape(pool)+"/volumes?"+v.Encode(), nil, "", &volumes)
+	_, err = r.queryStruct(http.MethodGet, "/storage-pools/"+url.PathEscape(pool)+"/volumes?"+v.Encode(), nil, "", &volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumesWithFilterAllProjects(pool string, fi
 		WithQuery("all-projects", "true")
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", url.String(), nil, "", &volumes)
+	_, err = r.queryStruct(http.MethodGet, url.String(), nil, "", &volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (r *ProtocolLXD) GetStoragePoolVolume(pool string, volType string, name str
 
 	// Fetch the raw value
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volType) + "/" + url.PathEscape(name)
-	etag, err := r.queryStruct("GET", path, nil, "", &volume)
+	etag, err := r.queryStruct(http.MethodGet, path, nil, "", &volume)
 	if err != nil {
 		return nil, "", err
 	}
@@ -262,7 +262,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeState(pool string, volType string, nam
 	// Fetch the raw value
 	state := api.StorageVolumeState{}
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volType) + "/" + url.PathEscape(name) + "/state"
-	_, err = r.queryStruct("GET", path, nil, "", &state)
+	_, err = r.queryStruct(http.MethodGet, path, nil, "", &state)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolume(pool string, volume api.StorageVol
 
 	// Send the request
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volume.Type)
-	_, _, err = r.query("POST", path, volume, "")
+	_, _, err = r.query(http.MethodPost, path, volume, "")
 	if err != nil {
 		return err
 	}
@@ -296,7 +296,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeSnapshot(pool string, volumeType st
 
 	// Send the request
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volumeType) + "/" + url.PathEscape(volumeName) + "/snapshots"
-	op, _, err := r.queryOperation("POST", path, snapshot, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path, snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeSnapshotNames(pool string, volumeType 
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volumeType) + "/" + url.PathEscape(volumeName) + "/snapshots"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeSnapshots(pool string, volumeType stri
 	snapshots := []api.StorageVolumeSnapshot{}
 
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volumeType) + "/" + url.PathEscape(volumeName) + "/snapshots?recursion=1"
-	_, err = r.queryStruct("GET", path, nil, "", &snapshots)
+	_, err = r.queryStruct(http.MethodGet, path, nil, "", &snapshots)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeSnapshot(pool string, volumeType strin
 	snapshot := api.StorageVolumeSnapshot{}
 
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volumeType) + "/" + url.PathEscape(volumeName) + "/snapshots/" + url.PathEscape(snapshotName)
-	etag, err := r.queryStruct("GET", path, nil, "", &snapshot)
+	etag, err := r.queryStruct(http.MethodGet, path, nil, "", &snapshot)
 	if err != nil {
 		return nil, "", err
 	}
@@ -370,7 +370,7 @@ func (r *ProtocolLXD) RenameStoragePoolVolumeSnapshot(pool string, volumeType st
 
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volumeType) + "/" + url.PathEscape(volumeName) + "/snapshots/" + url.PathEscape(snapshotName)
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, snapshot, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path, snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (r *ProtocolLXD) DeleteStoragePoolVolumeSnapshot(pool string, volumeType st
 	// Send the request
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volumeType) + "/" + url.PathEscape(volumeName) + "/snapshots/" + url.PathEscape(snapshotName)
 
-	op, _, err := r.queryOperation("DELETE", path, nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, path, nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (r *ProtocolLXD) UpdateStoragePoolVolumeSnapshot(pool string, volumeType st
 
 	// Send the request
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volumeType) + "/" + url.PathEscape(volumeName) + "/snapshots/" + url.PathEscape(snapshotName)
-	_, _, err = r.queryOperation("PUT", path, volume, ETag, true)
+	_, _, err = r.queryOperation(http.MethodPut, path, volume, ETag, true)
 	if err != nil {
 		return err
 	}
@@ -449,7 +449,7 @@ func (r *ProtocolLXD) MigrateStoragePoolVolume(pool string, volume api.StorageVo
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, req, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, path, req, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 
 			// Send the request
 			path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(req.Type)
-			top, _, err := r.queryOperation("POST", path, req, "", true)
+			top, _, err := r.queryOperation(http.MethodPost, path, req, "", true)
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
@@ -638,7 +638,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		}
 
 		// Send the request
-		op, _, err := r.queryOperation("POST", "/storage-pools/"+url.PathEscape(pool)+"/volumes/"+url.PathEscape(volume.Type), req, "", true)
+		op, _, err := r.queryOperation(http.MethodPost, "/storage-pools/"+url.PathEscape(pool)+"/volumes/"+url.PathEscape(volume.Type), req, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -688,7 +688,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volume.Type)
 
 		// Send the request
-		op, _, err := r.queryOperation("POST", path, req, "", true)
+		op, _, err := r.queryOperation(http.MethodPost, path, req, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -746,7 +746,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volume.Type)
 
 		// Send the request
-		targetOp, _, err := r.queryOperation("POST", path, req, "", true)
+		targetOp, _, err := r.queryOperation(http.MethodPost, path, req, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -819,7 +819,7 @@ func (r *ProtocolLXD) MoveStoragePoolVolume(pool string, source InstanceServer, 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/storage-pools/"+url.PathEscape(sourcePool)+"/volumes/"+url.PathEscape(volume.Type)+"/"+url.PathEscape(volume.Name), req, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/storage-pools/"+url.PathEscape(sourcePool)+"/volumes/"+url.PathEscape(volume.Type)+"/"+url.PathEscape(volume.Name), req, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -854,7 +854,7 @@ func (r *ProtocolLXD) UpdateStoragePoolVolume(pool string, volType string, name 
 
 	// Send the request
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volType) + "/" + url.PathEscape(name)
-	_, _, err = r.query("PUT", path, volume, ETag)
+	_, _, err = r.query(http.MethodPut, path, volume, ETag)
 	if err != nil {
 		return err
 	}
@@ -871,7 +871,7 @@ func (r *ProtocolLXD) DeleteStoragePoolVolume(pool string, volType string, name 
 
 	// Send the request
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volType) + "/" + url.PathEscape(name)
-	_, _, err = r.query("DELETE", path, nil, "")
+	_, _, err = r.query(http.MethodDelete, path, nil, "")
 	if err != nil {
 		return err
 	}
@@ -889,7 +889,7 @@ func (r *ProtocolLXD) RenameStoragePoolVolume(pool string, volType string, name 
 	path := "/storage-pools/" + url.PathEscape(pool) + "/volumes/" + url.PathEscape(volType) + "/" + url.PathEscape(name)
 
 	// Send the request
-	_, _, err = r.query("POST", path, volume, "")
+	_, _, err = r.query(http.MethodPost, path, volume, "")
 	if err != nil {
 		return err
 	}
@@ -907,7 +907,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeBackupNames(pool string, volName strin
 	// Fetch the raw URL values.
 	urls := []string{}
 	baseURL := "/storage-pools/" + url.PathEscape(pool) + "/volumes/custom/" + url.PathEscape(volName) + "/backups"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -926,7 +926,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeBackups(pool string, volName string) (
 	// Fetch the raw value
 	backups := []api.StoragePoolVolumeBackup{}
 
-	_, err = r.queryStruct("GET", "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups?recursion=1", nil, "", &backups)
+	_, err = r.queryStruct(http.MethodGet, "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups?recursion=1", nil, "", &backups)
 	if err != nil {
 		return nil, err
 	}
@@ -943,7 +943,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeBackup(pool string, volName string, na
 
 	// Fetch the raw value
 	backup := api.StoragePoolVolumeBackup{}
-	etag, err := r.queryStruct("GET", "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups/"+url.PathEscape(name), nil, "", &backup)
+	etag, err := r.queryStruct(http.MethodGet, "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups/"+url.PathEscape(name), nil, "", &backup)
 	if err != nil {
 		return nil, "", err
 	}
@@ -959,7 +959,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeBackup(pool string, volName string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups", backup, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups", backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -975,7 +975,7 @@ func (r *ProtocolLXD) RenameStoragePoolVolumeBackup(pool string, volName string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups/"+url.PathEscape(name), backup, "", true)
+	op, _, err := r.queryOperation(http.MethodPost, "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups/"+url.PathEscape(name), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -991,7 +991,7 @@ func (r *ProtocolLXD) DeleteStoragePoolVolumeBackup(pool string, volName string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups/"+url.PathEscape(name), nil, "", true)
+	op, _, err := r.queryOperation(http.MethodDelete, "/storage-pools/"+url.PathEscape(pool)+"/volumes/custom/"+url.PathEscape(volName)+"/backups/"+url.PathEscape(name), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1014,7 +1014,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeBackupFile(pool string, volName string
 	}
 
 	// Prepare the download request
-	request, err := http.NewRequest("GET", uri, nil)
+	request, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1079,7 +1079,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeFromISO(pool string, args StoragePo
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", reqURL, args.BackupFile)
+	req, err := http.NewRequest(http.MethodPost, reqURL, args.BackupFile)
 	if err != nil {
 		return nil, err
 	}
@@ -1144,7 +1144,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeFromBackup(pool string, args Storag
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", reqURL, args.BackupFile)
+	req, err := http.NewRequest(http.MethodPost, reqURL, args.BackupFile)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_warnings.go
+++ b/client/lxd_warnings.go
@@ -2,6 +2,7 @@ package lxd
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -19,7 +20,7 @@ func (r *ProtocolLXD) GetWarningUUIDs() ([]string, error) {
 	// Fetch the raw values.
 	urls := []string{}
 	baseURL := "/warnings"
-	_, err = r.queryStruct("GET", baseURL, nil, "", &urls)
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +38,7 @@ func (r *ProtocolLXD) GetWarnings() ([]api.Warning, error) {
 
 	warnings := []api.Warning{}
 
-	_, err = r.queryStruct("GET", "/warnings?recursion=1", nil, "", &warnings)
+	_, err = r.queryStruct(http.MethodGet, "/warnings?recursion=1", nil, "", &warnings)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func (r *ProtocolLXD) GetWarning(UUID string) (*api.Warning, string, error) {
 
 	warning := api.Warning{}
 
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), nil, "", &warning)
+	etag, err := r.queryStruct(http.MethodGet, fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), nil, "", &warning)
 	if err != nil {
 		return nil, "", err
 	}
@@ -70,7 +71,7 @@ func (r *ProtocolLXD) UpdateWarning(UUID string, warning api.WarningPut, ETag st
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), warning, "")
+	_, _, err = r.query(http.MethodPut, fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), warning, "")
 	if err != nil {
 		return err
 	}
@@ -86,7 +87,7 @@ func (r *ProtocolLXD) DeleteWarning(UUID string) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), nil, "")
+	_, _, err = r.query(http.MethodDelete, fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -160,7 +160,7 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		resp, _, err = d.RawQuery("GET", uri.Path+"/wait?"+uri.RawQuery, "", "")
+		resp, _, err = d.RawQuery(http.MethodGet, uri.Path+"/wait?"+uri.RawQuery, "", "")
 		if err != nil {
 			return err
 		}

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -144,7 +144,7 @@ func devLXDConfigGetHandler(d *Daemon, r *http.Request) *devLXDResponse {
 
 	defer client.Disconnect()
 
-	resp, _, err := client.RawQuery("GET", "/1.0/config", nil, "")
+	resp, _, err := client.RawQuery(http.MethodGet, "/1.0/config", nil, "")
 	if err != nil {
 		return smartResponse(err)
 	}
@@ -181,7 +181,7 @@ func devLXDConfigKeyGetHandler(d *Daemon, r *http.Request) *devLXDResponse {
 
 	defer client.Disconnect()
 
-	resp, _, err := client.RawQuery("GET", "/1.0/config/"+key, nil, "")
+	resp, _, err := client.RawQuery(http.MethodGet, "/1.0/config/"+key, nil, "")
 	if err != nil {
 		return smartResponse(err)
 	}
@@ -220,7 +220,7 @@ func devLXDMetadataGetHandler(d *Daemon, r *http.Request) *devLXDResponse {
 
 	defer client.Disconnect()
 
-	resp, _, err := client.RawQuery("GET", "/1.0/meta-data", nil, "")
+	resp, _, err := client.RawQuery(http.MethodGet, "/1.0/meta-data", nil, "")
 	if err != nil {
 		return smartResponse(err)
 	}
@@ -264,7 +264,7 @@ func devLXDDevicesGetHandler(d *Daemon, r *http.Request) *devLXDResponse {
 
 	defer client.Disconnect()
 
-	resp, _, err := client.RawQuery("GET", "/1.0/devices", nil, "")
+	resp, _, err := client.RawQuery(http.MethodGet, "/1.0/devices", nil, "")
 	if err != nil {
 		return smartResponse(err)
 	}

--- a/lxd-user/callhook/callhook.go
+++ b/lxd-user/callhook/callhook.go
@@ -3,6 +3,7 @@ package callhook
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -85,7 +86,7 @@ func HandleContainerHook(lxdPath string, projectName string, instanceRef string,
 		u.WithQuery("netns", os.Getenv("LXC_NET_NS"))
 	}
 
-	_, _, err = d.RawQuery("GET", u.String(), nil, "")
+	_, _, err = d.RawQuery(http.MethodGet, u.String(), nil, "")
 	if err != nil {
 		return err
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -870,7 +870,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Notify the leader of successful join, possibly triggering
 		// role changes.
-		_, _, err = client.RawQuery("POST", "/internal/cluster/rebalance", nil, "")
+		_, _, err = client.RawQuery(http.MethodPost, "/internal/cluster/rebalance", nil, "")
 		if err != nil {
 			logger.Warnf("Failed to trigger cluster rebalance: %v", err)
 		}
@@ -1138,7 +1138,7 @@ func clusterAcceptMember(client lxd.InstanceServer, name string, address string,
 	}
 
 	info := &internalClusterPostAcceptResponse{}
-	resp, _, err := client.RawQuery("POST", "/internal/cluster/accept", req, "")
+	resp, _, err := client.RawQuery(http.MethodPost, "/internal/cluster/accept", req, "")
 	if err != nil {
 		return nil, err
 	}
@@ -2667,7 +2667,7 @@ func changeMemberRole(s *state.State, r *http.Request, address string, nodes []d
 		return err
 	}
 
-	_, _, err = client.RawQuery("POST", "/internal/cluster/assign", post, "")
+	_, _, err = client.RawQuery(http.MethodPost, "/internal/cluster/assign", post, "")
 	if err != nil {
 		return err
 	}
@@ -2714,7 +2714,7 @@ findLeader:
 		return fmt.Errorf("Failed handing over cluster member role: %w", err)
 	}
 
-	_, _, err = client.RawQuery("POST", "/internal/cluster/handover", post, "")
+	_, _, err = client.RawQuery(http.MethodPost, "/internal/cluster/handover", post, "")
 	if err != nil {
 		return err
 	}
@@ -4594,7 +4594,7 @@ func autoHealCluster(_ context.Context, s *state.State, offlineMembers []db.Node
 
 	for _, member := range offlineMembers {
 		logger.Info("Healing cluster member instances", logger.Ctx{"member": member.Name})
-		_, _, err = dest.RawQuery("POST", "/internal/cluster/heal/"+member.Name, nil, "")
+		_, _, err = dest.RawQuery(http.MethodPost, "/internal/cluster/heal/"+member.Name, nil, "")
 		if err != nil {
 			return fmt.Errorf("Failed evacuating cluster member %q: %w", member.Name, err)
 		}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -995,7 +995,7 @@ func attemptGetLeaderAddressFromNodeAddress(ctx context.Context, transport http.
 	}
 
 	url := "https://" + nodeAddress + databaseEndpoint
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -536,7 +536,7 @@ func HeartbeatNode(taskCtx context.Context, address string, networkCert *shared.
 		return err
 	}
 
-	request, err := http.NewRequest("PUT", url, bytes.NewReader(buffer.Bytes()))
+	request, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(buffer.Bytes()))
 	if err != nil {
 		return err
 	}

--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -34,7 +34,7 @@ func NotifyUpgradeCompleted(state *state.State, networkCert *shared.CertInfo, se
 		}
 
 		url := info.Addresses[0] + databaseEndpoint
-		request, err := http.NewRequest("PATCH", url, nil)
+		request, err := http.NewRequest(http.MethodPatch, url, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create database notify upgrade request: %w", err)
 		}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -474,7 +474,7 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 
 		httpTransport.ResponseHeaderTimeout = 30 * time.Second
 
-		req, err := http.NewRequest("GET", args.Server, nil)
+		req, err := http.NewRequest(http.MethodGet, args.Server, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2245,7 +2245,7 @@ func distributeImage(ctx context.Context, s *state.State, nodes []string, oldFin
 				Pool:  poolName,
 			}
 
-			_, _, err = client.RawQuery("POST", "/internal/image-optimize", req, "")
+			_, _, err = client.RawQuery(http.MethodPost, "/internal/image-optimize", req, "")
 			if err != nil {
 				logger.Error("Failed creating new image in storage pool", logger.Ctx{"err": err, "remote": nodeAddress, "pool": poolName, "fingerprint": newImage.Fingerprint})
 			}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1967,7 +1967,7 @@ func (d *qemu) advertiseVsockAddress() error {
 		return nil
 	}
 
-	_, _, err = agent.RawQuery("PUT", "/1.0", connInfo, "")
+	_, _, err = agent.RawQuery(http.MethodPut, "/1.0", connInfo, "")
 	if err != nil {
 		return fmt.Errorf("Failed sending VM sock address to lxd-agent: %w", err)
 	}
@@ -8689,7 +8689,7 @@ func (d *qemu) devlxdEventSend(eventType string, eventMessage map[string]any) er
 
 	defer agent.Disconnect()
 
-	_, _, err = agent.RawQuery("POST", "/1.0/events", &event, "")
+	_, _, err = agent.RawQuery(http.MethodPost, "/1.0/events", &event, "")
 	if err != nil {
 		return err
 	}
@@ -9003,7 +9003,7 @@ func (d *qemu) getAgentMetrics() (*metrics.MetricSet, error) {
 
 	defer agent.Disconnect()
 
-	resp, _, err := agent.RawQuery("GET", "/1.0/metrics", nil, "")
+	resp, _, err := agent.RawQuery(http.MethodGet, "/1.0/metrics", nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -454,7 +454,7 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 
 	if client != nil {
 		url := api.NewURL().Path(version.APIVersion, "instances", name, "console").Project(projectName)
-		resp, _, err := client.RawQuery("POST", url.String(), post, "")
+		resp, _, err := client.RawQuery(http.MethodPost, url.String(), post, "")
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -590,7 +590,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 
 	if client != nil {
 		url := api.NewURL().Path(version.APIVersion, "instances", name, "exec").Project(projectName)
-		resp, _, err := client.RawQuery("POST", url.String(), post, "")
+		resp, _, err := client.RawQuery(http.MethodPost, url.String(), post, "")
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -110,7 +110,7 @@ func instanceRefreshTypes(ctx context.Context, s *state.State) error {
 			return err
 		}
 
-		httpReq, err := http.NewRequest("GET", url, nil)
+		httpReq, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/loki/loki.go
+++ b/lxd/loki/loki.go
@@ -161,7 +161,7 @@ func (c *Client) run() {
 }
 
 func (c *Client) checkLoki(ctx context.Context) error {
-	req, err := http.NewRequest("GET", c.cfg.url.String()+"/ready", nil)
+	req, err := http.NewRequest(http.MethodGet, c.cfg.url.String()+"/ready", nil)
 	if err != nil {
 		return err
 	}
@@ -226,7 +226,7 @@ func (c *Client) sendBatch(batch *batch) {
 }
 
 func (c *Client) send(ctx context.Context, buf []byte) (int, error) {
-	req, err := http.NewRequest("POST", c.cfg.url.String()+"/loki/api/v1/push", bytes.NewReader(buf))
+	req, err := http.NewRequest(http.MethodPost, c.cfg.url.String()+"/loki/api/v1/push", bytes.NewReader(buf))
 	if err != nil {
 		return -1, err
 	}

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -531,7 +532,7 @@ func (c *cmdClusterRemoveRaftNode) Run(cmd *cobra.Command, args []string) error 
 	}
 
 	endpoint := "/internal/cluster/raft-node/" + address
-	_, _, err = client.RawQuery("DELETE", endpoint, nil, "")
+	_, _, err = client.RawQuery(http.MethodDelete, endpoint, nil, "")
 	if err != nil {
 		return err
 	}

--- a/lxd/main_migratedumpsuccess.go
+++ b/lxd/main_migratedumpsuccess.go
@@ -16,6 +16,7 @@ type cmdMigratedumpsuccess struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command object representing the "migratedumpsuccess" command.
 func (c *cmdMigratedumpsuccess) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "migratedumpsuccess <operation> <secret>"
@@ -32,6 +33,7 @@ func (c *cmdMigratedumpsuccess) Command() *cobra.Command {
 	return cmd
 }
 
+// Run executes the "migratedumpsuccess" command.
 func (c *cmdMigratedumpsuccess) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	if len(args) < 2 {

--- a/lxd/main_migratedumpsuccess.go
+++ b/lxd/main_migratedumpsuccess.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -65,7 +66,7 @@ func (c *cmdMigratedumpsuccess) Run(cmd *cobra.Command, args []string) error {
 
 	_ = conn.Close()
 
-	resp, _, err := d.RawQuery("GET", fmt.Sprintf("%s/wait", args[0]), nil, "")
+	resp, _, err := d.RawQuery(http.MethodGet, fmt.Sprintf("%s/wait", args[0]), nil, "")
 	if err != nil {
 		return err
 	}

--- a/lxd/main_recover.go
+++ b/lxd/main_recover.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -181,7 +182,7 @@ func (c *cmdRecover) run(cmd *cobra.Command, args []string) error {
 	reqValidate.Pools = append(reqValidate.Pools, unknownPools...)
 
 	for {
-		resp, _, err := d.RawQuery("POST", "/internal/recover/validate", reqValidate, "")
+		resp, _, err := d.RawQuery(http.MethodPost, "/internal/recover/validate", reqValidate, "")
 		if err != nil {
 			return fmt.Errorf("Failed validation request: %w", err)
 		}
@@ -243,7 +244,7 @@ func (c *cmdRecover) run(cmd *cobra.Command, args []string) error {
 		Pools: reqValidate.Pools,
 	}
 
-	_, _, err = d.RawQuery("POST", "/internal/recover/import", reqImport, "")
+	_, _, err = d.RawQuery(http.MethodPost, "/internal/recover/import", reqImport, "")
 	if err != nil {
 		return fmt.Errorf("Failed import request: %w", err)
 	}

--- a/lxd/main_shutdown.go
+++ b/lxd/main_shutdown.go
@@ -66,7 +66,7 @@ func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 		httpTransport := httpClient.Transport.(*http.Transport)
 		httpTransport.ResponseHeaderTimeout = 3600 * time.Second
 
-		_, _, err = d.RawQuery("PUT", fmt.Sprintf("/internal/shutdown?%s", v.Encode()), nil, "")
+		_, _, err = d.RawQuery(http.MethodPut, fmt.Sprintf("/internal/shutdown?%s", v.Encode()), nil, "")
 		if err != nil {
 			chResult <- err
 			return

--- a/lxd/main_shutdown.go
+++ b/lxd/main_shutdown.go
@@ -63,7 +63,12 @@ func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Request shutdown, this shouldn't return until daemon has stopped so use a large request timeout.
-		httpTransport := httpClient.Transport.(*http.Transport)
+		httpTransport, ok := httpClient.Transport.(*http.Transport)
+		if !ok {
+			chResult <- fmt.Errorf("httpClient.Transport is not *http.Transport")
+			return
+		}
+
 		httpTransport.ResponseHeaderTimeout = 3600 * time.Second
 
 		_, _, err = d.RawQuery(http.MethodPut, fmt.Sprintf("/internal/shutdown?%s", v.Encode()), nil, "")

--- a/lxd/main_shutdown.go
+++ b/lxd/main_shutdown.go
@@ -19,6 +19,7 @@ type cmdShutdown struct {
 	flagTimeout int
 }
 
+// Command returns a cobra.Command object representing the "shutdown" command.
 func (c *cmdShutdown) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "shutdown"
@@ -39,6 +40,7 @@ func (c *cmdShutdown) Command() *cobra.Command {
 	return cmd
 }
 
+// Run executes the "shutdown" command.
 func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 	connArgs := &lxd.ConnectionArgs{
 		SkipGetServer: true,

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -104,7 +105,7 @@ func (c *cmdSQL) run(cmd *cobra.Command, args []string) error {
 			url += "&schema=1"
 		}
 
-		response, _, err := d.RawQuery("GET", url, nil, "")
+		response, _, err := d.RawQuery(http.MethodGet, url, nil, "")
 		if err != nil {
 			return fmt.Errorf("failed to request dump: %w", err)
 		}
@@ -124,7 +125,7 @@ func (c *cmdSQL) run(cmd *cobra.Command, args []string) error {
 		Query:    query,
 	}
 
-	response, _, err := d.RawQuery("POST", "/internal/sql", data, "")
+	response, _, err := d.RawQuery(http.MethodPost, "/internal/sql", data, "")
 	if err != nil {
 		return err
 	}

--- a/lxd/main_waitready.go
+++ b/lxd/main_waitready.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -67,7 +68,7 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 				logger.Debugf("Checking if LXD daemon is ready (attempt %d)", i)
 			}
 
-			_, _, err = d.RawQuery("GET", "/internal/ready", nil, "")
+			_, _, err = d.RawQuery(http.MethodGet, "/internal/ready", nil, "")
 			if err != nil {
 				errLast = err
 				if doLog {

--- a/lxd/main_waitready.go
+++ b/lxd/main_waitready.go
@@ -89,7 +89,6 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 	if c.flagTimeout > 0 {
 		select {
 		case <-finger:
-			break
 		case <-time.After(time.Second * time.Duration(c.flagTimeout)):
 			return fmt.Errorf("LXD still not running after %ds timeout (%v)", c.flagTimeout, errLast)
 		}

--- a/lxd/main_waitready.go
+++ b/lxd/main_waitready.go
@@ -17,6 +17,7 @@ type cmdWaitready struct {
 	flagTimeout int
 }
 
+// Command returns a cobra.Command object representing the "waitready" command.
 func (c *cmdWaitready) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "waitready"
@@ -34,6 +35,7 @@ func (c *cmdWaitready) Command() *cobra.Command {
 	return cmd
 }
 
+// Run executes the "waitready" command.
 func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 	finger := make(chan error, 1)
 	var errLast error

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -490,7 +490,7 @@ func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, 
 	}
 
 	// Connect
-	req, err := http.NewRequest("GET", address, nil)
+	req, err := http.NewRequest(http.MethodGet, address, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -103,7 +103,7 @@ func (s *SimpleStreams) cachedDownload(path string) ([]byte, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", uri, nil)
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/util.go
+++ b/shared/util.go
@@ -1219,7 +1219,7 @@ func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent st
 	if ctx != nil {
 		req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
 	} else {
-		req, err = http.NewRequest("GET", url, nil)
+		req, err = http.NewRequest(http.MethodGet, url, nil)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Replaces http method string literals with `http` package constants across entire codebase.