### PR TITLE
lxd: Improve clustering start up checks

### DIFF
--- a/lxd-user/main.go
+++ b/lxd-user/main.go
@@ -16,7 +16,7 @@ type cmdGlobal struct {
 func main() {
 	// daemon command (main)
 	daemonCmd := cmdDaemon{}
-	app := daemonCmd.Command()
+	app := daemonCmd.command()
 	app.Use = "lxd-user"
 	app.Short = "LXD user project daemon"
 	app.Long = `Description:

--- a/lxd-user/main_daemon.go
+++ b/lxd-user/main_daemon.go
@@ -21,15 +21,15 @@ var transactions uint64
 
 type cmdDaemon struct{}
 
-func (c *cmdDaemon) Command() *cobra.Command {
+func (c *cmdDaemon) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "lxd-user"
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 	// Setup logger.
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp: true,
@@ -100,7 +100,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 					mu.RUnlock()
 
 					// Daemon has been inactive for 10s, exit.
-					os.Exit(0)
+					os.Exit(0) //nolint:revive
 				}
 
 				mu.RUnlock()

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -529,6 +529,10 @@ func (g *Gateway) Shutdown() error {
 	}
 
 	err = g.server.Close()
+	if err != nil {
+		logger.Error("Failed stopping dqlite", logger.Ctx{"err": err})
+	}
+
 	close(g.stopCh)
 
 	// Unset the memory dial, since Shutdown() is also called for

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -520,32 +520,34 @@ func (g *Gateway) Shutdown() error {
 	logger.Info("Stop database gateway")
 
 	var err error
-	if g.server != nil {
-		if g.info.Role == db.RaftVoter {
-			g.Sync()
-		}
-
-		err = g.server.Close()
-		close(g.stopCh)
-
-		// Unset the memory dial, since Shutdown() is also called for
-		// switching between in-memory and network mode.
-		g.lock.Lock()
-		g.memoryDial = nil
-		g.lock.Unlock()
-
-		// Record the raft term and index in the logs on every shutdown. This
-		// allows an administrator to determine the furthest-ahead cluster member
-		// in case recovery is needed.
-		lastEntryInfo, err := dqlite.ReadLastEntryInfo(g.db.Dir())
-		if err != nil {
-			return err
-		}
-
-		// This isn't really a warning, but it's important that this break through
-		// the snap's default log level of 'Warn'.
-		logger.Warn("Dqlite last entry", logger.Ctx{"term": lastEntryInfo.Term, "index": lastEntryInfo.Index})
+	if g.server == nil {
+		return nil
 	}
+
+	if g.info.Role == db.RaftVoter {
+		g.Sync()
+	}
+
+	err = g.server.Close()
+	close(g.stopCh)
+
+	// Unset the memory dial, since Shutdown() is also called for
+	// switching between in-memory and network mode.
+	g.lock.Lock()
+	g.memoryDial = nil
+	g.lock.Unlock()
+
+	// Record the raft term and index in the logs on every shutdown. This
+	// allows an administrator to determine the furthest-ahead cluster member
+	// in case recovery is needed.
+	lastEntryInfo, err := dqlite.ReadLastEntryInfo(g.db.Dir())
+	if err != nil {
+		return err
+	}
+
+	// This isn't really a warning, but it's important that this break through
+	// the snap's default log level of 'Warn'.
+	logger.Warn("Dqlite last entry", logger.Ctx{"term": lastEntryInfo.Term, "index": lastEntryInfo.Index})
 
 	return err
 }

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -1061,7 +1062,12 @@ func Handover(state *state.State, gateway *Gateway, address string) (string, []d
 	}
 
 	if nodeID == 0 {
-		return "", nil, fmt.Errorf("No dqlite node has address %s: %w", address, err)
+		raftNodeAddresses := make([]string, 0, len(nodes))
+		for _, node := range nodes {
+			raftNodeAddresses = append(raftNodeAddresses, node.Address)
+		}
+
+		return "", nil, fmt.Errorf("No dqlite node has address %s (%s)", address, strings.Join(raftNodeAddresses, ","))
 	}
 
 	roles, err := newRolesChanges(state, gateway, nodes, nil)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1376,6 +1376,11 @@ func (d *Daemon) init() error {
 	localClusterAddress := d.localConfig.ClusterAddress()
 	debugAddress := d.localConfig.DebugAddress()
 
+	// Sense check for clustering mode.
+	if localClusterAddress == "" && d.serverClustered {
+		return fmt.Errorf("Server is clustered (has local raft addresses) but cluster.https_address is not set")
+	}
+
 	/* Setup dqlite */
 	clusterLogLevel := "ERROR"
 	if shared.ValueInSlice("dqlite", trace) {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2041,6 +2041,8 @@ func cancelCancelableOps() error {
 func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 	logger.Info("Starting shutdown sequence", logger.Ctx{"signal": sig})
 
+	s := d.State()
+
 	// Cancelling the context will make everyone aware that we're shutting down.
 	d.shutdownCancel()
 
@@ -2053,8 +2055,6 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 			d.gateway.Kill()
 		}
 	}
-
-	s := d.State()
 
 	// Stop any running minio processes cleanly before unmount storage pools.
 	miniod.StopAll()

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -137,7 +137,7 @@ func EnsureSchema(db *sql.DB, address string, dir string) error {
 		// Update the schema and api_extension columns of ourselves.
 		err = updateNodeVersion(tx, address, apiExtensions)
 		if err != nil {
-			return fmt.Errorf("Failed to update cluster member version info: %w", err)
+			return fmt.Errorf("Failed to update cluster member version info for %q: %w", address, err)
 		}
 
 		return checkClusterIsUpgradable(ctx, tx, [2]int{len(updates), apiExtensions})

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -132,7 +132,7 @@ func main() {
 
 	// forkfile sub-command
 	forkfileCmd := cmdForkfile{global: &globalCmd}
-	app.AddCommand(forkfileCmd.Command())
+	app.AddCommand(forkfileCmd.command())
 
 	// forklimits sub-command
 	forklimitsCmd := cmdForklimits{global: &globalCmd}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -84,7 +84,7 @@ func (c *cmdGlobal) rawArgs(cmd *cobra.Command) []string {
 func main() {
 	// daemon command (main)
 	daemonCmd := cmdDaemon{}
-	app := daemonCmd.Command()
+	app := daemonCmd.command()
 	app.SilenceUsage = true
 	app.CompletionOptions = cobra.CompletionOptions{DisableDefaultCmd: true}
 

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -21,7 +21,7 @@ type cmdDaemon struct {
 	flagGroup string
 }
 
-func (c *cmdDaemon) Command() *cobra.Command {
+func (c *cmdDaemon) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "lxd"
 	cmd.Short = "The LXD container manager (daemon)"
@@ -34,13 +34,13 @@ func (c *cmdDaemon) Command() *cobra.Command {
   There are however a number of subcommands that let you interact directly with
   the local LXD daemon and which may not be performed through the REST API alone.
 `
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVar(&c.flagGroup, "group", "", "The group of users that will be allowed to talk to LXD"+"``")
 
 	return cmd
 }
 
-func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 || (len(args) == 1 && args[0] != "daemon" && args[0] != "") {
 		return fmt.Errorf("unknown command \"%s\" for \"%s\"", args[0], cmd.CommandPath())
 	}

--- a/lxd/main_forkfile.go
+++ b/lxd/main_forkfile.go
@@ -101,7 +101,7 @@ type cmdForkfile struct {
 	global *cmdGlobal
 }
 
-func (c *cmdForkfile) Command() *cobra.Command {
+func (c *cmdForkfile) command() *cobra.Command {
 	// Main subcommand
 	cmd := &cobra.Command{}
 	cmd.Use = "forkfile <listen fd> <rootfs fd> <PIDFd> <PID>"
@@ -118,12 +118,12 @@ func (c *cmdForkfile) Command() *cobra.Command {
 `
 	cmd.Hidden = true
 	cmd.Args = cobra.ExactArgs(4)
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdForkfile) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdForkfile) run(cmd *cobra.Command, args []string) error {
 	var mu sync.RWMutex
 	var connections uint64
 	var transactions uint64
@@ -172,7 +172,7 @@ func (c *cmdForkfile) Run(cmd *cobra.Command, args []string) error {
 				mu.RUnlock()
 
 				// Daemon has been inactive for 10s, exit.
-				os.Exit(0)
+				os.Exit(0) //nolint:revive
 			}
 
 			mu.RUnlock()
@@ -202,7 +202,7 @@ func (c *cmdForkfile) Run(cmd *cobra.Command, args []string) error {
 			time.Sleep(time.Second)
 		}
 
-		os.Exit(0)
+		os.Exit(0) //nolint:revive
 	}()
 
 	// Connection handler.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1799,6 +1799,10 @@ func networkShutdown(s *state.State) {
 	// Get a list of projects.
 	var projectNames []string
 
+	if s.DB.Cluster == nil {
+		return
+	}
+
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		projectNames, err = dbCluster.GetProjectNames(ctx, tx.Tx())
 		return err


### PR DESCRIPTION
In some cases the `cluster.https_address` can become unset in the local DB and this can cause LXD to try and start up
in standalone mode and enter a start up loop that cannot be easily stopped.

Adds sense check to detect when this situation occurs.
