### PR TITLE
lxd: Use `api.NewURL()` to construct `network-acl` result urls

### DIFF
--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -235,7 +235,7 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 			}
 
 			if !recursion {
-				resultString = append(resultString, fmt.Sprintf("/%s/network-acls/%s", version.APIVersion, aclName))
+				resultString = append(resultString, api.NewURL().Path(version.APIVersion, "network-acls", aclName).String())
 			} else {
 				var netACL acl.NetworkACL
 				if !allProjects {


### PR DESCRIPTION
Follow up to https://github.com/canonical/lxd/pull/15369.