### PR TITLE
VM: Use fresh state in `expireLogsTask`

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1926,7 +1926,7 @@ func (d *Daemon) init() error {
 	//        but has not been fully completed.
 	if !d.os.MockMode {
 		// Log expiry (daily)
-		d.tasks.Add(expireLogsTask(d.State()))
+		d.tasks.Add(expireLogsTask(d))
 
 		// Remove expired images (daily)
 		d.taskPruneImages = d.tasks.Add(pruneExpiredImagesTask(d))

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -19,7 +19,7 @@ import (
 
 // This task function expires logs when executed. It's started by the Daemon
 // and will run once every 24h.
-func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
+func expireLogsTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
 		opRun := func(op *operations.Operation) error {
 			return expireLogs(ctx, state)

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -21,6 +21,8 @@ import (
 // and will run once every 24h.
 func expireLogsTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
+		state := d.State()
+
 		opRun := func(op *operations.Operation) error {
 			return expireLogs(ctx, state)
 		}


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14791.

This pull request refactors the `expireLogsTask` functions to use the `Daemon` struct directly instead of the `state.State` object to avoid using a long lived state. 