### PR TITLE
lxd: When shutting down by request ensure non-error exit status

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -279,10 +279,9 @@ func internalShutdown(d *Daemon, r *http.Request) response.Response {
 
 		f.Flush()
 
-		// Send result of d.Stop() to cmdDaemon so that process stops with correct exit code from Stop().
 		go func() {
-			<-r.Context().Done() // Wait until request is finished.
-			d.shutdownDoneCh <- stopErr
+			<-r.Context().Done()    // Wait until request is finished.
+			d.shutdownDoneCh <- nil // Send nil error to cmdDaemon to ensure LXD isn't restarted by systemd.
 		}()
 
 		return nil

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -87,7 +87,8 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 				logger.Warn("Ignoring signal, shutdown already in progress", logger.Ctx{"signal": sig})
 			} else {
 				go func() {
-					d.shutdownDoneCh <- d.Stop(context.Background(), sig)
+					_ = d.Stop(context.Background(), sig)
+					d.shutdownDoneCh <- nil // Send nil error to cmdDaemon to ensure LXD isn't restarted by systemd.
 				}()
 			}
 


### PR DESCRIPTION
To prevent systemd from restarting the service.