### PR TITLE
doc: Move contributing out of "Getting Started"

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -31,14 +31,13 @@ How to enable access to the UI and the documentation:
 ```
 
 ```{only} diataxis
-How to get support and contribute:
+How to get support:
 ```
 
 ```{filtered-toctree}
 :maxdepth: 1
 
 :diataxis:Get support </support>
-:diataxis:Contribute to LXD </contributing>
 ```
 
 In addition, the following clip gives a quick and easy introduction for standard use cases:
@@ -73,6 +72,5 @@ You can also find a series of demos and tutorials on YouTube:
 :topical:Access the UI </howto/access_ui>
 :topical:Access the documentation </howto/access_documentation>
 :topical:Frequently asked </faq>
-:topical:Contribute to LXD </contributing>
 :topical:Get support </support>
 ```

--- a/doc/howto/index.md
+++ b/doc/howto/index.md
@@ -48,3 +48,15 @@ You should also monitor your server or servers and configure them for the expect
 /clustering
 /production-setup
 ```
+
+(howtos-contribute)=
+## Contribute to LXD
+
+Learn how to contribute to the code or documentation for LXD.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Contribute to LXD </contributing>
+```


### PR DESCRIPTION
Contributing guidelines should be a little easier to find in the docs.

Also, I noticed that the diff of `CONTRIBUTING.md` and `doc/contributing.md` is quite substantial; should these documents be maintained as one document instead?