### PR TITLE
lxc/config: Make the images remote static

### DIFF
--- a/lxc/config/default.go
+++ b/lxc/config/default.go
@@ -10,6 +10,7 @@ var LocalRemote = Remote{
 // ImagesRemote is the main image server (over simplestreams).
 var ImagesRemote = Remote{
 	Addr:     "https://images.lxd.canonical.com",
+	Static:   true,
 	Public:   true,
 	Protocol: "simplestreams",
 }


### PR DESCRIPTION
The images remote is hard-coded and is therefore static.

(part 2 of #15311)