### PR TITLE
lxc/completion: Use filters when completing remotes

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -128,7 +128,7 @@ func (c *cmdClusterList) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", false, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -693,7 +693,7 @@ func (c *cmdClusterEnable) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -986,7 +986,7 @@ func (c *cmdClusterListTokens) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -184,7 +184,7 @@ lxc cluster group create g1 < config.yaml
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -450,7 +450,7 @@ func (c *cmdClusterGroupList) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxc/config"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -1215,40 +1216,73 @@ func (g *cmdGlobal) cmpProjectConfigs(projectName string) ([]string, cobra.Shell
 	return configs, cobra.ShellCompDirectiveNoFileComp
 }
 
+// remoteCompletionFilter is passed into cmpRemotes to determine which remotes to include in the result.
+// Filter functions must match positively. E.g. Return true to filter the remote from the result.
+type remoteCompletionFilter func(name string, remote config.Remote) bool
+
+// filterDefault returns a function that returns true if the given remote name equals the default remote.
+func filterDefaultRemote(conf config.Config) remoteCompletionFilter {
+	return func(name string, remote config.Remote) bool {
+		return name == conf.DefaultRemote
+	}
+}
+
+// filterPublicRemotes returns true if the remote is public (e.g. cannot create instances).
+func filterPublicRemotes(name string, remote config.Remote) bool {
+	return remote.Public
+}
+
+// filterStaticRemotes returns true if the remote is static (cannot be modified).
+func filterStaticRemotes(name string, remote config.Remote) bool {
+	return remote.Static
+}
+
+// filterGlobalRemotes returns true if the remote is global (cannot be removed).
+func filterGlobalRemotes(name string, remote config.Remote) bool {
+	return remote.Global
+}
+
+// instanceServerRemoteCompletionFilters returns a slice of remoteCompletionFilter for use when a command requires an
+// instance server only.
+func instanceServerRemoteCompletionFilters(conf config.Config) []remoteCompletionFilter {
+	return []remoteCompletionFilter{
+		filterPublicRemotes,
+		filterDefaultRemote(conf),
+	}
+}
+
+// imageServerRemoteCompletionFilters returns a slice of remoteCompletionFilter for use when a command requires an image
+// server (including instance servers).
+func imageServerRemoteCompletionFilters(conf config.Config) []remoteCompletionFilter {
+	return []remoteCompletionFilter{
+		filterDefaultRemote(conf),
+	}
+}
+
 // cmpRemotes provides shell completion for remotes.
-// It takes a boolean specifying whether to include all remotes or not and returns a list of remotes along with a shell completion directive.
-func (g *cmdGlobal) cmpRemotes(toComplete string, includeAll bool) ([]string, cobra.ShellCompDirective) {
+// It accepts a completion string, a suffix (usually a ":"), a boolean to indicate whether the cobra.ShellCompDirectiveNoSpace should be included
+// and a list of filters. The filters are used to return only applicable remotes dependant on usage. For example, if listing images we should
+// complete for all remotes (image servers and instance servers). If listing instances we should return only instance servers.
+func (g *cmdGlobal) cmpRemotes(toComplete string, suffix string, noSpace bool, filters ...remoteCompletionFilter) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 
+remoteLoop:
 	for remoteName, rc := range g.conf.Remotes {
-		if remoteName == "local" && g.conf.DefaultRemote == "local" || remoteName == g.conf.DefaultRemote || (!includeAll && rc.Protocol != "lxd" && rc.Protocol != "") {
-			continue
-		}
-
 		if !strings.HasPrefix(remoteName, toComplete) {
 			continue
 		}
 
-		results = append(results, remoteName+":")
-	}
-
-	if len(results) > 0 {
-		return results, cobra.ShellCompDirectiveNoSpace
-	}
-
-	return results, cobra.ShellCompDirectiveNoFileComp
-}
-
-// cmpRemoteNames provides shell completion for remote names.
-// It returns a list of remote names provided by `g.conf.Remotes` along with a shell completion directive.
-func (g *cmdGlobal) cmpRemoteNames(includeDefaultRemote bool) ([]string, cobra.ShellCompDirective) {
-	results := make([]string, 0, len(g.conf.Remotes))
-	for remoteName := range g.conf.Remotes {
-		if !includeDefaultRemote && remoteName == g.conf.DefaultRemote {
-			continue
+		for _, f := range filters {
+			if f(remoteName, rc) {
+				continue remoteLoop
+			}
 		}
 
-		results = append(results, remoteName)
+		results = append(results, remoteName+suffix)
+	}
+
+	if noSpace {
+		return results, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
 
 	return results, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -71,7 +71,7 @@ The pull transfer mode is the default as it is compatible with all LXD versions.
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -179,7 +179,7 @@ It requires the source to be an alias and for it to be public.`))
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -712,7 +712,7 @@ Descriptive properties can be set by providing key=value pairs. Example: os=Ubun
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1125,7 +1125,7 @@ Column shorthand chars:
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpImages(toComplete)
+		return c.global.cmpRemotes(toComplete, ":", false, imageServerRemoteCompletionFilters(*c.global.conf)...)
 	}
 
 	return cmd

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -68,7 +68,7 @@ func (c *cmdImageAliasCreate) command() *cobra.Command {
 		}
 
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, true)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		remote, _, found := strings.Cut(args[0], ":")
@@ -188,7 +188,7 @@ Filters may be part of the image hash or part of the image alias name.
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpRemotes(toComplete, true)
+		return c.global.cmpRemotes(toComplete, ":", true, imageServerRemoteCompletionFilters(*c.global.conf)...)
 	}
 
 	return cmd

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -136,7 +136,7 @@ lxc list -c ns,user.comment:comment
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -75,7 +75,7 @@ lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -342,7 +342,7 @@ lxc network create bar network=baz --type ovn
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpRemotes(toComplete, false)
+		return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 	}
 
 	return cmd
@@ -1027,7 +1027,7 @@ func (c *cmdNetworkList) command() *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpRemotes(toComplete, false)
+		return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 	}
 
 	return cmd

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -101,7 +101,7 @@ func (c *cmdNetworkACLList) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -92,7 +92,7 @@ func (c *cmdNetworkZoneList) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -376,7 +376,7 @@ lxc profile create p1 < config.yaml
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -739,7 +739,7 @@ u - Used By`))
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -109,7 +109,7 @@ lxc project create p1 < config.yaml
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -483,7 +483,7 @@ func (c *cmdProjectList) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -48,7 +48,7 @@ func (c *cmdPublish) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -877,7 +877,7 @@ func (c *cmdRemoteRename) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames(true)
+			return c.global.cmpRemotes(toComplete, "", false, filterStaticRemotes)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -958,7 +958,7 @@ func (c *cmdRemoteRemove) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames(false)
+			return c.global.cmpRemotes(toComplete, "", false, filterStaticRemotes, filterGlobalRemotes, filterDefaultRemote(*c.global.conf))
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1022,7 +1022,8 @@ func (c *cmdRemoteSwitch) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames(false)
+			// It's valid to switch to a public remote, but filter them from completions to prevent leading new users down a bad path.
+			return c.global.cmpRemotes(toComplete, "", false, filterDefaultRemote(*c.global.conf), filterPublicRemotes)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1070,7 +1071,7 @@ func (c *cmdRemoteSetURL) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames(true)
+			return c.global.cmpRemotes(toComplete, "", false, filterStaticRemotes)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -107,7 +107,7 @@ lxc storage create s1 dir < config.yaml
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -660,7 +660,7 @@ func (c *cmdStorageList) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemotes(toComplete, false)
+			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
We currently have a boolean to indicate if `cmpRemotes` should return all remotes, or just those that are not image servers (minus the default). This isn't specific enough when completing for commands such as `lxc remote set-url`, which cannot be performed on static remotes.

This is part 4 of splitting up #15311 and depends on #15458 (marking as draft until that is merged).