### PR TITLE
lxd: No need to call /1.0 repeatedly in waitready

### DIFF
--- a/lxd/main_waitready.go
+++ b/lxd/main_waitready.go
@@ -55,7 +55,9 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 				logger.Debugf("Connecting to LXD daemon (attempt %d)", i)
 			}
 
-			d, err := lxd.ConnectLXDUnix("", nil)
+			d, err := lxd.ConnectLXDUnix("", &lxd.ConnectionArgs{
+				SkipGetServer: true,
+			})
 			if err != nil {
 				errLast = err
 				if doLog {


### PR DESCRIPTION
We are calling `/internal/ready` in a loop already, so no need to call `/1.0` in a loop too.