### PR TITLE
lxc: Config option completion

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -665,36 +665,56 @@ func (g *cmdGlobal) cmpDeviceSubtype(remote string, deviceType string, prefix st
 }
 
 // cmpInstanceAllDeviceOptions provides shell completion for all instance device options.
-// It takes an instance name and device name and returns a list of all possible instance device options along with a shell completion directive.
-func (g *cmdGlobal) cmpInstanceAllDeviceOptions(instanceName string, deviceName string) ([]string, cobra.ShellCompDirective) {
-	resources, err := g.ParseServers(instanceName)
-	if err != nil || len(resources) == 0 {
-		return nil, cobra.ShellCompDirectiveError
+// It takes an instance name and device type and returns a list of all possible instance device options along with a shell completion directive.
+// If the subtype is given, only options supported by that subtype will be returned.
+func (g *cmdGlobal) cmpInstanceAllDeviceOptions(remote string, deviceType string, subtype string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := g.conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{SkipGetServer: true})
+	if err != nil {
+		return handleCompletionError(err)
 	}
-
-	resource := resources[0]
-	client := resource.server
 
 	metadataConfiguration, err := client.GetMetadataConfiguration()
 	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
+		return handleCompletionError(err)
 	}
 
-	deviceOptions := make([]string, 0, len(metadataConfiguration.Configs))
-
+	appendOption, result := configOptionAppender(toComplete, "=", -1)
 	for key, device := range metadataConfiguration.Configs {
+		if !strings.HasPrefix(key, "device-") {
+			continue
+		}
+
 		parts := strings.Split(key, "-")
-		if strings.HasPrefix(key, "device-") && parts[1] == deviceName {
+		metadataDeviceType := parts[1]
+		if metadataDeviceType == "unix" && len(parts) > 2 {
+			if parts[2] == "usb" {
+				metadataDeviceType = "usb"
+			} else {
+				metadataDeviceType += "-" + parts[2]
+			}
+		}
+
+		if metadataDeviceType == deviceType {
+			if subtype != "" {
+				if len(parts) < 3 {
+					continue
+				}
+
+				if parts[2] != subtype {
+					continue
+				}
+			}
+
 			conf := device["device-conf"]
 			for _, keyMap := range conf.Keys {
 				for option := range keyMap {
-					deviceOptions = append(deviceOptions, option)
+					appendOption(option)
 				}
 			}
 		}
 	}
 
-	return deviceOptions, cobra.ShellCompDirectiveNoFileComp
+	return result(), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 }
 
 // cmpInstancesAction provides shell completion for all instance actions (start, pause, exec, stop and delete).

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -389,12 +389,6 @@ func (g *cmdGlobal) cmpImages(toComplete string, instanceServerOnly bool) ([]str
 func (g *cmdGlobal) cmpInstanceKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	// Early return when completing server keys.
-	_, instanceNameOnly, found := strings.Cut(instanceName, ":")
-	if instanceNameOnly == "" && found {
-		return g.cmpServerAllKeys(instanceName)
-	}
-
 	resources, err := g.ParseServers(instanceName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -513,12 +507,6 @@ func (g *cmdGlobal) cmpInstanceAllKeys(profileName string) ([]string, cobra.Shel
 // It takes an instance name to determine instance type and returns a list of instance configuration keys along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceSetKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
-
-	// Early return when completing server keys.
-	_, instanceNameOnly, found := strings.Cut(instanceName, ":")
-	if instanceNameOnly == "" && found {
-		return g.cmpServerSetKeys(instanceName)
-	}
 
 	resources, err := g.ParseServers(instanceName)
 	if err != nil || len(resources) == 0 {

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -593,16 +593,13 @@ func (g *cmdGlobal) cmpInstanceDeviceNames(instanceName string) ([]string, cobra
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
-// cmpInstanceAllDevices provides shell completion for all instance devices.
+// cmpInstanceAllDeviceTypes provides shell completion for all instance device types.
 // It takes an instance name and returns a list of all possible instance devices along with a shell completion directive.
-func (g *cmdGlobal) cmpInstanceAllDevices(instanceName string) ([]string, cobra.ShellCompDirective) {
-	resources, err := g.ParseServers(instanceName)
-	if err != nil || len(resources) == 0 {
-		return nil, cobra.ShellCompDirectiveError
+func (g *cmdGlobal) cmpInstanceAllDeviceTypes(remote string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := g.conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{SkipGetServer: true})
+	if err != nil {
+		return handleCompletionError(err)
 	}
-
-	resource := resources[0]
-	client := resource.server
 
 	metadataConfiguration, err := client.GetMetadataConfiguration()
 	if err != nil {
@@ -612,10 +609,26 @@ func (g *cmdGlobal) cmpInstanceAllDevices(instanceName string) ([]string, cobra.
 	devices := make([]string, 0, len(metadataConfiguration.Configs))
 
 	for key := range metadataConfiguration.Configs {
-		if strings.HasPrefix(key, "device-") {
-			parts := strings.Split(key, "-")
-			deviceName := parts[1]
-			devices = append(devices, deviceName)
+		if !strings.HasPrefix(key, "device-") {
+			continue
+		}
+
+		parts := strings.Split(key, "-")
+		deviceType := parts[1]
+
+		// "unix" is not a device, get the next part.
+		if deviceType == "unix" && len(parts) > 2 {
+			// The metadata API has "unix-usb", but the device type is just "usb"
+			if parts[2] == "usb" {
+				deviceType = "usb"
+			} else {
+				// Otherwise append the next part.
+				deviceType += "-" + parts[2]
+			}
+		}
+
+		if strings.HasPrefix(deviceType, toComplete) && !shared.ValueInSlice(deviceType, devices) {
+			devices = append(devices, deviceType)
 		}
 	}
 

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -635,6 +635,35 @@ func (g *cmdGlobal) cmpInstanceAllDeviceTypes(remote string, toComplete string) 
 	return devices, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpDeviceSubtype returns completions for device subtypes. For example, if the device type is "nic", the subtype may be "bridged".
+// It is expected that the metadata API returns config keys per subtype under "device-<device_type>-<subtype>".
+// A prefix may be provided so that the completed result may be used as a config key directly, e.g. "nictype=".
+func (g *cmdGlobal) cmpDeviceSubtype(remote string, deviceType string, prefix string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := g.conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{SkipGetServer: true})
+	if err != nil {
+		return handleCompletionError(err)
+	}
+
+	metadataConfiguration, err := client.GetMetadataConfiguration()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	subTypes := make([]string, 0, len(metadataConfiguration.Configs))
+	for key := range metadataConfiguration.Configs {
+		subType, ok := strings.CutPrefix(key, "device-"+deviceType+"-")
+		if !ok {
+			continue
+		}
+
+		if strings.HasPrefix(subType, toComplete) {
+			subTypes = append(subTypes, prefix+subType)
+		}
+	}
+
+	return subTypes, cobra.ShellCompDirectiveNoFileComp
+}
+
 // cmpInstanceAllDeviceOptions provides shell completion for all instance device options.
 // It takes an instance name and device name and returns a list of all possible instance device options along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceAllDeviceOptions(instanceName string, deviceName string) ([]string, cobra.ShellCompDirective) {

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -587,42 +587,25 @@ func (g *cmdGlobal) cmpServerAllKeys(toComplete string) ([]string, cobra.ShellCo
 
 // cmpServerSetKeys provides shell completion for server configuration keys which are currently set.
 // It takes a partial input string and returns a list of server configuration keys along with a shell completion directive.
-func (g *cmdGlobal) cmpServerSetKeys(toComplete string) ([]string, cobra.ShellCompDirective) {
-	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
-
-	resources, err := g.ParseServers(toComplete)
-	if err != nil || len(resources) == 0 {
-		return nil, cobra.ShellCompDirectiveError
-	}
-
-	resource := resources[0]
-	server, _, err := resource.server.GetServer()
+func (g *cmdGlobal) cmpServerSetKeys(remote string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := g.conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{SkipGetServer: true})
 	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
+		return handleCompletionError(err)
 	}
 
-	// Fetch all server config keys that can be set.
-	allServerConfigKeys, _ := g.cmpServerAllKeys(resource.remote)
-
-	// Convert slice to map[string]struct{} for O(1) lookups.
-	keySet := make(map[string]struct{}, len(allServerConfigKeys))
-	for _, key := range allServerConfigKeys {
-		keySet[key] = struct{}{}
+	server, _, err := client.GetServer()
+	if err != nil {
+		return handleCompletionError(err)
 	}
 
-	// Pre-allocate configKeys slice capacity.
-	keyCount := len(allServerConfigKeys)
-	configKeys := make([]string, 0, keyCount)
-
-	for configKey := range server.Config {
-		// We only want to return the intersection between allServerConfigKeys and configKeys to avoid returning the full server config.
-		_, exists := keySet[configKey]
-		if exists {
-			configKeys = append(configKeys, configKey)
+	results := make([]string, 0, len(server.Config))
+	for k := range server.Config {
+		if strings.HasPrefix(k, toComplete) {
+			results = append(results, k)
 		}
 	}
 
-	return configKeys, cmpDirectives | cobra.ShellCompDirectiveNoSpace
+	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
 // cmpInstanceConfigTemplates provides shell completion for instance config templates.

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -86,6 +86,47 @@ func (c *cmdConfig) command() *cobra.Command {
 	return cmd
 }
 
+// configSetValidArgsFunc returns completions for server and instance configuration keys (and remotes if no remote is
+// specified). If the command is targeting an instance, only configuration keys valid for that instance type are offered.
+// This function can also be used for the `config get` command, since it is valid to get any key (even if unset). If the
+// command name is "set", configuration key completions are suffixed with an `=`.
+func (c *cmdConfig) configSetValidArgsFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var suffix string
+	if cmd.Name() == "set" {
+		suffix = "="
+	}
+
+	if len(args) == 0 {
+		remote, partial, err := c.global.conf.ParseRemote(toComplete)
+		if err != nil {
+			return handleCompletionError(err)
+		}
+
+		// Default remote: Return all config keys, remotes, and instances.
+		if partial == toComplete {
+			serverConfigKeys, _ := c.global.cmpServerAllKeys(remote, suffix, toComplete)
+			instancesAndRemotes, _ := c.global.cmpTopLevelResource("instance", toComplete)
+			return append(serverConfigKeys, instancesAndRemotes...), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		}
+
+		// Non-default remote: Return instances and remotes
+		return c.global.cmpTopLevelResource("instance", toComplete)
+	}
+
+	remote, instanceName, err := c.global.conf.ParseRemote(args[0])
+	if err != nil {
+		return handleCompletionError(err)
+	}
+
+	if instanceName == "" {
+		return c.global.cmpServerAllKeys(remote, suffix, toComplete)
+	}
+
+	instanceType := c.global.getInstanceType(remote, instanceName)
+
+	return c.global.cmpInstanceKeysByType(instanceType, suffix, toComplete)
+}
+
 // Edit.
 type cmdConfigEdit struct {
 	global *cmdGlobal
@@ -398,20 +439,14 @@ func (c *cmdConfigGet) command() *cobra.Command {
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) == 0 {
-			if strings.Contains(toComplete, ".") {
-				return c.global.cmpServerAllKeys(toComplete)
-			}
-
-			return c.global.cmpTopLevelResource("instance", toComplete)
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// Only one key is allowed.
+		if len(args) > 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		if len(args) == 1 {
-			return c.global.cmpInstanceKeys(args[0])
-		}
-
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		// The caller can get any key, even if unset. So call completions for 'config set'.
+		return c.config.configSetValidArgsFunc(cmd, args, toComplete)
 	}
 
 	return cmd
@@ -556,22 +591,7 @@ lxc config set core.https_address=[::]:8443
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as an instance property"))
 	cmd.RunE = c.run
 
-	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) == 0 {
-			if strings.Contains(toComplete, ".") {
-				return c.global.cmpServerAllKeys(toComplete)
-			}
-
-			return c.global.cmpTopLevelResource("instance", toComplete)
-		}
-
-		if len(args) == 1 {
-			return c.global.cmpInstanceKeys(args[0])
-		}
-
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-
+	cmd.ValidArgsFunction = c.config.configSetValidArgsFunc
 	return cmd
 }
 
@@ -910,21 +930,39 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 	cmd.RunE = c.run
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
 		if len(args) == 0 {
-			if strings.Contains(toComplete, ".") {
-				// Only complete config keys which are currently set.
-				return c.global.cmpServerSetKeys(toComplete)
+			remote, partial, err := c.global.conf.ParseRemote(toComplete)
+			if err != nil {
+				return handleCompletionError(err)
 			}
 
+			// Default remote: Return set config keys in the default remote, instance remotes, and instances in the default remote.
+			if partial == toComplete {
+				serverConfigKeys, _ := c.global.cmpServerSetKeys(remote, toComplete)
+				instancesAndRemotes, _ := c.global.cmpTopLevelResource("instance", toComplete)
+				return append(serverConfigKeys, instancesAndRemotes...), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+			}
+
+			// Non-default remote: Return instances and remotes
 			return c.global.cmpTopLevelResource("instance", toComplete)
 		}
 
-		if len(args) == 1 {
-			// Only complete config keys which are currently set.
-			return c.global.cmpInstanceSetKeys(args[0])
+		remote, instanceName, err := c.global.conf.ParseRemote(args[0])
+		if err != nil {
+			return handleCompletionError(err)
 		}
 
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		// If we have a remote but no instance, return set config keys in the specified remote.
+		if instanceName == "" {
+			return c.global.cmpServerSetKeys(remote, toComplete)
+		}
+
+		// Return set config keys for the instance.
+		return c.global.cmpInstanceSetKeys(remote, instanceName, toComplete)
 	}
 
 	return cmd

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -1037,15 +1037,15 @@ For backward compatibility, a single configuration key may still be set with:
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a profile property"))
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
 		if len(args) == 0 {
 			return c.global.cmpTopLevelResource("profile", toComplete)
 		}
 
-		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys(args[0])
-		}
-
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return c.global.cmpInstanceKeysByType(api.InstanceTypeAny, "=", toComplete)
 	}
 
 	return cmd


### PR DESCRIPTION
Updates completions for config options to suggest only `core.` rather than including all sub-options. This reduces the number of completions shown to the user for readability, while also allowing discoverability.

The driver behind this change was the testing added in #15311 (which will be re-added in a later PR) from which I found that `lxc config set <TAB>` did not show any server completions unless I specified the remote (e.g. `local:`). Similarly, I noticed lots of incorrect config keys being suggested when running `lxc profile device add ...` which could only be fixed by parsing the subtype of the device from the metadata API.

This is part 5 of splitting up #15311 and depends on #15467