### PR TITLE
lxc: Image alias/fingerprint completion

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -321,29 +321,6 @@ func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirec
 	return results, cmpDirectives
 }
 
-// cmpImageFingerprintsFromRemote provides shell completion for image fingerprints.
-// It takes a partial input string and a remote and returns image fingerprints for that remote along with a shell completion directive.
-func (g *cmdGlobal) cmpImageFingerprintsFromRemote(toComplete string, remote string) ([]string, cobra.ShellCompDirective) {
-	if remote == "" {
-		remote = g.conf.DefaultRemote
-	}
-
-	remoteServer, _ := g.conf.GetImageServer(remote)
-
-	images, _ := remoteServer.GetImages()
-
-	results := make([]string, 0, len(images))
-	for _, image := range images {
-		if !strings.HasPrefix(image.Fingerprint, toComplete) {
-			continue
-		}
-
-		results = append(results, image.Fingerprint)
-	}
-
-	return results, cobra.ShellCompDirectiveNoFileComp
-}
-
 // cmpInstanceKeys provides shell completion for all instance configuration keys.
 // It takes an instance name to determine instance type and returns a list of all instance configuration keys along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceKeys(instanceName string) ([]string, cobra.ShellCompDirective) {

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -175,7 +175,7 @@ It requires the source to be an alias and for it to be public.`))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -341,7 +341,7 @@ func (c *cmdImageDelete) command() *cobra.Command {
 	cmd.RunE = c.run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return c.global.cmpImages(toComplete)
+		return c.global.cmpImages(toComplete, true)
 	}
 
 	return cmd
@@ -407,7 +407,7 @@ lxc image edit <image> < image.yaml
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, true)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -533,7 +533,7 @@ The output target is optional and defaults to the working directory.`))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -954,7 +954,7 @@ func (c *cmdImageInfo) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1455,7 +1455,11 @@ func (c *cmdImageRefresh) command() *cobra.Command {
 	cmd.RunE = c.run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return c.global.cmpImages(toComplete)
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete, false)
+		}
+
+		return c.global.cmpImages(toComplete, true)
 	}
 
 	return cmd
@@ -1548,7 +1552,7 @@ func (c *cmdImageShow) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1613,7 +1617,7 @@ func (c *cmdImageGetProp) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -1677,7 +1681,7 @@ func (c *cmdImageSetProp) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, true)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1740,7 +1744,7 @@ func (c *cmdImageUnsetProp) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpImages(toComplete)
+			return c.global.cmpImages(toComplete, true)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -71,12 +71,12 @@ func (c *cmdImageAliasCreate) command() *cobra.Command {
 			return c.global.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*c.global.conf)...)
 		}
 
-		remote, _, found := strings.Cut(args[0], ":")
-		if !found {
-			remote = ""
+		remote, _, err := c.global.conf.ParseRemote(args[0])
+		if err != nil {
+			return handleCompletionError(err)
 		}
 
-		return c.global.cmpImageFingerprintsFromRemote(toComplete, remote)
+		return c.global.cmpTopLevelResourceInRemote(remote, "image", toComplete)
 	}
 
 	return cmd

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -131,7 +131,7 @@ func (c *cmdImageAliasDelete) command() *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpImages(toComplete)
+		return c.global.cmpImages(toComplete, true)
 	}
 
 	return cmd
@@ -295,7 +295,7 @@ func (c *cmdImageAliasRename) command() *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpImages(toComplete)
+		return c.global.cmpImages(toComplete, true)
 	}
 
 	return cmd

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -72,7 +72,7 @@ lxc init ubuntu:24.04 v1 --vm -c limits.cpu=2 -c limits.memory=8GiB -d root,size
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpImages(toComplete)
+		return c.global.cmpImages(toComplete, false)
 	}
 
 	_ = cmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -50,7 +50,7 @@ lxc launch ubuntu:24.04 v1 --vm -c limits.cpu=2 -c limits.memory=8GiB -d root,si
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpImages(toComplete)
+		return c.global.cmpImages(toComplete, false)
 	}
 
 	return cmd


### PR DESCRIPTION
After implementing #15458 I noticed a few things about image comparison.
1. Public image remotes were being suggested for destructive/mutative operations on images.
2. No image fingerprints would be suggested even though they are equally valid, just not human friendly. 

This is updated to allow specifying if only instance server remotes should be suggested (that allow image mutation/deletion) and to suggest image fingerprints in certain circumstances (see comments).

This is part 6 of splitting up #15311 and depends on #15467