### PR TITLE
lxc: Refactor snapshot completions

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -758,7 +758,21 @@ func (g *cmdGlobal) cmpInstancesAction(toComplete string, action string, flagFor
 		}
 	}
 
-	return results, cmpDirectives
+	return completionsFor(results, "", toComplete), cmpDirectives
+}
+
+func (g *cmdGlobal) cmpSnapshotNames(remote string, instanceName string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	server, err := g.conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{SkipGetServer: true})
+	if err != nil {
+		return handleCompletionError(err)
+	}
+
+	snapshotNames, err := server.GetInstanceSnapshotNames(instanceName)
+	if err != nil {
+		return handleCompletionError(err)
+	}
+
+	return completionsFor(snapshotNames, "", toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // cmpInstancesAndSnapshots provides shell completion for instances and their snapshots.
@@ -766,41 +780,33 @@ func (g *cmdGlobal) cmpInstancesAction(toComplete string, action string, flagFor
 func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
+	remote, partial, err := g.conf.ParseRemote(toComplete)
+	if err != nil {
+		return handleCompletionError(err)
+	}
 
-	resources, _ := g.ParseServers(toComplete)
+	instanceName, partialSnapshotName, isSnapshot := strings.Cut(partial, shared.SnapshotDelimiter)
+	if !isSnapshot {
+		return g.cmpTopLevelResource("instance", toComplete)
+	}
 
-	if len(resources) > 0 {
-		resource := resources[0]
-
-		if strings.Contains(resource.name, shared.SnapshotDelimiter) {
-			instName, _, _ := strings.Cut(resource.name, shared.SnapshotDelimiter)
-			snapshots, _ := resource.server.GetInstanceSnapshotNames(instName)
-			for _, snapshot := range snapshots {
-				results = append(results, instName+"/"+snapshot)
-			}
-		} else {
-			instances, _ := resource.server.GetInstanceNames("")
-			for _, instance := range instances {
-				var name string
-
-				if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
-					name = instance
-				} else {
-					name = resource.remote + ":" + instance
-				}
-
-				results = append(results, name)
-			}
+	completions, _ := g.cmpSnapshotNames(remote, instanceName, partialSnapshotName)
+	for _, snapshot := range completions {
+		name := instanceName + shared.SnapshotDelimiter + snapshot
+		if remote != g.conf.DefaultRemote || strings.Contains(toComplete, g.conf.DefaultRemote) {
+			name = remote + ":" + name
 		}
+
+		results = append(results, name)
 	}
 
 	if !strings.Contains(toComplete, ":") {
-		remotes, directives := g.cmpRemotes(toComplete, "", true, instanceServerRemoteCompletionFilters(*g.conf)...)
+		remotes, directives := g.cmpRemotes(toComplete, ":", true, instanceServerRemoteCompletionFilters(*g.conf)...)
 		results = append(results, remotes...)
 		cmpDirectives |= directives
 	}
 
-	return results, cmpDirectives
+	return completionsFor(results, "", toComplete), cmpDirectives
 }
 
 // cmpNetworkACLConfigs provides shell completion for network ACL configs.

--- a/lxc/rename.go
+++ b/lxc/rename.go
@@ -24,7 +24,7 @@ func (c *cmdRename) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpTopLevelResource("instance", toComplete)
+			return c.global.cmpInstancesAndSnapshots(toComplete)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/restore.go
+++ b/lxc/restore.go
@@ -33,6 +33,23 @@ lxc restore u1 snap0
 	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagStateful, "stateful", false, i18n.G("Whether or not to restore the instance's running state from snapshot (if available)"))
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		if len(args) > 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 0 {
+			return c.global.cmpTopLevelResource("instance", toComplete)
+		}
+
+		remote, instanceName, err := c.global.conf.ParseRemote(args[0])
+		if err != nil {
+			return handleCompletionError(err)
+		}
+
+		return c.global.cmpSnapshotNames(remote, instanceName, toComplete)
+	}
+
 	return cmd
 }
 

--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -44,6 +44,13 @@ running state, including process memory state, TCP connections, ...`))
 	cmd.Flags().BoolVar(&c.flagStateful, "stateful", false, i18n.G("Whether or not to snapshot the instance's running state"))
 	cmd.Flags().BoolVar(&c.flagNoExpiry, "no-expiry", false, i18n.G("Ignore any configured auto-expiry for the instance"))
 	cmd.Flags().BoolVar(&c.flagReuse, "reuse", false, i18n.G("If the snapshot name already exists, delete and create a new one"))
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpTopLevelResource("instance", toComplete)
+	}
 
 	return cmd
 }


### PR DESCRIPTION
This refactors snapshot completions to use the new established patterns and top-level resource comparisons introduced in #15458. Completions for snapshots are factored out into another method which accepts a remote name, an instance name, and a partial snapshot name.