### PR TITLE
lxc: Refactor file completion

### DIFF
--- a/lxc/export.go
+++ b/lxc/export.go
@@ -45,6 +45,14 @@ func (c *cmdExport) command() *cobra.Command {
 	cmd.Flags().StringVar(&c.flagExportVersion, "export-version", "",
 		i18n.G("Use a different metadata format version than the latest one supported by the server (to support imports on older LXD versions)")+"``")
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpTopLevelResource("instance", toComplete)
+	}
+
 	return cmd
 }
 

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -326,14 +326,6 @@ func (c *cmdFileDelete) command() *cobra.Command {
 	cmd.RunE = c.run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) == 0 {
-			return c.global.cmpTopLevelResource("instance", toComplete)
-		}
-
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return c.global.cmpFiles(toComplete, false)
 	}
 

--- a/lxc/import.go
+++ b/lxc/import.go
@@ -36,6 +36,20 @@ func (c *cmdImport) command() *cobra.Command {
 	cmd.Flags().StringVarP(&c.flagStorage, "storage", "s", "", i18n.G("Storage pool name")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagDevice, "device", "d", nil, i18n.G("New key/value to apply to a specific device")+"``")
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		if len(args) > 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		files, directive := c.global.cmpLocalFiles(toComplete, []string{".tar.gz", ".tar.xz"})
+		if len(args) == 0 {
+			remotes, _ := c.global.cmpRemotes(toComplete, ":", false, instanceServerRemoteCompletionFilters(*c.global.conf)...)
+			return append(files, remotes...), directive
+		}
+
+		return files, directive
+	}
+
 	return cmd
 }
 

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -324,6 +324,10 @@ For help with any of those, simply call them with --help.`))
 		}
 	}
 
+	// Prevent file completions by default.
+	// This is a workaround for https://github.com/spf13/cobra/issues/2209 and should be removed when resolved.
+	preventFileCompletions(app)
+
 	// Run the main command and handle errors
 	err = app.Execute()
 	if err != nil {
@@ -545,4 +549,20 @@ func (c *cmdGlobal) CheckArgs(cmd *cobra.Command, args []string, minArgs int, ma
 	}
 
 	return false, nil
+}
+
+// preventFileCompletions recurses the Command tree and sets a ValidArgsFunction on each Command if not already set.
+// This prevents file completion when e.g. invalid commands are being completed, or when no completions are available yet.
+// This is used because the majority of lxc commands interact with remote resources, and not the local filesystem.
+// This should be removed when https://github.com/spf13/cobra/issues/2209 is resolved.
+func preventFileCompletions(c *cobra.Command) {
+	if c.ValidArgsFunction == nil {
+		c.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
+	for _, cmd := range c.Commands() {
+		preventFileCompletions(cmd)
+	}
 }


### PR DESCRIPTION
While adding tests to #15311 I found that we were missing completions for many top-level commands. `lxc import` and `lxc export` were two of these. I figured we can have a quick win by refactoring the existing `cmpFiles` function, which wasn't just comparing files, but also comparing instances. This PR makes the function usage clearer and adds the missing completions.

Additionally, I've removed a completion function that was defined twice for `lxc file delete` and also prevented file completions from happening by default when no other completion function has been set.