### PR TITLE
lxc/completion: Use `strings.HasPrefix` over `strings.Contains`

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -308,7 +308,7 @@ func (g *cmdGlobal) cmpImages(toComplete string, instanceServerOnly bool) ([]str
 		}
 
 		var name string
-		if remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
+		if remote == g.conf.DefaultRemote && !strings.HasPrefix(toComplete, g.conf.DefaultRemote) {
 			name = result
 		} else {
 			name = remote + ":" + result


### PR DESCRIPTION
Addresses https://github.com/canonical/lxd/pull/15477/commits/39439ea80becf899eff375203f7111e60d98fb9f#r2064096914