### PR TITLE
lxd/daemon: Manage images and backups volumes without symlinks

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -833,7 +833,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	return response.EmptySyncResponse
 }
 
-func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *clusterConfig.Config) error {
+func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, newNodeConfig *node.Config, newClusterConfig *clusterConfig.Config) error {
 	s := d.State()
 
 	maasChanged := false
@@ -854,7 +854,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		case "core.proxy_https":
 			fallthrough
 		case "core.proxy_ignore_hosts":
-			daemonConfigSetProxy(d, clusterConfig)
+			daemonConfigSetProxy(d, newClusterConfig)
 		case "maas.api.url":
 			fallthrough
 		case "maas.api.key":
@@ -866,7 +866,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			}
 
 		case "cluster.offline_threshold":
-			d.gateway.HeartbeatOfflineThreshold = clusterConfig.OfflineThreshold()
+			d.gateway.HeartbeatOfflineThreshold = newClusterConfig.OfflineThreshold()
 			d.taskClusterHeartbeat.Reset()
 		case "images.auto_update_interval":
 			fallthrough
@@ -929,7 +929,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			return err
 		}
 
-		s.Endpoints.NetworkUpdateTrustedProxy(clusterConfig.HTTPSTrustedProxy())
+		s.Endpoints.NetworkUpdateTrustedProxy(newClusterConfig.HTTPSTrustedProxy())
 	}
 
 	value, ok = nodeChanged["cluster.https_address"]
@@ -939,7 +939,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			return err
 		}
 
-		s.Endpoints.NetworkUpdateTrustedProxy(clusterConfig.HTTPSTrustedProxy())
+		s.Endpoints.NetworkUpdateTrustedProxy(newClusterConfig.HTTPSTrustedProxy())
 	}
 
 	value, ok = nodeChanged["core.debug_address"]
@@ -983,8 +983,8 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if maasChanged {
-		url, key := clusterConfig.MAASController()
-		machine := nodeConfig.MAASMachine()
+		url, key := newClusterConfig.MAASController()
+		machine := newNodeConfig.MAASMachine()
 		err := d.setupMAASController(url, key, machine)
 		if err != nil {
 			return err
@@ -992,9 +992,9 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if bgpChanged {
-		address := nodeConfig.BGPAddress()
-		asn := clusterConfig.BGPASN()
-		routerid := nodeConfig.BGPRouterID()
+		address := newNodeConfig.BGPAddress()
+		asn := newClusterConfig.BGPASN()
+		routerid := newNodeConfig.BGPRouterID()
 
 		if asn > math.MaxUint32 {
 			return errors.New("Cannot convert BGP ASN to uint32: Upper bound exceeded")
@@ -1007,7 +1007,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if dnsChanged {
-		address := nodeConfig.DNSAddress()
+		address := newNodeConfig.DNSAddress()
 
 		err := s.DNS.Reconfigure(address)
 		if err != nil {
@@ -1016,7 +1016,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if lokiChanged {
-		lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := clusterConfig.LokiServer()
+		lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := newClusterConfig.LokiServer()
 
 		if lokiURL == "" || lokiLoglevel == "" || len(lokiTypes) == 0 {
 			d.internalListener.RemoveHandler("loki")
@@ -1045,7 +1045,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcScopes, oidcAudience, oidcGroupsClaim := clusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcScopes, oidcAudience, oidcGroupsClaim := newClusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil
@@ -1064,7 +1064,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if syslogSocketChanged {
-		err := d.setupSyslogSocket(nodeConfig.SyslogSocket())
+		err := d.setupSyslogSocket(newNodeConfig.SyslogSocket())
 		if err != nil {
 			return err
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -846,7 +846,14 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			changes[k], _ = v.(string)
 		}
 
-		err = doAPI10UpdateTriggers(d, nil, changes, nodeConfig, currentClusterConfig)
+		// Copy the old config so that the update triggers have access to it.
+		// In this case it will not be used as we are not changing any node values.
+		oldNodeConfig := make(map[string]any)
+		for k, v := range s.LocalConfig.Dump() {
+			oldNodeConfig[k] = v
+		}
+
+		err = doAPI10UpdateTriggers(d, nil, changes, oldNodeConfig, nodeConfig, currentClusterConfig)
 		if err != nil {
 			return err
 		}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -102,7 +103,9 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	}
 
 	// Create the target path if needed.
-	backupsPath := shared.VarPath("backups", "instances", project.Instance(sourceInst.Project().Name, sourceInst.Name()))
+	backupsPathBase := s.BackupsStoragePath()
+
+	backupsPath := filepath.Join(backupsPathBase, "instances", project.Instance(sourceInst.Project().Name, sourceInst.Name()))
 	if !shared.PathExists(backupsPath) {
 		err := os.MkdirAll(backupsPath, 0700)
 		if err != nil {
@@ -112,7 +115,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		revert.Add(func() { _ = os.Remove(backupsPath) })
 	}
 
-	target := shared.VarPath("backups", "instances", project.Instance(sourceInst.Project().Name, b.Name()))
+	target := filepath.Join(backupsPathBase, "instances", project.Instance(sourceInst.Project().Name, b.Name()))
 
 	// Setup the tarball writer.
 	l.Debug("Opening backup tarball for writing", logger.Ctx{"path": target})
@@ -444,7 +447,9 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	}
 
 	// Create the target path if needed.
-	backupsPath := shared.VarPath("backups", "custom", pool.Name(), project.StorageVolume(projectName, volumeName))
+	backupsPathBase := s.BackupsStoragePath()
+
+	backupsPath := filepath.Join(backupsPathBase, "custom", pool.Name(), project.StorageVolume(projectName, volumeName))
 	if !shared.PathExists(backupsPath) {
 		err := os.MkdirAll(backupsPath, 0700)
 		if err != nil {
@@ -454,7 +459,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		revert.Add(func() { _ = os.Remove(backupsPath) })
 	}
 
-	target := shared.VarPath("backups", "custom", pool.Name(), project.StorageVolume(projectName, backupRow.Name))
+	target := filepath.Join(backupsPathBase, "custom", pool.Name(), project.StorageVolume(projectName, backupRow.Name))
 
 	// Setup the tarball writer.
 	l.Debug("Opening backup tarball for writing", logger.Ctx{"path": target})

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/lxd/lxd/backup/config"
-	"github.com/canonical/lxd/lxd/sys"
+	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -54,7 +54,7 @@ type Info struct {
 }
 
 // GetInfo extracts backup information from a given ReadSeeker.
-func GetInfo(r io.ReadSeeker, sysOS *sys.OS, outputPath string) (*Info, error) {
+func GetInfo(s *state.State, r io.ReadSeeker, outputPath string) (*Info, error) {
 	result := Info{}
 	hasIndexFile := false
 
@@ -63,7 +63,7 @@ func GetInfo(r io.ReadSeeker, sysOS *sys.OS, outputPath string) (*Info, error) {
 	optimizedHeaderFalse := false
 
 	// Extract.
-	tr, cancelFunc, err := TarReader(r, sysOS, outputPath)
+	tr, cancelFunc, err := TarReader(s, r, outputPath)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/backup/backup_utils.go
+++ b/lxd/backup/backup_utils.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/archive"
-	"github.com/canonical/lxd/lxd/sys"
+	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
 )
 
 // TarReader rewinds backup file handle r and returns new tar reader and process cleanup function.
-func TarReader(r io.ReadSeeker, sysOS *sys.OS, outputPath string) (*tar.Reader, context.CancelFunc, error) {
+func TarReader(s *state.State, r io.ReadSeeker, outputPath string) (*tar.Reader, context.CancelFunc, error) {
 	_, err := r.Seek(0, io.SeekStart)
 	if err != nil {
 		return nil, nil, err
@@ -28,7 +28,7 @@ func TarReader(r io.ReadSeeker, sysOS *sys.OS, outputPath string) (*tar.Reader, 
 		return nil, nil, errors.New("Unsupported backup compression")
 	}
 
-	tr, cancelFunc, err := archive.CompressedTarReader(context.Background(), r, unpacker, sysOS, outputPath)
+	tr, cancelFunc, err := archive.CompressedTarReader(s, context.Background(), r, unpacker, outputPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lxd/backup/backup_volume.go
+++ b/lxd/backup/backup_volume.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -54,16 +55,17 @@ func (b *VolumeBackup) OptimizedStorage() bool {
 
 // Rename renames a volume backup.
 func (b *VolumeBackup) Rename(newName string) error {
-	oldBackupPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
-	newBackupPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, newName))
+	backupsPath := b.state.BackupsStoragePath()
+	oldBackupPath := filepath.Join(backupsPath, "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
+	newBackupPath := filepath.Join(backupsPath, "custom", b.poolName, project.StorageVolume(b.projectName, newName))
 
 	// Extract the old and new parent backup paths from the old and new backup names rather than use
 	// instance.Name() as this may be in flux if the instance itself is being renamed, whereas the relevant
 	// instance name is encoded into the backup names.
 	oldParentName, _, _ := api.GetParentAndSnapshotName(b.name)
-	oldParentBackupsPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, oldParentName))
+	oldParentBackupsPath := filepath.Join(backupsPath, "custom", b.poolName, project.StorageVolume(b.projectName, oldParentName))
 	newParentName, _, _ := api.GetParentAndSnapshotName(newName)
-	newParentBackupsPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, newParentName))
+	newParentBackupsPath := filepath.Join(backupsPath, "custom", b.poolName, project.StorageVolume(b.projectName, newParentName))
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -107,7 +109,8 @@ func (b *VolumeBackup) Rename(newName string) error {
 
 // Delete removes a volume backup.
 func (b *VolumeBackup) Delete() error {
-	backupPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
+	backupsPathBase := b.state.BackupsStoragePath()
+	backupPath := filepath.Join(backupsPathBase, "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
 	// Delete the on-disk data.
 	if shared.PathExists(backupPath) {
 		err := os.RemoveAll(backupPath)
@@ -117,7 +120,7 @@ func (b *VolumeBackup) Delete() error {
 	}
 
 	// Check if we can remove the volume directory.
-	backupsPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, b.volumeName))
+	backupsPath := filepath.Join(backupsPathBase, "custom", b.poolName, project.StorageVolume(b.projectName, b.volumeName))
 	empty, _ := shared.PathIsEmpty(backupsPath)
 	if empty {
 		err := os.Remove(backupsPath)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1638,7 +1638,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Create directories on daemon storage mounts.
-	err = d.os.InitStorage()
+	err = d.os.InitStorage(d.localConfig)
 	if err != nil {
 		return err
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -61,6 +61,7 @@ import (
 	networkZone "github.com/canonical/lxd/lxd/network/zone"
 	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/rsync"
@@ -727,6 +728,24 @@ func (d *Daemon) State() *state.State {
 			Leader:    localClusterAddress == leaderAddress,
 			Address:   leaderAddress,
 		}, nil
+	}
+
+	storagePath := func(config string, path string) string {
+		if config == "" {
+			return path
+		}
+
+		poolName, volumeName, _ := daemonStorageSplitVolume(config)
+		volStorageName := project.StorageVolume(api.ProjectDefaultName, volumeName)
+		return storageDrivers.GetVolumeMountPath(poolName, storageDrivers.VolumeTypeCustom, volStorageName)
+	}
+
+	s.ImagesStoragePath = func() string {
+		return storagePath(s.LocalConfig.StorageImagesVolume(), shared.VarPath("images"))
+	}
+
+	s.BackupsStoragePath = func() string {
+		return storagePath(s.LocalConfig.StorageBackupsVolume(), shared.VarPath("backups"))
 	}
 
 	return s

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -319,7 +319,7 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 	l.Info("Downloading image")
 
 	// Cleanup any leftover from a past attempt
-	destDir := shared.VarPath("images")
+	destDir := s.ImagesStoragePath()
 	destName := filepath.Join(destDir, fp)
 
 	failure := true

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -407,7 +407,7 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 			ProgressHandler: progress,
 			Canceler:        canceler,
 			DeltaSourceRetriever: func(fingerprint string, file string) string {
-				path := shared.VarPath("images", fmt.Sprintf("%s.%s", fingerprint, file))
+				path := filepath.Join(destDir, fingerprint+"."+file)
 				if shared.PathExists(path) {
 					return path
 				}

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -51,7 +51,7 @@ func daemonStorageVolumesUnmount(s *state.State, ctx context.Context) error {
 			return err
 		}
 
-		// Mount volume.
+		// Unmount volume.
 		_, err = pool.UnmountCustomVolume(api.ProjectDefaultName, volumeName, nil)
 		if err != nil {
 			return fmt.Errorf("Failed to unmount storage volume %q: %w", source, err)

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -252,20 +252,25 @@ func daemonStorageValidate(s *state.State, target string) (validatedTarget strin
 	return pool.Name() + "/" + dbVol.Name, nil
 }
 
-func daemonStorageMove(s *state.State, storageType string, target string) error {
+func daemonStorageMove(s *state.State, storageType string, oldConfig string, newconfig string) error {
 	destPath := shared.VarPath(storageType)
-
-	// Track down the current storage.
+	var sourcePath string
 	var sourcePool string
 	var sourceVolume string
+	var err error
 
-	sourcePath, err := os.Readlink(destPath)
-	if err != nil {
+	// Track down the current storage.
+	if oldConfig == "" {
 		sourcePath = destPath
 	} else {
-		fields := strings.Split(sourcePath, "/")
-		sourcePool = fields[len(fields)-3]
-		sourceVolume = fields[len(fields)-1]
+		sourcePool, sourceVolume, err = daemonStorageSplitVolume(oldConfig)
+
+		if err != nil {
+			return err
+		}
+
+		sourceVolume = project.StorageVolume(api.ProjectDefaultName, sourceVolume)
+		sourcePath = storageDrivers.GetVolumeMountPath(sourcePool, storageDrivers.VolumeTypeCustom, sourceVolume)
 	}
 
 	moveContent := func(source string, target string) error {
@@ -292,20 +297,14 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	}
 
 	// Deal with unsetting.
-	if target == "" {
+	if newconfig == "" {
 		// Things already look correct.
 		if sourcePath == destPath {
 			return nil
 		}
 
-		// Remove the symlink.
-		err = os.Remove(destPath)
-		if err != nil {
-			return fmt.Errorf("Failed to delete storage symlink at %q: %w", destPath, err)
-		}
-
-		// Re-create as a directory.
-		err = os.MkdirAll(destPath, 0700)
+		// Re-create the directory.
+		err := os.MkdirAll(destPath, 0700)
 		if err != nil {
 			return fmt.Errorf("Failed to create directory %q: %w", destPath, err)
 		}
@@ -332,7 +331,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	}
 
 	// Parse the target.
-	poolName, volumeName, err := daemonStorageSplitVolume(target)
+	poolName, volumeName, err := daemonStorageSplitVolume(newconfig)
 	if err != nil {
 		return err
 	}
@@ -345,38 +344,29 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	// Mount volume.
 	_, err = pool.MountCustomVolume(api.ProjectDefaultName, volumeName, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to mount storage volume %q: %w", target, err)
+		return fmt.Errorf("Failed to mount storage volume %q: %w", newconfig, err)
 	}
 
 	// Set ownership & mode.
-	volStorageName := project.StorageVolume(api.ProjectDefaultName, volumeName)
-	mountpoint := storageDrivers.GetVolumeMountPath(poolName, storageDrivers.VolumeTypeCustom, volStorageName)
-	destPath = mountpoint
-
-	err = os.Chmod(mountpoint, 0700)
-	if err != nil {
-		return fmt.Errorf("Failed to set permissions on %q: %w", mountpoint, err)
+	switch storageType {
+	case "images":
+		destPath = s.ImagesStoragePath()
+	case "backups":
+		destPath = s.BackupsStoragePath()
 	}
 
-	err = os.Chown(mountpoint, 0, 0)
+	err = os.Chmod(destPath, 0700)
 	if err != nil {
-		return fmt.Errorf("Failed to set ownership on %q: %w", mountpoint, err)
+		return fmt.Errorf("Failed to set permissions on %q: %w", destPath, err)
+	}
+
+	err = os.Chown(destPath, 0, 0)
+	if err != nil {
+		return fmt.Errorf("Failed to set ownership on %q: %w", destPath, err)
 	}
 
 	// Handle changes.
 	if sourcePath != shared.VarPath(storageType) {
-		// Remove the symlink.
-		err := os.Remove(shared.VarPath(storageType))
-		if err != nil {
-			return fmt.Errorf("Failed to remove the new symlink at %q: %w", shared.VarPath(storageType), err)
-		}
-
-		// Create the new symlink.
-		err = os.Symlink(destPath, shared.VarPath(storageType))
-		if err != nil {
-			return fmt.Errorf("Failed to create the new symlink at %q: %w", shared.VarPath(storageType), err)
-		}
-
 		// Move the data across.
 		err = moveContent(sourcePath, destPath)
 		if err != nil {
@@ -396,20 +386,6 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		}
 
 		return nil
-	}
-
-	sourcePath = shared.VarPath(storageType) + ".temp"
-
-	// Rename the existing storage.
-	err = os.Rename(shared.VarPath(storageType), sourcePath)
-	if err != nil {
-		return fmt.Errorf("Failed to rename existing storage %q: %w", shared.VarPath(storageType), err)
-	}
-
-	// Create the new symlink.
-	err = os.Symlink(destPath, shared.VarPath(storageType))
-	if err != nil {
-		return fmt.Errorf("Failed to create the new symlink at %q: %w", shared.VarPath(storageType), err)
 	}
 
 	// Move the data across.

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -77,7 +76,7 @@ func instanceImageTransfer(s *state.State, r *http.Request, projectName string, 
 
 	client = client.UseProject(projectName)
 
-	err = imageImportFromNode(filepath.Join(s.OS.VarDir, "images"), client, hash)
+	err = imageImportFromNode(s.ImagesStoragePath(), client, hash)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6429,7 +6429,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 	}
 
 	// Convert from raw to qcow2 and add to tarball.
-	tmpPath, err := os.MkdirTemp(shared.VarPath("images"), "lxd_export_")
+	tmpPath, err := os.MkdirTemp(d.state.ImagesStoragePath(), "lxd_export_")
 	if err != nil {
 		return meta, err
 	}

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -731,7 +732,7 @@ func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	ent := response.FileResponseEntry{
-		Path: shared.VarPath("backups", "instances", project.Instance(projectName, backup.Name())),
+		Path: filepath.Join(d.State().BackupsStoragePath(), "instances", project.Instance(projectName, backup.Name())),
 	}
 
 	s.Events.SendLifecycle(projectName, lifecycle.InstanceBackupRetrieved.Event(fullName, backup.Instance(), nil))

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -660,8 +660,10 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	revert := revert.New()
 	defer revert.Fail()
 
+	backupsPath := s.BackupsStoragePath()
+
 	// Create temporary file to store uploaded backup data.
-	backupFile, err := os.CreateTemp(shared.VarPath("backups"), backup.WorkingDirPrefix+"_")
+	backupFile, err := os.CreateTemp(backupsPath, backup.WorkingDirPrefix+"_")
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -691,7 +693,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		decomArgs := append(decomArgs, backupFile.Name())
 
 		// Create temporary file to store the decompressed tarball in.
-		tarFile, err := os.CreateTemp(shared.VarPath("backups"), backup.WorkingDirPrefix+"_decompress_")
+		tarFile, err := os.CreateTemp(backupsPath, backup.WorkingDirPrefix+"_decompress_")
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -699,7 +701,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		defer func() { _ = os.Remove(tarFile.Name()) }()
 
 		// Decompress to tarFile temporary file.
-		err = archive.ExtractWithFds(decomArgs[0], decomArgs[1:], nil, nil, s.OS, tarFile)
+		err = archive.ExtractWithFds(s, decomArgs[0], decomArgs[1:], nil, nil, tarFile)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -719,7 +721,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	}
 
 	logger.Debug("Reading backup file info")
-	bInfo, err := backup.GetInfo(backupFile, s.OS, backupFile.Name())
+	bInfo, err := backup.GetInfo(s, backupFile, backupFile.Name())
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -92,6 +92,12 @@ type State struct {
 	// Whether we are the leader and the leader address if not.
 	LeaderInfo func() (*LeaderInfo, error)
 
+	// Storage path used by this daemon
+	ImagesStoragePath func() string
+
+	// Storage path used by this daemon
+	BackupsStoragePath func() string
+
 	// Local server UUID.
 	ServerUUID string
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6005,6 +6005,12 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 	l.Debug("RenameCustomVolume started")
 	defer l.Debug("RenameCustomVolume finished")
 
+	// Silence the static analysis tool
+	err := ValidVolumeName(newVolName)
+	if err != nil {
+		return err
+	}
+
 	if shared.IsSnapshot(volName) {
 		return errors.New("Volume name cannot be a snapshot")
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1824,8 +1824,8 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) f
 				}}
 		}
 
-		imageFile := shared.VarPath("images", fingerprint)
-		return ImageUnpack(imageFile, vol, rootBlockPath, b.state.OS, allowUnsafeResize, tracker)
+		imageFile := filepath.Join(b.state.ImagesStoragePath(), fingerprint)
+		return ImageUnpack(b.state, imageFile, vol, rootBlockPath, allowUnsafeResize, tracker)
 	}
 }
 
@@ -2392,7 +2392,8 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 				}
 
 				// Make sure that the image is available locally too (not guaranteed in clusters).
-				imageExists = err == nil && shared.PathExists(shared.VarPath("images", fingerprint))
+				imagePath := filepath.Join(b.state.ImagesStoragePath(), fingerprint)
+				imageExists = err == nil && shared.PathExists(imagePath)
 			}
 
 			if imageExists {
@@ -2575,7 +2576,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 		// The conversion cannot be done in-place, therefore the image has to be
 		// saved in an intermediate location.
 		conversionID := "conversion_" + inst.Project().Name + "_" + inst.Name()
-		imgPath := filepath.Join(shared.VarPath("backups"), conversionID)
+		imgPath := filepath.Join(b.state.BackupsStoragePath(), conversionID)
 
 		// Create new file in backups directory.
 		to, err := os.OpenFile(imgPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
@@ -6396,7 +6397,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	// Remove backups directory for volume.
-	backupsPath := shared.VarPath("backups", "custom", b.name, project.StorageVolume(projectName, volName))
+	backupsPath := filepath.Join(b.state.BackupsStoragePath(), "custom", b.name, project.StorageVolume(projectName, volName))
 	if shared.PathExists(backupsPath) {
 		err := os.RemoveAll(backupsPath)
 		if err != nil {

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -572,7 +572,7 @@ func (d *btrfs) loadOptimizedBackupHeader(r io.ReadSeeker, mountPath string) (*B
 	header := BTRFSMetaDataHeader{}
 
 	// Extract.
-	tr, cancelFunc, err := backup.TarReader(r, d.state.OS, mountPath)
+	tr, cancelFunc, err := backup.TarReader(d.state, r, mountPath)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -319,7 +319,7 @@ func (d *ceph) getVolumeSize(volumeName string) (int64, error) {
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *ceph) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -65,7 +65,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *cephfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy copies an existing storage volume (with or without snapshots) into a new volume.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -101,7 +101,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
 func (d *dir) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	// Run the generic backup unpacker
-	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), d.state.OS, vol, srcBackup.Snapshots, srcData, op)
+	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), d.state, vol, srcBackup.Snapshots, srcData, op)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -138,7 +138,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
 func (d *lvm) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -154,7 +154,7 @@ func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, op *operation
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *powerflex) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -172,7 +172,7 @@ func (d *pure) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *pure) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -2534,7 +2534,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 	defer revert.Fail()
 
 	// Create temporary file to store uploaded backup data.
-	backupFile, err := os.CreateTemp(shared.VarPath("backups"), backup.WorkingDirPrefix+"_")
+	backupFile, err := os.CreateTemp(s.BackupsStoragePath(), backup.WorkingDirPrefix+"_")
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -2564,7 +2564,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 		decomArgs := append(decomArgs, backupFile.Name())
 
 		// Create temporary file to store the decompressed tarball in.
-		tarFile, err := os.CreateTemp(shared.VarPath("backups"), backup.WorkingDirPrefix+"_decompress_")
+		tarFile, err := os.CreateTemp(s.BackupsStoragePath(), backup.WorkingDirPrefix+"_decompress_")
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -2572,7 +2572,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 		defer func() { _ = os.Remove(tarFile.Name()) }()
 
 		// Decompress to tarFile temporary file.
-		err = archive.ExtractWithFds(decomArgs[0], decomArgs[1:], nil, nil, s.OS, tarFile)
+		err = archive.ExtractWithFds(s, decomArgs[0], decomArgs[1:], nil, nil, tarFile)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -2592,7 +2592,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 	}
 
 	logger.Debug("Reading backup file info")
-	bInfo, err := backup.GetInfo(backupFile, s.OS, backupFile.Name())
+	bInfo, err := backup.GetInfo(s, backupFile, backupFile.Name())
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -814,7 +815,7 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 	}
 
 	ent := response.FileResponseEntry{
-		Path: shared.VarPath("backups", "custom", details.pool.Name(), project.StorageVolume(effectiveProjectName, fullName)),
+		Path: filepath.Join(s.BackupsStoragePath(), "custom", details.pool.Name(), project.StorageVolume(effectiveProjectName, fullName)),
 	}
 
 	s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRetrieved.Event(details.pool.Name(), details.volumeTypeName, fullName, effectiveProjectName, request.CreateRequestor(r), nil))

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/lxd/lxd/cgroup"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/idmap"
+	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
@@ -232,8 +233,8 @@ func (s *OS) Init() ([]cluster.Warning, error) {
 }
 
 // InitStorage initialises the storage layer after it has been mounted.
-func (s *OS) InitStorage() error {
-	return s.initStorageDirs()
+func (s *OS) InitStorage(config *node.Config) error {
+	return s.initStorageDirs(config)
 }
 
 // InUbuntuCore returns true if we're running on Ubuntu Core.

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -39,8 +39,8 @@ _server_config_storage() {
   lxc query --wait /1.0/containers/foo/backups -X POST -d '{\"expires_at\": \"2100-01-01T10:00:00-05:00\"}'
 
   # Record before
-  BACKUPS_BEFORE=$(find "${LXD_DIR}/backups/" | sort)
-  IMAGES_BEFORE=$(find "${LXD_DIR}/images/" | sort)
+  BACKUPS_BEFORE=$(cd "${LXD_DIR}/backups/" && find . | sort)
+  IMAGES_BEFORE=$(cd "${LXD_DIR}/images/" && find . | sort)
 
   lxc storage volume create "${pool}" backups
   lxc storage volume create "${pool}" images
@@ -64,8 +64,8 @@ _server_config_storage() {
   lxc config set storage.images_volume "${pool}/images"
 
   # Record after
-  BACKUPS_AFTER=$(find "${LXD_DIR}/backups/" | sort)
-  IMAGES_AFTER=$(find "${LXD_DIR}/images/" | sort)
+  BACKUPS_AFTER=$(cd "${LXD_DIR}/storage-pools/${pool}/custom/default_backups/" && find . | sort)
+  IMAGES_AFTER=$(cd "${LXD_DIR}/storage-pools/${pool}/custom/default_images/" && find . | sort)
 
   # Validate content
   if [ "${BACKUPS_BEFORE}" != "${BACKUPS_AFTER}" ]; then


### PR DESCRIPTION
When `storage.backups_volume` or `storage.images_volume` local configs are set, don't create any symlinks for `LXD_DIR/backups` or `LXD_DIR/images`. Instead, adjust LXD so that the backup or image files are directly operated at the target volume.