### PR TITLE
lxd: Make d.gateway.Cluster available even if OpenCluster returns with PreconditionFailed

### DIFF
--- a/lxc/query.go
+++ b/lxc/query.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
@@ -87,8 +88,10 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 		return errors.New(i18n.G("Query path must start with /"))
 	}
 
-	// Attempt to connect
-	d, err := conf.GetInstanceServer(remote)
+	// Setup client
+	d, err := conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{
+		SkipGetServer: true,
+	})
 	if err != nil {
 		return err
 	}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -267,7 +267,10 @@ func internalShutdown(d *Daemon, r *http.Request) response.Response {
 	return response.ManualResponse(func(w http.ResponseWriter) error {
 		defer forceCtxCancel()
 
-		<-d.setupChan // Wait for daemon to start.
+		select {
+		case <-d.setupChan: // Wait for daemon to start.
+		case <-r.Context().Done(): // Don't leave this go routine around if client disconnects.
+		}
 
 		// Run shutdown sequence synchronously.
 		stopErr := d.Stop(forceCtx, unix.SIGPWR)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2209,6 +2209,8 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		trackError(d.seccomp.Stop(), "Stop seccomp")
 	}
 
+	trackError(filesystem.SyncFS(filepath.Join(d.os.VarDir, "database")), "Sync database directory")
+
 	n = len(errs)
 	if n > 0 {
 		format := "%v"

--- a/lxd/main_waitready.go
+++ b/lxd/main_waitready.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -72,7 +73,8 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 				logger.Debugf("Checking if LXD daemon is ready (attempt %d)", i)
 			}
 
-			_, _, err = d.RawQuery(http.MethodGet, "/internal/ready", nil, "")
+			u := api.NewURL().Path("internal", "ready").WithQuery("wait", "1")
+			_, _, err = d.RawQuery(http.MethodGet, u.String(), nil, "")
 			if err != nil {
 				errLast = err
 				if doLog {

--- a/lxd/main_waitready.go
+++ b/lxd/main_waitready.go
@@ -64,7 +64,7 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 					logger.Debugf("Failed connecting to LXD daemon (attempt %d): %v", i, err)
 				}
 
-				time.Sleep(500 * time.Millisecond)
+				time.Sleep(time.Second)
 				continue
 			}
 
@@ -79,7 +79,7 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 					logger.Debugf("Failed to check if LXD daemon is ready (attempt %d): %v", i, err)
 				}
 
-				time.Sleep(500 * time.Millisecond)
+				time.Sleep(time.Second)
 				continue
 			}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2244,6 +2244,17 @@ func (n *bridge) Stop() error {
 		return err
 	}
 
+	// Kill any existing dnsmasq and forkdns daemon for this network
+	err = dnsmasq.Kill(n.name, false)
+	if err != nil {
+		return err
+	}
+
+	err = n.killForkDNS()
+	if err != nil {
+		return err
+	}
+
 	// Destroy the bridge interface
 	if n.config["bridge.driver"] == "openvswitch" {
 		ovs := openvswitch.NewOVS()
@@ -2276,17 +2287,6 @@ func (n *bridge) Stop() error {
 		if err != nil {
 			return fmt.Errorf("Failed deleting firewall: %w", err)
 		}
-	}
-
-	// Kill any existing dnsmasq and forkdns daemon for this network
-	err = dnsmasq.Kill(n.name, false)
-	if err != nil {
-		return err
-	}
-
-	err = n.killForkDNS()
-	if err != nil {
-		return err
 	}
 
 	// Get a list of interfaces


### PR DESCRIPTION
So its available for use with gateway heartbeats.

Also several other LXD start up and shutdown improvements.