### PR TITLE
Storage: Skip GPT alt‐header move on non-GPT disks (handle `sgdisk` exits 2 & 3)

### DIFF
--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -302,9 +302,10 @@ func (d *common) moveGPTAltHeader(devPath string) error {
 	if ok {
 		exitError, ok := runErr.Unwrap().(*exec.ExitError)
 		if ok {
-			// sgdisk manpage says exit status 3 means:
-			// "Non-GPT disk detected and no -g option, but operation requires a write action".
-			if exitError.ExitCode() == 3 {
+			// sgdisk exit code 3 = “Non-GPT  disk  detected and no -g option, but operation requires a write action”
+			// exit code 2 = “an error occurred while reading the partition table" (e.g. no GPT present or header CRC mismatch)
+			// Treat both as non-error for raw/MBR images, since we only relocate a GPT alternative header if one exists.
+			if exitError.ExitCode() == 2 || exitError.ExitCode() == 3 {
 				return nil // Non-error as non-GPT disk specified.
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15411.

When moving the GPT alternative header, `sgdisk` will exit with code 2 if no valid GPT header is found (read error) or code 3 if it detects an MBR disk without `-g` (write skipped). Neither condition represents a failure in our context, there is simply no GPT backup header to move. Treat both codes as non-fatal so raw/MBR images continue without error, while still propagating any other `sgdisk` failures.