### PR TITLE
lxd: Generate server-side initiated web socket pings for remote console connections

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -2714,13 +2714,12 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 		}
 	}
 
-	var controlConn *websocket.Conn
 	// Call the control handler with a connection to the control socket
 	if fds[api.SecretNameControl] == "" {
 		return nil, fmt.Errorf("Did not receive a file descriptor for the control channel")
 	}
 
-	controlConn, err = r.GetOperationWebsocket(opAPI.ID, fds[api.SecretNameControl])
+	controlConn, err := r.GetOperationWebsocket(opAPI.ID, fds[api.SecretNameControl])
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -2724,6 +2724,10 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 		return nil, err
 	}
 
+	go func() {
+		_, _, _ = controlConn.ReadMessage() // Consume pings from server.
+	}()
+
 	go args.Control(controlConn)
 
 	// Connect to the websocket
@@ -2821,6 +2825,10 @@ func (r *ProtocolLXD) ConsoleInstanceDynamic(instanceName string, console api.In
 	if err != nil {
 		return nil, nil, err
 	}
+
+	go func() {
+		_, _, _ = controlConn.ReadMessage() // Consume pings from server.
+	}()
 
 	go args.Control(controlConn)
 

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -102,6 +102,8 @@ func (s *consoleWs) connectConsole(op *operations.Operation, r *http.Request, w 
 				return err
 			}
 
+			ws.StartKeepAlive(conn)
+
 			s.connsLock.Lock()
 			s.conns[fd] = conn
 			s.connsLock.Unlock()
@@ -145,6 +147,8 @@ func (s *consoleWs) connectVGA(op *operations.Operation, r *http.Request, w http
 		if err != nil {
 			return err
 		}
+
+		ws.StartKeepAlive(conn)
 
 		if fd == -1 {
 			logger.Debug("VGA control websocket connected")

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -440,7 +440,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 					// detect when the client disconnects to avoid leaving the command running
 					// in the background.
 					go func() {
-						_, _, err := conn.ReadMessage()
+						_, _, err := conn.ReadMessage() // Consume pings from server.
 
 						// If there is a control connection, then leave it to that handler
 						// to clean the command up. If there's no control connection, the
@@ -460,7 +460,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 					// avoid a situation where we hit an inactivity timeout on
 					// stderr during long exec sessions
 					go func() {
-						_, _, _ = conn.ReadMessage()
+						_, _, _ = conn.ReadMessage() // Consume pings from server.
 					}()
 				}
 

--- a/shared/ws/upgrader.go
+++ b/shared/ws/upgrader.go
@@ -5,10 +5,44 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/tcp"
 )
 
 // Upgrader is a websocket upgrader which ignores the request Origin.
 var Upgrader = websocket.Upgrader{
 	CheckOrigin:      func(r *http.Request) bool { return true },
 	HandshakeTimeout: time.Second * 5,
+}
+
+// StartKeepAlive sets TCP_USER_TIMEOUT and TCP keep alive timeouts on a connection and starts a periodic websocket
+// ping go routine if the underlying connection is TCP. Otherwise this is a no-op.
+func StartKeepAlive(conn *websocket.Conn) {
+	// Set TCP timeout options.
+	remoteTCP, _ := tcp.ExtractConn(conn.UnderlyingConn())
+	if remoteTCP == nil {
+		return
+	}
+
+	err := tcp.SetTimeouts(remoteTCP, 0)
+	if err != nil {
+		logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+	}
+
+	// Start channel keep alive to run until channel is closed.
+	go func() {
+		pingInterval := time.Second * 10
+		t := time.NewTicker(pingInterval)
+		defer t.Stop()
+
+		for {
+			err := conn.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
+			if err != nil {
+				return
+			}
+
+			<-t.C
+		}
+	}()
 }


### PR DESCRIPTION
To avoid prematurely disconnecting console clients using LXD UI.

Closes https://github.com/canonical/lxd/pull/15439 as is unnecessary with this change.
Fixes https://github.com/canonical/lxd-ui/issues/1193