### PR TITLE
doc: update admonitions for microcloud integrated docs

### DIFF
--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -6,9 +6,10 @@ relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
 # How to form a cluster
 
 ````{only} integrated
-```{note}
-MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles forming a LXD cluster. Following MicroCloud setup, LXD cluster commands can be used on the MicroCloud.
-```
+```{admonition} For MicroCloud users
+:class: note
+The MicroCloud setup process forms a LXD cluster. Thus, you do not need to follow the steps on this page. After MicroCloud setup, LXD cluster commands can be used with the MicroCloud cluster.
+``
 ````
 
 When forming a LXD cluster, you start with a bootstrap server.

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -2,8 +2,9 @@
 # How to initialize LXD
 
 ````{only} integrated
-```{note}
-MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles the initialization of LXD.
+```{admonition} For MicroCloud users
+:class: note
+The MicroCloud setup process initializes LXD on cluster members. Thus, you do not need to follow the steps on this page.
 ```
 ````
 

--- a/doc/howto/network_create.md
+++ b/doc/howto/network_create.md
@@ -2,9 +2,12 @@
 # How to create a network
 
 ````{only} integrated
-```{note}
-MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles forming a network. Following MicroCloud setup, LXD networking commands can be used with the MicroCloud.
+
+```{admonition} For MicroCloud users
+:class: note
+The MicroCloud setup process creates a network. Thus, you do not need to follow the steps on this page. After MicroCloud setup, LXD networking commands can be used with the cluster.
 ```
+
 ````
 
 To create a managed network, use the [`lxc network`](lxc_network.md) command and its subcommands.

--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -2,9 +2,12 @@
 # How to set up OVN with LXD
 
 ````{only} integrated
-```{note}
-MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles OVN network setup.
+
+```{admonition} For MicroCloud users
+:class: note
+The MicroCloud setup process sets up an OVN network. Thus, you do not need to follow the steps on this page.
 ```
+
 ````
 
 See the following sections for how to set up a basic OVN network, either as a standalone network or to host a small LXD cluster.

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -6,8 +6,9 @@ discourse: "[Building&#32;custom&#32;LXD&#32;binaries&#32;for&#32;side&#32;loadi
 # How to install LXD
 
 ````{only} integrated
-```{note}
-MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles the installation and configuration of LXD.
+```{admonition} For MicroCloud users
+:class: note
+The MicroCloud setup process installs LXD on cluster members. Thus, you do not need to follow the steps on this page.
 ```
 ````
 

--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -3,8 +3,9 @@
 
 ````{only} integrated
 
-```{note}
-MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles the installation and initialization of LXD.
+```{admonition} For MicroCloud users
+:class: note
+The MicroCloud setup process installs and initializes LXD. Thus, you do not need to follow the steps on this page.
 ```
 
 ````

--- a/doc/tutorial/ui.md
+++ b/doc/tutorial/ui.md
@@ -3,8 +3,9 @@
 
 ````{only} integrated
 
-```{note}
-MicroCloud users can skip the first Install and initialize LXD section and begin at the {ref}`Access the UI <tutorial-ui-access>` section. The MicroCloud setup process handles LXD installation and initialization.
+```{admonition} For MicroCloud users
+:class: note
+The MicroCloud setup process installs and initializes LXD. Thus, you can skip the first Install and initialize LXD section and begin at the {ref}`Access the UI <tutorial-ui-access>` section.
 ```
 
 ````


### PR DESCRIPTION
Updates (per documentation practice lead) to include an explicit title ("For MicroCloud users") and improve wording for the admonitions that appear only on certain LXD docs pages when viewed through the MicroCloud docs integration.