### PR TITLE
golangci-lint: enable testifylint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -81,6 +81,10 @@ linters:
         - name: duplicated-imports
         # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-return
         - name: error-return
+    testifylint:
+      disable:
+        - float-compare
+        - require-error
   exclusions:
     generated: lax
     paths:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     - misspell
     - prealloc
     - revive
+    - testifylint
     - whitespace
   settings:
     errcheck:

--- a/lxc-to-lxd/main_migrate_test.go
+++ b/lxc-to-lxd/main_migrate_test.go
@@ -220,7 +220,7 @@ func TestConvertNetworkConfig(t *testing.T) {
 
 		for _, conf := range tt.config {
 			parts := strings.SplitN(conf, "=", 2)
-			require.Equal(t, 2, len(parts))
+			require.Len(t, parts, 2)
 			err := c.SetConfigItem(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
 			require.NoError(t, err)
 		}

--- a/lxc/utils_properties_test.go
+++ b/lxc/utils_properties_test.go
@@ -35,7 +35,7 @@ func (s *utilsPropertiesTestSuite) TestStringToTimeHookFuncInvalidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncValidData() {
 	hookFunc := stringToBoolHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, interface{}) (interface{}, error))
+	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
 
 	result, err := hook(reflect.String, reflect.Bool, "t")
 	s.NoError(err)

--- a/lxc/utils_properties_test.go
+++ b/lxc/utils_properties_test.go
@@ -117,7 +117,7 @@ func (s *utilsPropertiesTestSuite) TestUnsetFieldByJsonTagValid() {
 
 	err := unsetFieldByJsonTag(&ts, "name")
 	s.NoError(err)
-	s.Equal("", ts.Name)
+	s.Empty(ts.Name)
 }
 
 func (s *utilsPropertiesTestSuite) TestUnsetFieldByJsonTagInvalid() {

--- a/lxc/utils_properties_test.go
+++ b/lxc/utils_properties_test.go
@@ -35,7 +35,7 @@ func (s *utilsPropertiesTestSuite) TestStringToTimeHookFuncInvalidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncValidData() {
 	hookFunc := stringToBoolHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error)) //nolint:revive
 
 	result, err := hook(reflect.String, reflect.Bool, "t")
 	s.NoError(err)
@@ -44,7 +44,7 @@ func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncValidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncInvalidData() {
 	hookFunc := stringToBoolHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error)) //nolint:revive
 
 	_, err := hook(reflect.String, reflect.Bool, "not a boolean")
 	s.Error(err, "Expected an error but got nil")
@@ -52,7 +52,7 @@ func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncInvalidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncValidData() {
 	hookFunc := stringToIntHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error)) //nolint:revive
 
 	result, err := hook(reflect.String, reflect.Int, "123")
 	s.NoError(err)
@@ -61,7 +61,7 @@ func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncValidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncInvalidData() {
 	hookFunc := stringToIntHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error)) //nolint:revive
 
 	_, err := hook(reflect.String, reflect.Int, "not an int")
 	s.Error(err, "Expected an error but got nil")
@@ -69,7 +69,7 @@ func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncInvalidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToFloatHookFuncValidData() {
 	hookFunc := stringToFloatHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error)) //nolint:revive
 
 	result, err := hook(reflect.String, reflect.Float64, "123.45")
 	s.NoError(err)
@@ -78,7 +78,7 @@ func (s *utilsPropertiesTestSuite) TestStringToFloatHookFuncValidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToFloatHookFuncInvalidData() {
 	hookFunc := stringToFloatHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error)) //nolint:revive
 
 	_, err := hook(reflect.String, reflect.Float64, "not a float")
 	s.Error(err, "Expected an error but got nil")

--- a/lxc/utils_properties_test.go
+++ b/lxc/utils_properties_test.go
@@ -106,7 +106,7 @@ func (s *utilsPropertiesTestSuite) TestSetFieldByJsonTagNonSettable() {
 	}
 
 	setFieldByJsonTag(&ts, "invalid name", "Jane Doe")
-	s.NotEqual(ts.Name, "Jane Doe")
+	s.NotEqual("Jane Doe", ts.Name)
 }
 
 func (s *utilsPropertiesTestSuite) TestUnsetFieldByJsonTagValid() {

--- a/lxc/utils_properties_test.go
+++ b/lxc/utils_properties_test.go
@@ -154,7 +154,7 @@ func (s *utilsPropertiesTestSuite) TestUnpackKVToWritable() {
 	s.Equal("John Doe", ws.Name)
 	s.Equal(30, ws.Age)
 	s.Equal(85.5, ws.Score)
-	s.Equal(true, ws.Alive)
+	s.True(ws.Alive)
 	s.Equal("2000-01-01T00:00:00Z", ws.Birth.Format(time.RFC3339))
 }
 

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -28,7 +28,7 @@ func (s *utilsTestSuite) TestIsAliasesSubsetTrue() {
 		{Name: "baz"},
 	}
 
-	s.Exactly(IsAliasesSubset(a1, a2), true)
+	s.Exactly(true, IsAliasesSubset(a1, a2))
 }
 
 func (s *utilsTestSuite) TestIsAliasesSubsetFalse() {
@@ -42,7 +42,7 @@ func (s *utilsTestSuite) TestIsAliasesSubsetFalse() {
 		{Name: "baz"},
 	}
 
-	s.Exactly(IsAliasesSubset(a1, a2), false)
+	s.Exactly(false, IsAliasesSubset(a1, a2))
 }
 
 func (s *utilsTestSuite) TestGetExistingAliases() {
@@ -68,9 +68,9 @@ func (s *utilsTestSuite) TestGetExistingAliasesEmpty() {
 }
 
 func (s *utilsTestSuite) TestStructHasFields() {
-	s.Equal(structHasField(reflect.TypeOf(api.Image{}), "type"), true)
-	s.Equal(structHasField(reflect.TypeOf(api.Image{}), "public"), true)
-	s.Equal(structHasField(reflect.TypeOf(api.Image{}), "foo"), false)
+	s.Equal(true, structHasField(reflect.TypeOf(api.Image{}), "type"))
+	s.Equal(true, structHasField(reflect.TypeOf(api.Image{}), "public"))
+	s.Equal(false, structHasField(reflect.TypeOf(api.Image{}), "foo"))
 }
 
 func (s *utilsTestSuite) TestGetServerSupportedFilters() {

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -28,7 +28,7 @@ func (s *utilsTestSuite) TestIsAliasesSubsetTrue() {
 		{Name: "baz"},
 	}
 
-	s.Exactly(true, IsAliasesSubset(a1, a2))
+	s.True(IsAliasesSubset(a1, a2))
 }
 
 func (s *utilsTestSuite) TestIsAliasesSubsetFalse() {
@@ -42,7 +42,7 @@ func (s *utilsTestSuite) TestIsAliasesSubsetFalse() {
 		{Name: "baz"},
 	}
 
-	s.Exactly(false, IsAliasesSubset(a1, a2))
+	s.False(IsAliasesSubset(a1, a2))
 }
 
 func (s *utilsTestSuite) TestGetExistingAliases() {
@@ -68,9 +68,9 @@ func (s *utilsTestSuite) TestGetExistingAliasesEmpty() {
 }
 
 func (s *utilsTestSuite) TestStructHasFields() {
-	s.Equal(true, structHasField(reflect.TypeOf(api.Image{}), "type"))
-	s.Equal(true, structHasField(reflect.TypeOf(api.Image{}), "public"))
-	s.Equal(false, structHasField(reflect.TypeOf(api.Image{}), "foo"))
+	s.True(structHasField(reflect.TypeOf(api.Image{}), "type"))
+	s.True(structHasField(reflect.TypeOf(api.Image{}), "public"))
+	s.False(structHasField(reflect.TypeOf(api.Image{}), "foo"))
 }
 
 func (s *utilsTestSuite) TestGetServerSupportedFilters() {

--- a/lxd/acme/acme_test.go
+++ b/lxd/acme/acme_test.go
@@ -68,7 +68,7 @@ func Test_certificateNeedsUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			needsUpdate := certificateNeedsUpdate(tt.args.domain, tt.args.cert)
-			require.Equal(t, needsUpdate, tt.want)
+			require.Equal(t, tt.want, needsUpdate)
 		})
 	}
 }

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -49,7 +49,7 @@ func TestCluster_Get(t *testing.T) {
 
 	cluster, _, err := client.GetCluster()
 	require.NoError(t, err)
-	assert.Equal(t, "", cluster.ServerName)
+	assert.Empty(t, cluster.ServerName)
 	assert.False(t, cluster.Enabled)
 }
 

--- a/lxd/api_internal_test.go
+++ b/lxd/api_internal_test.go
@@ -95,7 +95,7 @@ func TestInternalImportRootDevicePopulate_ExpandedDeviceProfileDeviceMatch(t *te
 
 	internalImportRootDevicePopulate(instancePoolName, localDevices, expandedDevices, profiles)
 
-	assert.Equal(t, 0, len(localDevices))
+	assert.Empty(t, localDevices)
 }
 
 // Test that for an instance with no local root disk device, if the new profile root disk device doesn't match the

--- a/lxd/api_internal_test.go
+++ b/lxd/api_internal_test.go
@@ -95,7 +95,7 @@ func TestInternalImportRootDevicePopulate_ExpandedDeviceProfileDeviceMatch(t *te
 
 	internalImportRootDevicePopulate(instancePoolName, localDevices, expandedDevices, profiles)
 
-	assert.Equal(t, len(localDevices), 0)
+	assert.Equal(t, 0, len(localDevices))
 }
 
 // Test that for an instance with no local root disk device, if the new profile root disk device doesn't match the

--- a/lxd/auth/drivers/tls_test.go
+++ b/lxd/auth/drivers/tls_test.go
@@ -284,18 +284,18 @@ func (s *tlsSuite) TestTLSAuthorizer() {
 			err := s.authorizer.CheckPermission(ctx, tt.entityURL, entitlement)
 			if tt.expectErr {
 				s.T().Logf("%q does not have %q on %q", tt.id.Name, entitlement, tt.entityURL)
-				s.Assert().Error(err)
-				s.Assert().True(api.StatusErrorCheck(err, tt.expectErrCode))
+				s.Error(err)
+				s.True(api.StatusErrorCheck(err, tt.expectErrCode))
 			} else {
 				s.T().Logf("%q has %q on %q", tt.id.Name, entitlement, tt.entityURL)
-				s.Assert().NoError(err)
+				s.NoError(err)
 			}
 
 			// If we don't expect an error from CheckPermission (e.g. access is allowed), then we expect the permission
 			// checker to return true (and vice versa).
 			permissionChecker, err := s.authorizer.GetPermissionChecker(ctx, entitlement, entityType)
-			s.Assert().NoError(err)
-			s.Assert().Equal(!tt.expectErr, permissionChecker(tt.entityURL))
+			s.NoError(err)
+			s.Equal(!tt.expectErr, permissionChecker(tt.entityURL))
 		}
 	}
 }

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -93,7 +93,7 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	_, err = config.Replace(map[string]any{})
 	assert.NoError(t, err)
 
-	assert.Equal(t, "", config.ProxyHTTP())
+	assert.Empty(t, config.ProxyHTTP())
 
 	values, err := tx.Config(context.Background())
 	require.NoError(t, err)

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -179,7 +179,7 @@ func TestGateway_RaftNodesNotLeader(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, nodes, 1)
-	assert.Equal(t, nodes[0].ID, uint64(1))
+	assert.Equal(t, uint64(1), nodes[0].ID)
 	assert.Equal(t, nodes[0].Address, address)
 }
 

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -59,7 +59,7 @@ func TestGateway_Single(t *testing.T) {
 	require.NoError(t, netConn.Close())
 
 	leader, err := gateway.LeaderAddress()
-	assert.Equal(t, "", leader)
+	assert.Empty(t, leader)
 	assert.EqualError(t, err, cluster.ErrNodeIsNotClustered.Error())
 
 	driver, err := driver.New(

--- a/lxd/cluster/member_state_test.go
+++ b/lxd/cluster/member_state_test.go
@@ -45,7 +45,7 @@ func TestClusterState(t *testing.T) {
 	for clusterMemberName, state := range states {
 		// Local cluster member
 		if clusterMemberName == "0" {
-			assert.Greater(t, state.SysInfo.LogicalCPUs, uint64(0))
+			assert.Positive(t, state.SysInfo.LogicalCPUs)
 			continue
 		}
 

--- a/lxd/cluster/member_state_test.go
+++ b/lxd/cluster/member_state_test.go
@@ -40,7 +40,7 @@ func TestClusterState(t *testing.T) {
 	states, err := cluster.ClusterState(state, cert)
 	require.NoError(t, err)
 
-	assert.Equal(t, 3, len(states))
+	assert.Len(t, states, 3)
 
 	for clusterMemberName, state := range states {
 		// Local cluster member
@@ -70,7 +70,7 @@ func TestClusterState(t *testing.T) {
 	states, err = cluster.ClusterState(state, cert, members...)
 	require.NoError(t, err)
 
-	assert.Equal(t, 2, len(states))
+	assert.Len(t, states, 2)
 	for _, state := range states {
 		assert.Equal(t, uint64(24), state.SysInfo.LogicalCPUs)
 	}

--- a/lxd/config/map_test.go
+++ b/lxd/config/map_test.go
@@ -300,7 +300,7 @@ func TestMap_Getters(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "hello", m.GetString("foo"))
-	assert.Equal(t, true, m.GetBool("bar"))
+	assert.True(t, m.GetBool("bar"))
 	assert.Equal(t, int64(123), m.GetInt64("egg"))
 }
 

--- a/lxd/db/certificates_test.go
+++ b/lxd/db/certificates_test.go
@@ -27,5 +27,5 @@ func TestGetCertificate(t *testing.T) {
 
 	cert, err := cluster.GetCertificate(ctx, tx.Tx(), "foobar")
 	require.NoError(t, err)
-	assert.Equal(t, cert.Fingerprint, "foobar")
+	assert.Equal(t, "foobar", cert.Fingerprint)
 }

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -766,7 +766,7 @@ func TestUpdateFromV34(t *testing.T) {
 	var nodeID any
 	require.NoError(t, row.Scan(&id, &nodeID))
 	assert.Equal(t, 2, id)
-	assert.Equal(t, nil, nodeID)
+	assert.Nil(t, nodeID)
 }
 
 func TestUpdateFromV69(t *testing.T) {

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -38,7 +38,7 @@ func TestUpdateFromV0(t *testing.T) {
 	_, err = db.Exec(stmt, time.Now())
 	require.Error(t, err)
 	var sqliteErr sqlite3.Error
-	require.True(t, errors.As(err, &sqliteErr))
+	require.ErrorAs(t, err, &sqliteErr)
 	require.Equal(t, sqlite3.ErrConstraintUnique, sqliteErr.ExtendedCode)
 }
 

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 	"time"

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -576,19 +576,19 @@ INSERT INTO instances VALUES (2, 1, 'eoan/snap', 2, 1, 0, ?, 0, ?, 'Eoan Ermine 
 
 	config, err := query.SelectConfig(context.Background(), tx, "instances_config", "id = 1")
 	require.NoError(t, err)
-	assert.Equal(t, config, map[string]string{"key": "value2"})
+	assert.Equal(t, map[string]string{"key": "value2"}, config)
 
 	config, err = query.SelectConfig(context.Background(), tx, "instances_snapshots_config", "id = 1")
 	require.NoError(t, err)
-	assert.Equal(t, config, map[string]string{"key": "value1"})
+	assert.Equal(t, map[string]string{"key": "value1"}, config)
 
 	config, err = query.SelectConfig(context.Background(), tx, "instances_devices_config", "id = 1")
 	require.NoError(t, err)
-	assert.Equal(t, config, map[string]string{"k": "v"})
+	assert.Equal(t, map[string]string{"k": "v"}, config)
 
 	config, err = query.SelectConfig(context.Background(), tx, "instances_snapshots_devices_config", "id = 1")
 	require.NoError(t, err)
-	assert.Equal(t, config, map[string]string{"k": "v"})
+	assert.Equal(t, map[string]string{"k": "v"}, config)
 }
 
 func TestUpdateFromV19(t *testing.T) {
@@ -676,7 +676,7 @@ func TestUpdateFromV25(t *testing.T) {
 	config, err := query.SelectConfig(context.Background(), tx, "storage_volumes_snapshots_config", "")
 	require.NoError(t, err)
 	assert.Len(t, config, 1)
-	assert.Equal(t, config["k"], "v-old")
+	assert.Equal(t, "v-old", config["k"])
 }
 
 func TestUpdateFromV26_WithoutVolumes(t *testing.T) {
@@ -721,7 +721,7 @@ func TestUpdateFromV26_WithVolumes(t *testing.T) {
 	ids, err := query.SelectIntegers(context.Background(), tx, "SELECT seq FROM sqlite_sequence WHERE name = 'storage_volumes'")
 	require.NoError(t, err)
 
-	assert.Equal(t, ids[0], 2)
+	assert.Equal(t, 2, ids[0])
 }
 
 func TestUpdateFromV34(t *testing.T) {
@@ -760,14 +760,14 @@ func TestUpdateFromV34(t *testing.T) {
 	count, err := query.Count(context.Background(), tx, "storage_volumes", "")
 	require.NoError(t, err)
 
-	assert.Equal(t, count, 1)
+	assert.Equal(t, 1, count)
 
 	row := tx.QueryRow("SELECT id, node_id FROM storage_volumes")
 	var id int
 	var nodeID any
 	require.NoError(t, row.Scan(&id, &nodeID))
-	assert.Equal(t, id, 2)
-	assert.Equal(t, nodeID, nil)
+	assert.Equal(t, 2, id)
+	assert.Equal(t, nil, nodeID)
 }
 
 func TestUpdateFromV69(t *testing.T) {

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -45,7 +45,7 @@ func (s *dbTestSuite) SetupTest() {
 	defer commit()
 
 	_, err := tx.Exec(fixtures)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *dbTestSuite) TearDownTest() {
@@ -59,7 +59,7 @@ func (s *dbTestSuite) CreateTestDb() (*Cluster, func()) {
 	// Setup logging if main() hasn't been called/when testing
 	if logger.Log == nil {
 		err = logger.InitLogger("", "", true, true, nil)
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	db, cleanup := NewTestCluster(s.T())
@@ -69,9 +69,9 @@ func (s *dbTestSuite) CreateTestDb() (*Cluster, func()) {
 // Enter a transaction on the test in-memory DB.
 func (s *dbTestSuite) CreateTestTx() (*sql.Tx, func()) {
 	tx, err := s.db.DB().Begin()
-	s.Nil(err)
+	s.NoError(err)
 	commit := func() {
-		s.Nil(tx.Commit())
+		s.NoError(tx.Commit())
 	}
 
 	return tx, commit
@@ -93,30 +93,30 @@ func (s *dbTestSuite) Test_deleting_a_container_cascades_on_related_tables() {
 	defer commit()
 
 	_, err = tx.Exec(statements)
-	s.Nil(err, "Error deleting container!")
+	s.NoError(err, "Error deleting container!")
 
 	// Make sure there are 0 container_profiles entries left.
 	statements = `SELECT count(*) FROM instances_profiles;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a container didn't delete the profile association!")
 
 	// Make sure there are 0 containers_config entries left.
 	statements = `SELECT count(*) FROM instances_config;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a container didn't delete the associated container_config!")
 
 	// Make sure there are 0 containers_devices entries left.
 	statements = `SELECT count(*) FROM instances_devices;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a container didn't delete the associated container_devices!")
 
 	// Make sure there are 0 containers_devices_config entries left.
 	statements = `SELECT count(*) FROM instances_devices_config;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a container didn't delete the associated container_devices_config!")
 }
 
@@ -132,30 +132,30 @@ func (s *dbTestSuite) Test_deleting_a_profile_cascades_on_related_tables() {
 	defer commit()
 
 	_, err = tx.Exec(statements)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Make sure there are 0 container_profiles entries left.
 	statements = `SELECT count(*) FROM instances_profiles WHERE profile_id = 2;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a profile didn't delete the container association!")
 
 	// Make sure there are 0 profiles_devices entries left.
 	statements = `SELECT count(*) FROM profiles_devices WHERE profile_id == 2;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a profile didn't delete the related profiles_devices!")
 
 	// Make sure there are 0 profiles_config entries left.
 	statements = `SELECT count(*) FROM profiles_config WHERE profile_id == 2;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a profile didn't delete the related profiles_config! There are %d left")
 
 	// Make sure there are 0 profiles_devices_config entries left.
 	statements = `SELECT count(*) FROM profiles_devices_config WHERE profile_device_id == 3;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting a profile didn't delete the related profiles_devices_config!")
 }
 
@@ -171,17 +171,17 @@ func (s *dbTestSuite) Test_deleting_an_image_cascades_on_related_tables() {
 	defer commit()
 
 	_, err = tx.Exec(statements)
-	s.Nil(err)
+	s.NoError(err)
 	// Make sure there are 0 images_aliases entries left.
 	statements = `SELECT count(*) FROM images_aliases;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting an image didn't delete the image alias association!")
 
 	// Make sure there are 0 images_properties entries left.
 	statements = `SELECT count(*) FROM images_properties;`
 	err = tx.QueryRow(statements).Scan(&count)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, count, "Deleting an image didn't delete the related images_properties!")
 }
 
@@ -195,7 +195,7 @@ func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
 		return err
 	})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(result)
 	s.Equal("filename", result.Filename)
 	s.Equal(result.CreatedAt.UTC(), time.Unix(1431547174, 0).UTC())
@@ -223,7 +223,7 @@ func (s *dbTestSuite) Test_ImageExists_true() {
 		return err
 	})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.True(exists)
 }
 
@@ -236,14 +236,14 @@ func (s *dbTestSuite) Test_ImageExists_false() {
 		return err
 	})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.False(exists)
 }
 
 func (s *dbTestSuite) Test_GetImageAlias_alias_exists() {
 	_ = s.db.Transaction(context.Background(), func(ctx context.Context, tx *ClusterTx) error {
 		_, alias, err := tx.GetImageAlias(ctx, "default", "somealias", true)
-		s.Nil(err)
+		s.NoError(err)
 		s.Equal("fingerprint", alias.Target)
 
 		return nil
@@ -262,10 +262,10 @@ func (s *dbTestSuite) Test_GetImageAlias_alias_does_not_exists() {
 func (s *dbTestSuite) Test_CreateImageAlias() {
 	_ = s.db.Transaction(context.Background(), func(ctx context.Context, tx *ClusterTx) error {
 		err := tx.CreateImageAlias(ctx, "default", "Chaosphere", 1, "Someone will like the name")
-		s.Nil(err)
+		s.NoError(err)
 
 		_, alias, err := tx.GetImageAlias(ctx, "default", "Chaosphere", true)
-		s.Nil(err)
+		s.NoError(err)
 		s.Equal("fingerprint", alias.Target)
 
 		return nil
@@ -277,13 +277,13 @@ func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint() {
 
 	_ = s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		imageID, _, err := tx.GetImage(ctx, "fingerprint", cluster.ImageFilter{Project: &project})
-		s.Nil(err)
+		s.NoError(err)
 
 		err = tx.CreateImageSource(ctx, imageID, "server.remote", "simplestreams", "", "test")
-		s.Nil(err)
+		s.NoError(err)
 
 		fingerprint, err := tx.GetCachedImageSourceFingerprint(ctx, "server.remote", "simplestreams", "test", "container", 0)
-		s.Nil(err)
+		s.NoError(err)
 		s.Equal("fingerprint", fingerprint)
 		return nil
 	})
@@ -294,10 +294,10 @@ func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint_no_match() {
 
 	_ = s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		imageID, _, err := tx.GetImage(ctx, "fingerprint", cluster.ImageFilter{Project: &project})
-		s.Nil(err)
+		s.NoError(err)
 
 		err = tx.CreateImageSource(ctx, imageID, "server.remote", "simplestreams", "", "test")
-		s.Nil(err)
+		s.NoError(err)
 
 		_, err = tx.GetCachedImageSourceFingerprint(ctx, "server.remote", "lxd", "test", "container", 0)
 		s.True(api.StatusErrorCheck(err, http.StatusNotFound))

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -99,25 +99,25 @@ func (s *dbTestSuite) Test_deleting_a_container_cascades_on_related_tables() {
 	statements = `SELECT count(*) FROM instances_profiles;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a container didn't delete the profile association!")
+	s.Equal(0, count, "Deleting a container didn't delete the profile association!")
 
 	// Make sure there are 0 containers_config entries left.
 	statements = `SELECT count(*) FROM instances_config;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a container didn't delete the associated container_config!")
+	s.Equal(0, count, "Deleting a container didn't delete the associated container_config!")
 
 	// Make sure there are 0 containers_devices entries left.
 	statements = `SELECT count(*) FROM instances_devices;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a container didn't delete the associated container_devices!")
+	s.Equal(0, count, "Deleting a container didn't delete the associated container_devices!")
 
 	// Make sure there are 0 containers_devices_config entries left.
 	statements = `SELECT count(*) FROM instances_devices_config;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a container didn't delete the associated container_devices_config!")
+	s.Equal(0, count, "Deleting a container didn't delete the associated container_devices_config!")
 }
 
 func (s *dbTestSuite) Test_deleting_a_profile_cascades_on_related_tables() {
@@ -138,25 +138,25 @@ func (s *dbTestSuite) Test_deleting_a_profile_cascades_on_related_tables() {
 	statements = `SELECT count(*) FROM instances_profiles WHERE profile_id = 2;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a profile didn't delete the container association!")
+	s.Equal(0, count, "Deleting a profile didn't delete the container association!")
 
 	// Make sure there are 0 profiles_devices entries left.
 	statements = `SELECT count(*) FROM profiles_devices WHERE profile_id == 2;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a profile didn't delete the related profiles_devices!")
+	s.Equal(0, count, "Deleting a profile didn't delete the related profiles_devices!")
 
 	// Make sure there are 0 profiles_config entries left.
 	statements = `SELECT count(*) FROM profiles_config WHERE profile_id == 2;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a profile didn't delete the related profiles_config! There are %d left")
+	s.Equal(0, count, "Deleting a profile didn't delete the related profiles_config! There are %d left")
 
 	// Make sure there are 0 profiles_devices_config entries left.
 	statements = `SELECT count(*) FROM profiles_devices_config WHERE profile_device_id == 3;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting a profile didn't delete the related profiles_devices_config!")
+	s.Equal(0, count, "Deleting a profile didn't delete the related profiles_devices_config!")
 }
 
 func (s *dbTestSuite) Test_deleting_an_image_cascades_on_related_tables() {
@@ -176,13 +176,13 @@ func (s *dbTestSuite) Test_deleting_an_image_cascades_on_related_tables() {
 	statements = `SELECT count(*) FROM images_aliases;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting an image didn't delete the image alias association!")
+	s.Equal(0, count, "Deleting an image didn't delete the image alias association!")
 
 	// Make sure there are 0 images_properties entries left.
 	statements = `SELECT count(*) FROM images_properties;`
 	err = tx.QueryRow(statements).Scan(&count)
 	s.Nil(err)
-	s.Equal(count, 0, "Deleting an image didn't delete the related images_properties!")
+	s.Equal(0, count, "Deleting an image didn't delete the related images_properties!")
 }
 
 func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
@@ -197,7 +197,7 @@ func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
 
 	s.Nil(err)
 	s.NotNil(result)
-	s.Equal(result.Filename, "filename")
+	s.Equal("filename", result.Filename)
 	s.Equal(result.CreatedAt.UTC(), time.Unix(1431547174, 0).UTC())
 	s.Equal(result.ExpiresAt.UTC(), time.Unix(1431547175, 0).UTC())
 	s.Equal(result.UploadedAt.UTC(), time.Unix(1431547176, 0).UTC())
@@ -244,7 +244,7 @@ func (s *dbTestSuite) Test_GetImageAlias_alias_exists() {
 	_ = s.db.Transaction(context.Background(), func(ctx context.Context, tx *ClusterTx) error {
 		_, alias, err := tx.GetImageAlias(ctx, "default", "somealias", true)
 		s.Nil(err)
-		s.Equal(alias.Target, "fingerprint")
+		s.Equal("fingerprint", alias.Target)
 
 		return nil
 	})
@@ -266,7 +266,7 @@ func (s *dbTestSuite) Test_CreateImageAlias() {
 
 		_, alias, err := tx.GetImageAlias(ctx, "default", "Chaosphere", true)
 		s.Nil(err)
-		s.Equal(alias.Target, "fingerprint")
+		s.Equal("fingerprint", alias.Target)
 
 		return nil
 	})
@@ -284,7 +284,7 @@ func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint() {
 
 		fingerprint, err := tx.GetCachedImageSourceFingerprint(ctx, "server.remote", "simplestreams", "test", "container", 0)
 		s.Nil(err)
-		s.Equal(fingerprint, "fingerprint")
+		s.Equal("fingerprint", fingerprint)
 		return nil
 	})
 }

--- a/lxd/db/images_test.go
+++ b/lxd/db/images_test.go
@@ -82,7 +82,7 @@ func TestGetImage(t *testing.T) {
 		// 'public' is ignored if 'false'
 		id, img, err := tx.GetImage(ctx, "a", cluster.ImageFilter{Project: &project})
 		require.NoError(t, err)
-		assert.Equal(t, true, img.Public)
+		assert.True(t, img.Public)
 		assert.NotEqual(t, id, -1)
 
 		// non-public image with 'default' project
@@ -100,7 +100,7 @@ func TestGetImage(t *testing.T) {
 		public := true
 		id, img, err = tx.GetImage(ctx, "a", cluster.ImageFilter{Project: &project, Public: &public})
 		require.NoError(t, err)
-		assert.Equal(t, true, img.Public)
+		assert.True(t, img.Public)
 		assert.NotEqual(t, id, -1)
 
 		return nil

--- a/lxd/db/images_test.go
+++ b/lxd/db/images_test.go
@@ -82,7 +82,7 @@ func TestGetImage(t *testing.T) {
 		// 'public' is ignored if 'false'
 		id, img, err := tx.GetImage(ctx, "a", cluster.ImageFilter{Project: &project})
 		require.NoError(t, err)
-		assert.Equal(t, img.Public, true)
+		assert.Equal(t, true, img.Public)
 		assert.NotEqual(t, id, -1)
 
 		// non-public image with 'default' project
@@ -100,7 +100,7 @@ func TestGetImage(t *testing.T) {
 		public := true
 		id, img, err = tx.GetImage(ctx, "a", cluster.ImageFilter{Project: &project, Public: &public})
 		require.NoError(t, err)
-		assert.Equal(t, img.Public, true)
+		assert.Equal(t, true, img.Public)
 		assert.NotEqual(t, id, -1)
 
 		return nil

--- a/lxd/db/images_test.go
+++ b/lxd/db/images_test.go
@@ -25,7 +25,7 @@ func TestLocateImage(t *testing.T) {
 
 		address, err := tx.LocateImage(ctx, "abc")
 		require.NoError(t, err)
-		assert.Equal(t, "", address)
+		assert.Empty(t, address)
 
 		// Pretend that the function is being run on another node.
 		tx.NodeID(2)
@@ -39,7 +39,7 @@ func TestLocateImage(t *testing.T) {
 		require.NoError(t, err)
 
 		address, err = tx.LocateImage(ctx, "abc")
-		require.Equal(t, "", address)
+		require.Empty(t, address)
 		require.EqualError(t, err, "Image not available on any online member")
 
 		return nil

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -51,7 +51,7 @@ func TestContainerList(t *testing.T) {
 	assert.Equal(t, "c1", c1.Name)
 	assert.Equal(t, "node2", c1.Node)
 	assert.Equal(t, map[string]string{}, c1Config)
-	assert.Len(t, c1Devices, 0)
+	assert.Empty(t, c1Devices)
 
 	c2 := containers[1]
 	c2Devices, err := cluster.GetInstanceDevices(context.TODO(), tx.Tx(), c2.ID)
@@ -536,13 +536,13 @@ func TestGetLocalInstancesInProject(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]string{"z": "w", "a": "b"}, c2Config)
-	assert.Len(t, c2Devices, 0)
+	assert.Empty(t, c2Devices)
 
 	c3Config, err := cluster.GetInstanceConfig(context.TODO(), tx.Tx(), containers[2].ID)
 	require.NoError(t, err)
 	c3Devices, err := cluster.GetInstanceDevices(context.TODO(), tx.Tx(), containers[2].ID)
 	require.NoError(t, err)
-	assert.Len(t, c3Config, 0)
+	assert.Empty(t, c3Config)
 	assert.Equal(t, map[string]map[string]string{"root": {"type": "disk", "x": "y"}}, cluster.DevicesToAPI(c3Devices))
 }
 

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -59,7 +59,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 
 	networkID, err := tx.GetNetworkID(context.Background(), api.ProjectDefaultName, "network1")
 	require.NoError(t, err)
-	assert.True(t, networkID > 0)
+	assert.Positive(t, networkID)
 
 	config = map[string]string{"bridge.external_interfaces": "bar"}
 	err = tx.CreatePendingNetwork(context.Background(), "rusp", api.ProjectDefaultName, "network1", db.NetworkTypeBridge, config)

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -39,9 +39,9 @@ func TestGetNetworksLocalConfigs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, config, map[string]map[string]string{
+	assert.Equal(t, map[string]map[string]string{
 		"lxdbr0": {"bridge.external_interfaces": "vlan0"},
-	})
+	}, config)
 }
 
 func TestCreatePendingNetwork(t *testing.T) {

--- a/lxd/db/node/update_test.go
+++ b/lxd/db/node/update_test.go
@@ -24,7 +24,7 @@ func TestUpdateFromV38_RaftNodes(t *testing.T) {
 	err = query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error {
 		roles, err := query.SelectIntegers(ctx, tx, "SELECT role FROM raft_nodes")
 		require.NoError(t, err)
-		assert.Equal(t, roles, []int{0})
+		assert.Equal(t, []int{0}, roles)
 		return nil
 	})
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestUpdateFromV37_CopyCoreHTTPSAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, clusterAddress, "1.2.3.4:666")
+	assert.Equal(t, "1.2.3.4:666", clusterAddress)
 }
 
 // If clustering is not enabled, the core.https_address config does not get copied.

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -232,7 +232,7 @@ func TestNodeIsEmpty_Instances(t *testing.T) {
 
 	message, err := tx.NodeIsEmpty(context.Background(), id)
 	require.NoError(t, err)
-	assert.Equal(t, "", message)
+	assert.Empty(t, message)
 
 	_, err = tx.Tx().Exec(`
 INSERT INTO instances (id, node_id, name, architecture, type, project_id, description) VALUES (1, ?, 'foo', 1, 1, 1, '')
@@ -248,7 +248,7 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 
 	message, err = tx.NodeIsEmpty(context.Background(), id)
 	require.NoError(t, err)
-	assert.Equal(t, "", message)
+	assert.Empty(t, message)
 }
 
 // A node is considered empty only if it has no images that are available only
@@ -280,7 +280,7 @@ INSERT INTO images_nodes(image_id, node_id) VALUES(1, 1)`)
 
 	message, err = tx.NodeIsEmpty(context.Background(), id)
 	require.NoError(t, err)
-	assert.Equal(t, "", message)
+	assert.Empty(t, message)
 }
 
 // A node is considered empty only if it has no custom volumes on it.

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -39,12 +39,12 @@ func TestOperation(t *testing.T) {
 	operations, err := cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
 	assert.Len(t, operations, 1)
-	assert.Equal(t, operations[0].UUID, "abcd")
+	assert.Equal(t, "abcd", operations[0].UUID)
 
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err := cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, len(ops), 1)
+	assert.Equal(t, 1, len(ops))
 	operation := ops[0]
 	assert.Equal(t, id, operation.ID)
 	assert.Equal(t, operationtype.InstanceCreate, operation.Type)
@@ -60,7 +60,7 @@ func TestOperation(t *testing.T) {
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err = cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, len(ops), 0)
+	assert.Equal(t, 0, len(ops))
 }
 
 // Add, get and remove an operation not associated with any project.
@@ -85,12 +85,12 @@ func TestOperationNoProject(t *testing.T) {
 	operations, err := cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
 	assert.Len(t, operations, 1)
-	assert.Equal(t, operations[0].UUID, "abcd")
+	assert.Equal(t, "abcd", operations[0].UUID)
 
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err := cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, len(ops), 1)
+	assert.Equal(t, 1, len(ops))
 	operation := ops[0]
 	require.NoError(t, err)
 	assert.Equal(t, id, operation.ID)
@@ -107,5 +107,5 @@ func TestOperationNoProject(t *testing.T) {
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err = cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, len(ops), 0)
+	assert.Equal(t, 0, len(ops))
 }

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -60,7 +60,7 @@ func TestOperation(t *testing.T) {
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err = cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(ops))
+	assert.Empty(t, ops)
 }
 
 // Add, get and remove an operation not associated with any project.
@@ -107,5 +107,5 @@ func TestOperationNoProject(t *testing.T) {
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err = cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(ops))
+	assert.Empty(t, ops)
 }

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -44,7 +44,7 @@ func TestOperation(t *testing.T) {
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err := cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(ops))
+	assert.Len(t, ops, 1)
 	operation := ops[0]
 	assert.Equal(t, id, operation.ID)
 	assert.Equal(t, operationtype.InstanceCreate, operation.Type)
@@ -90,7 +90,7 @@ func TestOperationNoProject(t *testing.T) {
 	filter = cluster.OperationFilter{UUID: &uuid}
 	ops, err := cluster.GetOperations(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(ops))
+	assert.Len(t, ops, 1)
 	operation := ops[0]
 	require.NoError(t, err)
 	assert.Equal(t, id, operation.ID)

--- a/lxd/db/query/dump_test.go
+++ b/lxd/db/query/dump_test.go
@@ -99,7 +99,7 @@ func TestDumpTableStoragePoolsConfig(t *testing.T) {
 );`, dump["storage_pools_config"][1])
 	data, err := query.GetTableData(context.Background(), tx, "storage_pools_config")
 	require.NoError(t, err)
-	assert.Equal(t, data, []string{"INSERT INTO storage_pools_config VALUES(1,1,NULL,'k','v');"})
+	assert.Equal(t, []string{"INSERT INTO storage_pools_config VALUES(1,1,NULL,'k','v');"}, data)
 }
 
 // Return a new transaction against an in-memory SQLite database populated with

--- a/lxd/db/query/slices_test.go
+++ b/lxd/db/query/slices_test.go
@@ -76,7 +76,7 @@ func TestInsertStrings(t *testing.T) {
 
 	values, err := query.SelectStrings(context.Background(), tx, "SELECT name FROM test ORDER BY name DESC LIMIT 2")
 	require.NoError(t, err)
-	assert.Equal(t, values, []string{"yy", "xx"})
+	assert.Equal(t, []string{"yy", "xx"}, values)
 }
 
 // Return a new transaction against an in-memory SQLite database with a single

--- a/lxd/db/query/slices_test.go
+++ b/lxd/db/query/slices_test.go
@@ -35,7 +35,7 @@ var testStringsErrorCases = []struct {
 func TestStrings(t *testing.T) {
 	tx := newTxForSlices(t)
 	values, err := query.SelectStrings(context.Background(), tx, "SELECT name FROM test ORDER BY name")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"bar", "foo"}, values)
 }
 
@@ -63,7 +63,7 @@ var testIntegersErrorCases = []struct {
 func TestIntegers(t *testing.T) {
 	tx := newTxForSlices(t)
 	values, err := query.SelectIntegers(context.Background(), tx, "SELECT id FROM test ORDER BY id")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []int{0, 1}, values)
 }
 

--- a/lxd/db/query/transaction_test.go
+++ b/lxd/db/query/transaction_test.go
@@ -19,7 +19,7 @@ func TestTransaction_BeginError(t *testing.T) {
 	require.NoError(t, err)
 
 	err = query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error { return nil })
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Failed to begin transaction")
 }
 

--- a/lxd/db/schema/schema_test.go
+++ b/lxd/db/schema/schema_test.go
@@ -67,7 +67,7 @@ func TestSchemaEnsure_VersionMoreRecentThanExpected(t *testing.T) {
 
 	schema, _ = newSchemaAndDB(t)
 	_, err = schema.Ensure(db)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.EqualError(t, err, "schema version '1' is more recent than expected '0'")
 }
 
@@ -79,7 +79,7 @@ func TestSchemaEnsure_FreshStatementError(t *testing.T) {
 	schema.Fresh("garbage")
 
 	_, err := schema.Ensure(db)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot apply fresh schema")
 }
 
@@ -98,7 +98,7 @@ func TestSchemaEnsure_MissingVersion(t *testing.T) {
 	schema.Add(updateNoop)
 
 	_, err = schema.Ensure(db)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.EqualError(t, err, "Missing updates: 1 to 3")
 }
 

--- a/lxd/db/schema/update_test.go
+++ b/lxd/db/schema/update_test.go
@@ -19,6 +19,6 @@ func TestDotGo(t *testing.T) {
 	}
 
 	require.NoError(t, schema.DotGo(updates, "xyz", "xyz.go"))
-	require.Equal(t, true, shared.PathExists("xyz.go"))
+	require.True(t, shared.PathExists("xyz.go"))
 	require.NoError(t, os.Remove("xyz.go"))
 }

--- a/lxd/db/snapshots_test.go
+++ b/lxd/db/snapshots_test.go
@@ -46,7 +46,7 @@ func TestGetInstanceSnapshots(t *testing.T) {
 	assert.Equal(t, "snap1", s1.Name)
 	assert.Equal(t, "c1", s1.Instance)
 	assert.Equal(t, map[string]string{}, s1Config)
-	assert.Len(t, s1Devices, 0)
+	assert.Empty(t, s1Devices)
 
 	s2Config, err := cluster.GetInstanceSnapshotConfig(context.TODO(), tx.Tx(), snapshots[1].ID)
 	require.NoError(t, err)

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -217,7 +217,7 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, thisVolume)
 	assert.Equal(t, volumeID, thisVolume.ID)
-	assert.Equal(t, "", thisVolume.Location)
+	assert.Empty(t, thisVolume.Location)
 
 	// Update the volume
 	config["k"] = "v2"

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -59,9 +59,9 @@ func TestGetStoragePoolsLocalConfigs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, config, map[string]map[string]string{
+	assert.Equal(t, map[string]map[string]string{
 		"BTRFS": {"source": "/egg/baz"},
-	})
+	}, config)
 }
 
 func TestStoragePoolsCreatePending(t *testing.T) {
@@ -217,7 +217,7 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, thisVolume)
 	assert.Equal(t, volumeID, thisVolume.ID)
-	assert.Equal(t, thisVolume.Location, "")
+	assert.Equal(t, "", thisVolume.Location)
 
 	// Update the volume
 	config["k"] = "v2"
@@ -278,10 +278,10 @@ func TestCreateStoragePoolVolume_Snapshot(t *testing.T) {
 		require.NoError(t, err)
 
 		n := tx.GetNextStorageVolumeSnapshotIndex(ctx, "p1", "v1", 1, "snap%d")
-		assert.Equal(t, n, 1)
+		assert.Equal(t, 1, n)
 
 		n = tx.GetNextStorageVolumeSnapshotIndex(ctx, "p2", "v1", 1, "snap%d")
-		assert.Equal(t, n, 0)
+		assert.Equal(t, 0, n)
 
 		return nil
 	})

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -79,7 +79,7 @@ func TestStoragePoolsCreatePending(t *testing.T) {
 
 	poolID, err := tx.GetStoragePoolID(context.Background(), "pool1")
 	require.NoError(t, err)
-	assert.True(t, poolID > 0)
+	assert.Positive(t, poolID)
 
 	config = map[string]string{"source": "/bar"}
 	err = tx.CreatePendingStoragePool(context.Background(), "rusp", "pool1", "dir", config)

--- a/lxd/device/device_utils_disk_test.go
+++ b/lxd/device/device_utils_disk_test.go
@@ -22,11 +22,11 @@ func TestDiskAddRootUserNSEntry(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, idmaps, expected)
+	assert.Equal(t, expected, idmaps)
 
 	// Check doesn't add another one if an existing combined entry exists.
 	idmaps = diskAddRootUserNSEntry(idmaps, 65534)
-	assert.Equal(t, idmaps, expected)
+	assert.Equal(t, expected, idmaps)
 
 	// Check adds a root gid entry if root uid entry already exists.
 	idmaps = []idmap.IdmapEntry{
@@ -57,7 +57,7 @@ func TestDiskAddRootUserNSEntry(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, idmaps, expected)
+	assert.Equal(t, expected, idmaps)
 
 	// Check adds a root uid entry if root gid entry already exists.
 	idmaps = []idmap.IdmapEntry{
@@ -88,5 +88,5 @@ func TestDiskAddRootUserNSEntry(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, idmaps, expected)
+	assert.Equal(t, expected, idmaps)
 }

--- a/lxd/endpoints/devlxd_test.go
+++ b/lxd/endpoints/devlxd_test.go
@@ -22,5 +22,5 @@ func TestEndpoints_DevLxdCreateUnixSocket(t *testing.T) {
 
 	// The unix socket file gets removed after shutdown.
 	cleanup()
-	assert.Equal(t, false, shared.PathExists(path))
+	assert.False(t, shared.PathExists(path))
 }

--- a/lxd/endpoints/endpoints_test.go
+++ b/lxd/endpoints/endpoints_test.go
@@ -104,6 +104,6 @@ func assertNoSocketBasedActivation(t *testing.T) {
 	// confusing child processes or other logic.
 	for _, name := range []string{"LISTEN_PID", "LISTEN_FDS"} {
 		_, ok := os.LookupEnv(name)
-		assert.Equal(t, false, ok)
+		assert.False(t, ok)
 	}
 }

--- a/lxd/endpoints/local_test.go
+++ b/lxd/endpoints/local_test.go
@@ -24,7 +24,7 @@ func TestEndpoints_LocalCreateUnixSocket(t *testing.T) {
 
 	// The unix socket file gets removed after shutdown.
 	cleanup()
-	assert.Equal(t, false, shared.PathExists(path))
+	assert.False(t, shared.PathExists(path))
 }
 
 // If socket-based activation is detected, it will be used for binding the API
@@ -57,7 +57,7 @@ func TestEndpoints_LocalSocketBasedActivation(t *testing.T) {
 	// which prevents listeners created from file descriptors from removing
 	// their socket files on close).
 	cleanup()
-	assert.Equal(t, true, shared.PathExists(path))
+	assert.True(t, shared.PathExists(path))
 }
 
 // If a custom group for the unix socket is specified, but no such one exists,

--- a/lxd/idmap/idmapset_linux_test.go
+++ b/lxd/idmap/idmapset_linux_test.go
@@ -116,11 +116,11 @@ func TestIdmapSetIntersects(t *testing.T) {
 func TestIdmapHostIDMapRange(t *testing.T) {
 	// Check empty entry is not covered.
 	idmap := IdmapEntry{}
-	assert.Equal(t, false, idmap.HostIDsCoveredBy(nil, nil))
+	assert.False(t, idmap.HostIDsCoveredBy(nil, nil))
 
 	// Check nil allowed lists are not covered.
 	idmap = IdmapEntry{Isuid: true, Hostid: 1000, Maprange: 1}
-	assert.Equal(t, false, idmap.HostIDsCoveredBy(nil, nil))
+	assert.False(t, idmap.HostIDsCoveredBy(nil, nil))
 
 	// Check that UID/GID specific host IDs are covered by equivalent UID/GID specific host ID rule.
 	uidOnlyEntry := IdmapEntry{Isuid: true, Hostid: 1000, Maprange: 1}
@@ -134,33 +134,33 @@ func TestIdmapHostIDMapRange(t *testing.T) {
 		{Isgid: true, Hostid: 1000, Maprange: 1},
 	}
 
-	assert.Equal(t, true, uidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
-	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
-	assert.Equal(t, true, uidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+	assert.True(t, uidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.False(t, uidOnlyEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.True(t, uidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
 
-	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
-	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
-	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+	assert.False(t, uidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.False(t, uidOnlyEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.False(t, uidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
 
-	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
-	assert.Equal(t, true, gidOnlyEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
-	assert.Equal(t, true, gidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+	assert.False(t, gidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.True(t, gidOnlyEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.True(t, gidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
 
-	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
-	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
-	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+	assert.False(t, gidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.False(t, gidOnlyEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.False(t, gidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
 
 	// Check ranges are correctly blocked when not covered by single ID allow list.
 	uidOnlyRangeEntry := IdmapEntry{Isuid: true, Hostid: 1000, Maprange: 2}
 	gidOnlyRangeEntry := IdmapEntry{Isgid: true, Hostid: 1000, Maprange: 2}
 
-	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
-	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
-	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+	assert.False(t, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.False(t, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.False(t, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
 
-	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
-	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
-	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+	assert.False(t, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.False(t, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.False(t, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
 
 	// Check ranges are allowed when fully covered.
 	allowedUIDMaps = []IdmapEntry{
@@ -171,34 +171,34 @@ func TestIdmapHostIDMapRange(t *testing.T) {
 		{Isgid: true, Hostid: 1000, Maprange: 2},
 	}
 
-	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
-	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
-	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+	assert.True(t, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.False(t, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.True(t, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
 
-	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
-	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
-	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+	assert.False(t, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.True(t, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.True(t, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
 
 	// Check ranges for combined allowed ID maps are correctly validated.
 	allowedCombinedMaps := []IdmapEntry{
 		{Isuid: true, Isgid: true, Hostid: 1000, Maprange: 2},
 	}
 
-	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
-	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
-	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
+	assert.True(t, uidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.False(t, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.True(t, uidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
 
-	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
-	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
-	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
+	assert.False(t, gidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.True(t, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.True(t, gidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
 
 	combinedEntry := IdmapEntry{Isuid: true, Isgid: true, Hostid: 1000, Maprange: 1}
 
-	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
-	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
-	assert.Equal(t, true, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
+	assert.False(t, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.False(t, combinedEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.True(t, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
 
-	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
-	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
-	assert.Equal(t, true, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
+	assert.False(t, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.False(t, combinedEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.True(t, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
 }

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -32,7 +32,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
 
@@ -70,7 +70,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		return err
 	})
 
-	suite.Req.Nil(err, "Failed to create the unprivileged profile.")
+	suite.Req.NoError(err, "Failed to create the unprivileged profile.")
 	defer func() {
 		_ = suite.d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			return cluster.DeleteProfile(ctx, tx.Tx(), "default", "unprivileged")
@@ -84,7 +84,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 
 		return err
 	})
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	args := db.InstanceArgs{
 		Type:      instancetype.Container,
@@ -94,7 +94,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
 
@@ -127,15 +127,15 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 
 		return err
 	})
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
 
 	out, _, err := c.Render()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	state, ok := out.(*api.Instance)
 	suite.Req.True(ok)
@@ -167,39 +167,39 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 
 		return err
 	})
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	// Create the container
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
 
 	poolName, err := c.StoragePool()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	pool, err := storagePools.LoadByName(state, poolName)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		_, err = tx.CreateStoragePoolVolume(ctx, c.Project().Name, c.Name(), "", cluster.StoragePoolVolumeTypeContainer, pool.ID(), nil, cluster.StoragePoolVolumeContentTypeFS, time.Now())
 
 		return err
 	})
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	// Load the container and trigger initLXC()
 	c2, err := instance.LoadByProjectAndName(state, "default", "testFoo")
 	c2.IsRunning()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	hostInterfaces, _ := net.Interfaces()
 
 	apiC1, etagC1, err := c.RenderFull(hostInterfaces)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	apiC2, etagC2, err := c2.RenderFull(hostInterfaces)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	suite.Equal(etagC1, etagC2)
 	suite.Exactly(
@@ -218,7 +218,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
 
@@ -235,7 +235,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
 
@@ -251,10 +251,10 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
-	suite.Req.Nil(c.Delete(true), "Failed to delete the container.")
+	suite.Req.NoError(c.Delete(true), "Failed to delete the container.")
 }
 
 func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
@@ -273,7 +273,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 
 		return err
 	})
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	args := db.InstanceArgs{
 		Type:     instancetype.Container,
@@ -337,10 +337,10 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
-	suite.Req.Nil(c.Delete(true), "Failed to delete the container.")
+	suite.Req.NoError(c.Delete(true), "Failed to delete the container.")
 }
 
 func (suite *containerTestSuite) TestContainer_Rename() {
@@ -351,11 +351,11 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
 
-	suite.Req.Nil(c.Rename("testFoo2", true), "Failed to rename the container.")
+	suite.Req.NoError(c.Rename("testFoo2", true), "Failed to rename the container.")
 	suite.Req.Equal(shared.VarPath("containers", "testFoo2"), c.Path())
 }
 
@@ -367,7 +367,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 			"security.idmap.isolated": "true",
 		},
 	}, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
 
@@ -378,14 +378,14 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 			"security.idmap.isolated": "true",
 		},
 	}, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c2.Delete(true) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	map2, err := c2.(instance.Container).NextIdmap()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	host := suite.d.os.IdmapSet.Idmap[0]
 
@@ -410,7 +410,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 			"security.idmap.isolated": "false",
 		},
 	}, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
 
@@ -421,14 +421,14 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 			"security.idmap.isolated": "true",
 		},
 	}, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c2.Delete(true) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	map2, err := c2.(instance.Container).NextIdmap()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	host := suite.d.os.IdmapSet.Idmap[0]
 
@@ -454,12 +454,12 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 			"raw.idmap":               "both 1000 1000",
 		},
 	}, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 
 	host := suite.d.os.IdmapSet.Idmap[0]
 
@@ -497,17 +497,17 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 
 		/* we should fail if there are no ids left */
 		if i == 6 {
-			suite.Req.NotNil(err)
+			suite.Req.Error(err)
 			return
 		}
 
-		suite.Req.Nil(err)
+		suite.Req.NoError(err)
 
 		op.Done(nil)
 		instances = append(instances, c)
 
 		m, err := c.(instance.Container).NextIdmap()
-		suite.Req.Nil(err)
+		suite.Req.NoError(err)
 
 		maps = append(maps, m)
 	}
@@ -526,7 +526,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 
 	for _, c := range instances {
 		err := c.Delete(true)
-		suite.Req.NotNil(err)
+		suite.Req.Error(err)
 	}
 }
 

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -297,7 +297,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		},
 		Name: "testFoo",
 	}, true)
-	suite.Req.NoError(err, fmt.Errorf("Adding multiple routed with gateway mode ['none'] should succeed. "))
+	suite.Req.NoError(err, "Adding multiple routed with gateway mode ['none'] should succeed.")
 
 	eth0["ipv6.gateway"] = "auto"
 	eth1["ipv6.gateway"] = ""
@@ -312,7 +312,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}, true)
 	suite.Req.Error(err,
-		fmt.Errorf("Adding multiple routed nic devices with any gateway mmode ['auto',''] should throw error. "))
+		"Adding multiple routed nic devices with any gateway mode ['auto',''] should throw error.")
 
 	err = c.Update(db.InstanceArgs{
 		Type:     instancetype.Container,
@@ -325,7 +325,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}, true)
 	suite.Req.NoError(err,
-		fmt.Errorf("Adding multiple nic devices with unicque nictype ['routed'] should throw error. "))
+		"Adding multiple nic devices with unique nictype ['routed'] should throw error.")
 }
 
 func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {

--- a/lxd/node/config_test.go
+++ b/lxd/node/config_test.go
@@ -68,7 +68,7 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": ""}, changed)
 
-	assert.Equal(t, "", config.HTTPSAddress())
+	assert.Empty(t, config.HTTPSAddress())
 
 	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestHTTPSAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	assert.Equal(t, "", config.HTTPSAddress())
+	assert.Empty(t, config.HTTPSAddress())
 
 	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err = node.ConfigLoad(ctx, tx)
@@ -149,7 +149,7 @@ func TestClusterAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "", nodeConfig.ClusterAddress())
+	assert.Empty(t, nodeConfig.ClusterAddress())
 
 	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodeConfig, err = node.ConfigLoad(ctx, tx)

--- a/lxd/project/limits/permission_internal_test.go
+++ b/lxd/project/limits/permission_internal_test.go
@@ -24,7 +24,7 @@ func TestParseHostIDMapRange(t *testing.T) {
 		}
 
 		idmaps, err := parseHostIDMapRange(isUID, isGID, "foo")
-		assert.NotErrorIs(t, err, nil)
+		assert.Error(t, err)
 		assert.Nil(t, idmaps)
 
 		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000")
@@ -38,7 +38,7 @@ func TestParseHostIDMapRange(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, err, nil)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, idmaps)
 
 		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000-1001")
@@ -52,7 +52,7 @@ func TestParseHostIDMapRange(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, err, nil)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, idmaps)
 
 		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000-1001,1002")
@@ -73,7 +73,7 @@ func TestParseHostIDMapRange(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, err, nil)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, idmaps)
 	}
 }

--- a/lxd/project/limits/permission_internal_test.go
+++ b/lxd/project/limits/permission_internal_test.go
@@ -39,7 +39,7 @@ func TestParseHostIDMapRange(t *testing.T) {
 		}
 
 		assert.ErrorIs(t, err, nil)
-		assert.Equal(t, idmaps, expected)
+		assert.Equal(t, expected, idmaps)
 
 		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000-1001")
 		expected = []idmap.IdmapEntry{
@@ -53,7 +53,7 @@ func TestParseHostIDMapRange(t *testing.T) {
 		}
 
 		assert.ErrorIs(t, err, nil)
-		assert.Equal(t, idmaps, expected)
+		assert.Equal(t, expected, idmaps)
 
 		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000-1001,1002")
 		expected = []idmap.IdmapEntry{
@@ -74,7 +74,7 @@ func TestParseHostIDMapRange(t *testing.T) {
 		}
 
 		assert.ErrorIs(t, err, nil)
-		assert.Equal(t, idmaps, expected)
+		assert.Equal(t, expected, idmaps)
 	}
 }
 

--- a/lxd/project/limits/permissions_test.go
+++ b/lxd/project/limits/permissions_test.go
@@ -250,7 +250,7 @@ func TestCheckClusterTargetRestriction_RestrictedTrueWithOverride(t *testing.T) 
 	require.NoError(t, err)
 
 	err = limits.CheckClusterTargetRestriction(authorizer, req, p, "n1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 // If a direct targeting is allowed, the check passes.

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -19,10 +19,10 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
-	suite.Equal(true, snapshotIsScheduledNow("* * * * *",
+	suite.True(snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),
 		"snapshot.schedule config '* * * * *' should have matched now")
-	suite.Equal(true, snapshotIsScheduledNow("@daily,"+
+	suite.True(snapshotIsScheduledNow("@daily,"+
 		"@hourly,"+
 		"@midnight,"+
 		"@weekly,"+

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -18,7 +18,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 	}
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
-	suite.Req.Nil(err)
+	suite.Req.NoError(err)
 	suite.True(snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),
 		"snapshot.schedule config '* * * * *' should have matched now")

--- a/lxd/util/net_test.go
+++ b/lxd/util/net_test.go
@@ -23,7 +23,7 @@ func TestInMemoryNetwork(t *testing.T) {
 
 	go func() {
 		_, err := client.Write([]byte("hello"))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	buffer := make([]byte, 5)

--- a/shared/entity/type_test.go
+++ b/shared/entity/type_test.go
@@ -319,7 +319,7 @@ func TestURL(t *testing.T) {
 			}
 
 			normalisedURL, err := actualEntityType.URL(actualProject, actualLocation, actualPathArgs...)
-			assert.Equal(t, normalisedURL.String(), tt.expectedNormalisedURL)
+			assert.Equal(t, tt.expectedNormalisedURL, normalisedURL.String())
 			assert.NoError(t, err)
 		})
 	}

--- a/shared/network_ip_test.go
+++ b/shared/network_ip_test.go
@@ -216,7 +216,7 @@ func TestParseNetworks(t *testing.T) {
 			if tc.expectErr {
 				assert.Error(t, err, "Expected ParseNetworks to return an error.")
 			} else {
-				assert.Nil(t, err, "Expected ParseNetworks to succeed.")
+				assert.NoError(t, err, "Expected ParseNetworks to succeed.")
 			}
 
 			require.Equal(t, len(nets), len(tc.expectNets), "Expected number of networks in/out to match.")

--- a/shared/network_ip_test.go
+++ b/shared/network_ip_test.go
@@ -219,7 +219,7 @@ func TestParseNetworks(t *testing.T) {
 				assert.NoError(t, err, "Expected ParseNetworks to succeed.")
 			}
 
-			require.Equal(t, len(nets), len(tc.expectNets), "Expected number of networks in/out to match.")
+			require.Len(t, tc.expectNets, len(nets), "Expected number of networks in/out to match.")
 
 			for i, net := range nets {
 				assert.Equal(t, net.String(), tc.expectNets[i], "Expected networks to match.")

--- a/shared/osarch/release_test.go
+++ b/shared/osarch/release_test.go
@@ -24,7 +24,7 @@ VERSION_ID="16.04"
 	defer cleanup()
 
 	lsbRelease, err := getLSBRelease(filename)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(
 		map[string]string{
 			"NAME":       "Ubuntu",
@@ -39,7 +39,7 @@ func (s *releaseTestSuite) TestGetLSBReleaseSingleQuotes() {
 	defer cleanup()
 
 	lsbRelease, err := getLSBRelease(filename)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(map[string]string{"NAME": "Ubuntu"}, lsbRelease)
 }
 
@@ -49,7 +49,7 @@ func (s *releaseTestSuite) TestGetLSBReleaseNoQuotes() {
 	defer cleanup()
 
 	lsbRelease, err := getLSBRelease(filename)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(map[string]string{"NAME": "Ubuntu"}, lsbRelease)
 }
 
@@ -65,7 +65,7 @@ VERSION_ID="16.04"
 	defer cleanup()
 
 	lsbRelease, err := getLSBRelease(filename)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(
 		map[string]string{
 			"NAME":       "Ubuntu",

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -259,7 +259,6 @@ func TestGetExpiry(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedDate, expiryDate)
 
-	refDate = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 	expiryDate, err = GetExpiry(refDate, "5S 1M 2H 3d 4y")
 	expectedDate = time.Date(2004, time.January, 4, 2, 1, 5, 0, time.UTC)
 	require.NoError(t, err)

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -266,8 +266,9 @@ func TestGetExpiry(t *testing.T) {
 	require.Equal(t, expectedDate, expiryDate)
 
 	expiryDate, err = GetExpiry(refDate, "0M 0H 0d 0w 0m 0y")
+	expectedDate = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 	require.NoError(t, err)
-	require.Equal(t, expiryDate, expiryDate)
+	require.Equal(t, expectedDate, expiryDate)
 
 	expiryDate, err = GetExpiry(refDate, "")
 	require.NoError(t, err)

--- a/shared/version/version_test.go
+++ b/shared/version/version_test.go
@@ -16,7 +16,7 @@ func TestVersionTestSuite(t *testing.T) {
 
 func (s *versionTestSuite) TestNewVersion() {
 	v, err := NewDottedVersion("1.2.3")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, v.Major)
 	s.Equal(2, v.Minor)
 	s.Equal(3, v.Patch)
@@ -24,19 +24,19 @@ func (s *versionTestSuite) TestNewVersion() {
 
 func (s *versionTestSuite) TestNewVersionNoPatch() {
 	v, err := NewDottedVersion("1.2")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(-1, v.Patch)
 }
 
 func (s *versionTestSuite) TestNewVersionInvalid() {
 	v, err := NewDottedVersion("1.nope")
 	s.Nil(v)
-	s.NotNil(err)
+	s.Error(err)
 }
 
 func (s *versionTestSuite) TestParseDashes() {
 	v, err := Parse("1.2.3-asdf")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, v.Major)
 	s.Equal(2, v.Minor)
 	s.Equal(3, v.Patch)
@@ -44,7 +44,7 @@ func (s *versionTestSuite) TestParseDashes() {
 
 func (s *versionTestSuite) TestParseParentheses() {
 	v, err := Parse("1.2.3(beta1)")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, v.Major)
 	s.Equal(2, v.Minor)
 	s.Equal(3, v.Patch)
@@ -53,7 +53,7 @@ func (s *versionTestSuite) TestParseParentheses() {
 func (s *versionTestSuite) TestParseFail() {
 	v, err := Parse("asdfaf")
 	s.Nil(v)
-	s.NotNil(err)
+	s.Error(err)
 }
 
 func (s *versionTestSuite) TestString() {


### PR DESCRIPTION
All the changes with the `(testifylint)` marker in their commit messages were done using `testifylint -fix`.

After those changes, `testifylint -disable float-compare,require-error ./...` comes out clean.