### PR TITLE
Stop generating `fmt.Errorf` calls without format directives in `lxd-generate`

### DIFF
--- a/lxd/db/cluster/auth_groups.mapper.go
+++ b/lxd/db/cluster/auth_groups.mapper.go
@@ -186,9 +186,9 @@ func GetAuthGroups(ctx context.Context, tx *sql.Tx, filters ...AuthGroupFilter) 
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty AuthGroupFilter")
+			return nil, errors.New("Cannot filter on empty AuthGroupFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -224,7 +224,7 @@ func GetAuthGroup(ctx context.Context, tx *sql.Tx, name string) (*AuthGroup, err
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"auths_groups\" entry matches")
+		return nil, errors.New("More than one \"auths_groups\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/cluster_groups.mapper.go
+++ b/lxd/db/cluster/cluster_groups.mapper.go
@@ -155,9 +155,9 @@ func GetClusterGroups(ctx context.Context, tx *sql.Tx, filters ...ClusterGroupFi
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty ClusterGroupFilter")
+			return nil, errors.New("Cannot filter on empty ClusterGroupFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -193,7 +193,7 @@ func GetClusterGroup(ctx context.Context, tx *sql.Tx, name string) (*ClusterGrou
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"clusters_groups\" entry matches")
+		return nil, errors.New("More than one \"clusters_groups\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/config.mapper.go
+++ b/lxd/db/cluster/config.mapper.go
@@ -7,6 +7,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -87,9 +88,9 @@ func GetConfig(ctx context.Context, tx *sql.Tx, parent string, filters ...Config
 	// Result slice.
 	objects := make([]Config, 0)
 
-	configObjectsLocal := strings.Replace(configObjects, "%s_id", parent+"_id", -1)
+	configObjectsLocal := strings.ReplaceAll(configObjects, "%s_id", parent+"_id")
 	fillParent := make([]any, strings.Count(configObjectsLocal, "%s"))
-	mangledParent := strings.Replace(parent, "_", "s_", -1) + "s"
+	mangledParent := strings.ReplaceAll(parent, "_", "s_") + "s"
 	for i := range fillParent {
 		fillParent[i] = mangledParent
 	}
@@ -118,7 +119,7 @@ func GetConfig(ctx context.Context, tx *sql.Tx, parent string, filters ...Config
 		}
 
 		if len(entries) == 0 {
-			return nil, fmt.Errorf("Cannot filter on empty ConfigFilter")
+			return nil, errors.New("Cannot filter on empty ConfigFilter")
 		}
 
 		queryParts[0] += fmt.Sprintf(cond, strings.Join(entries, " AND "))
@@ -152,10 +153,10 @@ func CreateConfig(ctx context.Context, tx *sql.Tx, parent string, object Config)
 		return nil
 	}
 
-	configCreateLocal := strings.Replace(configCreate, "%s_id", parent+"_id", -1)
+	configCreateLocal := strings.ReplaceAll(configCreate, "%s_id", parent+"_id")
 	fillParent := make([]any, strings.Count(configCreateLocal, "%s"))
 	for i := range fillParent {
-		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
+		fillParent[i] = strings.ReplaceAll(parent, "_", "s_") + "s"
 	}
 
 	queryStr := fmt.Sprintf(configCreateLocal, fillParent...)
@@ -196,10 +197,10 @@ func UpdateConfig(ctx context.Context, tx *sql.Tx, parent string, referenceID in
 // DeleteConfig deletes the config matching the given key parameters.
 // generator: config DeleteMany
 func DeleteConfig(ctx context.Context, tx *sql.Tx, parent string, referenceID int) error {
-	configDeleteLocal := strings.Replace(configDelete, "%s_id", parent+"_id", -1)
+	configDeleteLocal := strings.ReplaceAll(configDelete, "%s_id", parent+"_id")
 	fillParent := make([]any, strings.Count(configDeleteLocal, "%s"))
 	for i := range fillParent {
-		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
+		fillParent[i] = strings.ReplaceAll(parent, "_", "s_") + "s"
 	}
 
 	queryStr := fmt.Sprintf(configDeleteLocal, fillParent...)

--- a/lxd/db/cluster/devices.mapper.go
+++ b/lxd/db/cluster/devices.mapper.go
@@ -7,6 +7,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -87,9 +88,9 @@ func GetDevices(ctx context.Context, tx *sql.Tx, parent string, filters ...Devic
 	// Result slice.
 	objects := make([]Device, 0)
 
-	deviceObjectsLocal := strings.Replace(deviceObjects, "%s_id", parent+"_id", -1)
+	deviceObjectsLocal := strings.ReplaceAll(deviceObjects, "%s_id", parent+"_id")
 	fillParent := make([]any, strings.Count(deviceObjectsLocal, "%s"))
-	mangledParent := strings.Replace(parent, "_", "s_", -1) + "s"
+	mangledParent := strings.ReplaceAll(parent, "_", "s_") + "s"
 	for i := range fillParent {
 		fillParent[i] = mangledParent
 	}
@@ -118,7 +119,7 @@ func GetDevices(ctx context.Context, tx *sql.Tx, parent string, filters ...Devic
 		}
 
 		if len(entries) == 0 {
-			return nil, fmt.Errorf("Cannot filter on empty DeviceFilter")
+			return nil, errors.New("Cannot filter on empty DeviceFilter")
 		}
 
 		queryParts[0] += fmt.Sprintf(cond, strings.Join(entries, " AND "))
@@ -136,7 +137,7 @@ func GetDevices(ctx context.Context, tx *sql.Tx, parent string, filters ...Devic
 		filter := f.Config
 		if filter != nil {
 			if filter.Key == nil && filter.Value == nil {
-				return nil, fmt.Errorf("Cannot filter on empty ConfigFilter")
+				return nil, errors.New("Cannot filter on empty ConfigFilter")
 			}
 
 			configFilters = append(configFilters, *filter)
@@ -173,10 +174,10 @@ func GetDevices(ctx context.Context, tx *sql.Tx, parent string, filters ...Devic
 // CreateDevices adds a new device to the database.
 // generator: device Create
 func CreateDevices(ctx context.Context, tx *sql.Tx, parent string, objects map[string]Device) error {
-	deviceCreateLocal := strings.Replace(deviceCreate, "%s_id", parent+"_id", -1)
+	deviceCreateLocal := strings.ReplaceAll(deviceCreate, "%s_id", parent+"_id")
 	fillParent := make([]any, strings.Count(deviceCreateLocal, "%s"))
 	for i := range fillParent {
-		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
+		fillParent[i] = strings.ReplaceAll(parent, "_", "s_") + "s"
 	}
 
 	queryStr := fmt.Sprintf(deviceCreateLocal, fillParent...)
@@ -235,10 +236,10 @@ func UpdateDevices(ctx context.Context, tx *sql.Tx, parent string, referenceID i
 // DeleteDevices deletes the device matching the given key parameters.
 // generator: device DeleteMany
 func DeleteDevices(ctx context.Context, tx *sql.Tx, parent string, referenceID int) error {
-	deviceDeleteLocal := strings.Replace(deviceDelete, "%s_id", parent+"_id", -1)
+	deviceDeleteLocal := strings.ReplaceAll(deviceDelete, "%s_id", parent+"_id")
 	fillParent := make([]any, strings.Count(deviceDeleteLocal, "%s"))
 	for i := range fillParent {
-		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
+		fillParent[i] = strings.ReplaceAll(parent, "_", "s_") + "s"
 	}
 
 	queryStr := fmt.Sprintf(deviceDeleteLocal, fillParent...)

--- a/lxd/db/cluster/identities.mapper.go
+++ b/lxd/db/cluster/identities.mapper.go
@@ -310,9 +310,9 @@ func GetIdentitys(ctx context.Context, tx *sql.Tx, filters ...IdentityFilter) ([
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.AuthMethod == nil && filter.Type == nil && filter.Identifier == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty IdentityFilter")
+			return nil, errors.New("Cannot filter on empty IdentityFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -349,7 +349,7 @@ func GetIdentity(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, identif
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"identity\" entry matches")
+		return nil, errors.New("More than one \"identity\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/identity_provider_groups.mapper.go
+++ b/lxd/db/cluster/identity_provider_groups.mapper.go
@@ -186,9 +186,9 @@ func GetIdentityProviderGroups(ctx context.Context, tx *sql.Tx, filters ...Ident
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty IdentityProviderGroupFilter")
+			return nil, errors.New("Cannot filter on empty IdentityProviderGroupFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -224,7 +224,7 @@ func GetIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) (*Id
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"identity_providers_groups\" entry matches")
+		return nil, errors.New("More than one \"identity_providers_groups\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/images.mapper.go
+++ b/lxd/db/cluster/images.mapper.go
@@ -7,6 +7,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -324,9 +325,9 @@ func GetImages(ctx context.Context, tx *sql.Tx, filters ...ImageFilter) ([]Image
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-			return nil, fmt.Errorf("Cannot filter on empty ImageFilter")
+			return nil, errors.New("Cannot filter on empty ImageFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -363,6 +364,6 @@ func GetImage(ctx context.Context, tx *sql.Tx, project string, fingerprint strin
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"images\" entry matches")
+		return nil, errors.New("More than one \"images\" entry matches")
 	}
 }

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -655,9 +655,9 @@ func GetInstances(ctx context.Context, tx *sql.Tx, filters ...InstanceFilter) ([
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
-			return nil, fmt.Errorf("Cannot filter on empty InstanceFilter")
+			return nil, errors.New("Cannot filter on empty InstanceFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -731,7 +731,7 @@ func GetInstance(ctx context.Context, tx *sql.Tx, project string, name string) (
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"instances\" entry matches")
+		return nil, errors.New("More than one \"instances\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/nodes_cluster_groups.mapper.go
+++ b/lxd/db/cluster/nodes_cluster_groups.mapper.go
@@ -7,6 +7,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -136,9 +137,9 @@ func GetNodeClusterGroups(ctx context.Context, tx *sql.Tx, filters ...NodeCluste
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.GroupID == nil {
-			return nil, fmt.Errorf("Cannot filter on empty NodeClusterGroupFilter")
+			return nil, errors.New("Cannot filter on empty NodeClusterGroupFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -7,6 +7,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -209,9 +210,9 @@ func GetOperations(ctx context.Context, tx *sql.Tx, filters ...OperationFilter) 
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.NodeID == nil && filter.UUID == nil {
-			return nil, fmt.Errorf("Cannot filter on empty OperationFilter")
+			return nil, errors.New("Cannot filter on empty OperationFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -291,9 +291,9 @@ func GetProfiles(ctx context.Context, tx *sql.Tx, filters ...ProfileFilter) ([]P
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty ProfileFilter")
+			return nil, errors.New("Cannot filter on empty ProfileFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -367,7 +367,7 @@ func GetProfile(ctx context.Context, tx *sql.Tx, project string, name string) (*
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"profiles\" entry matches")
+		return nil, errors.New("More than one \"profiles\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -186,9 +186,9 @@ func GetProjects(ctx context.Context, tx *sql.Tx, filters ...ProjectFilter) ([]P
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty ProjectFilter")
+			return nil, errors.New("Cannot filter on empty ProjectFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -240,7 +240,7 @@ func GetProject(ctx context.Context, tx *sql.Tx, name string) (*Project, error) 
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"projects\" entry matches")
+		return nil, errors.New("More than one \"projects\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -221,9 +221,9 @@ func GetInstanceSnapshots(ctx context.Context, tx *sql.Tx, filters ...InstanceSn
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Project == nil && filter.Instance == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty InstanceSnapshotFilter")
+			return nil, errors.New("Cannot filter on empty InstanceSnapshotFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -298,7 +298,7 @@ func GetInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, instan
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"instances_snapshots\" entry matches")
+		return nil, errors.New("More than one \"instances_snapshots\" entry matches")
 	}
 }
 

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -346,9 +346,9 @@ func GetWarnings(ctx context.Context, tx *sql.Tx, filters ...WarningFilter) ([]W
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.UUID == nil && filter.Project == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityType == nil && filter.EntityID == nil && filter.Status == nil {
-			return nil, fmt.Errorf("Cannot filter on empty WarningFilter")
+			return nil, errors.New("Cannot filter on empty WarningFilter")
 		} else {
-			return nil, fmt.Errorf("No statement exists for the given Filter")
+			return nil, errors.New("No statement exists for the given Filter")
 		}
 	}
 
@@ -384,7 +384,7 @@ func GetWarning(ctx context.Context, tx *sql.Tx, uuid string) (*Warning, error) 
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"warnings\" entry matches")
+		return nil, errors.New("More than one \"warnings\" entry matches")
 	}
 }
 

--- a/lxd/db/generate/db/constants.go
+++ b/lxd/db/generate/db/constants.go
@@ -5,6 +5,7 @@ package db
 // Imports is a list of the package imports every generated source file has.
 var Imports = []string{
 	"database/sql",
+	"errors",
 	"fmt",
 	"github.com/canonical/lxd/lxd/db/query",
 	"github.com/canonical/lxd/shared/api",

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -219,7 +219,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 		}
 
 		buf.L("if len(entries) == 0 {")
-		buf.L("return nil, fmt.Errorf(\"Cannot filter on empty %s\")", entityFilter(mapping.Name))
+		buf.L("return nil, errors.New(\"Cannot filter on empty %s\")", entityFilter(mapping.Name))
 		buf.L("}")
 		buf.N()
 		buf.L("queryParts[0] += fmt.Sprintf(cond, strings.Join(entries, \" AND \"))")
@@ -312,9 +312,9 @@ func (m *Method) getMany(buf *file.Buffer) error {
 		}
 
 		buf.L("%s %s {", branch, activeCriteria([]string{}, FieldNames(mapping.Filters)))
-		buf.L("return nil, fmt.Errorf(\"Cannot filter on empty %s\")", entityFilter(mapping.Name))
+		buf.L("return nil, errors.New(\"Cannot filter on empty %s\")", entityFilter(mapping.Name))
 		buf.L("} else {")
-		buf.L("return nil, fmt.Errorf(\"No statement exists for the given Filter\")")
+		buf.L("return nil, errors.New(\"No statement exists for the given Filter\")")
 		buf.L("}")
 		buf.L("}")
 		buf.N()
@@ -380,7 +380,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 			buf.L("filter := f.%s", refStruct)
 			buf.L("if filter != nil {")
 			buf.L("if %s {", activeCriteria(nil, FieldNames(refMapping.Filters)))
-			buf.L("return nil, fmt.Errorf(\"Cannot filter on empty %s\")", entityFilter(refMapping.Name))
+			buf.L("return nil, errors.New(\"Cannot filter on empty %s\")", entityFilter(refMapping.Name))
 			buf.L("}")
 			buf.N()
 			buf.L("%sFilters = append(%sFilters, *filter)", refVar, refVar)
@@ -419,7 +419,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 			buf.L("filter := f.%s", refStruct)
 			buf.L("if filter != nil {")
 			buf.L("if %s {", activeCriteria(nil, FieldNames(refMapping.Filters)))
-			buf.L("return nil, fmt.Errorf(\"Cannot filter on empty %s\")", entityFilter(refMapping.Name))
+			buf.L("return nil, errors.New(\"Cannot filter on empty %s\")", entityFilter(refMapping.Name))
 			buf.L("}")
 			buf.N()
 			buf.L("%sFilters = append(%sFilters, *filter)", refVar, refVar)
@@ -577,7 +577,7 @@ func (m *Method) getOne(buf *file.Buffer) error {
 	buf.L("case 1:")
 	buf.L("        return &objects[0], nil")
 	buf.L("default:")
-	buf.L(`        return nil, fmt.Errorf("More than one \"%s\" entry matches")`, entityTable(m.entity, m.config["table"]))
+	buf.L(`        return nil, errors.New("More than one \"%s\" entry matches")`, entityTable(m.entity, m.config["table"]))
 	buf.L("}")
 
 	return nil


### PR DESCRIPTION
Discussed here https://github.com/canonical/lxd/pull/15502#discussion_r2071295337 and quickly put up a PR as I only found a few other cases. Verified that there are no more generated occurrences of this using `grep -r 'fmt\.Errorf[^%]*)' lxd/db/cluster | grep -c 'mapper.go'`.