### PR TITLE
lxd/response/swagger: annotate individual strucs for nolint:unused

### DIFF
--- a/lxd/response/swagger.go
+++ b/lxd/response/swagger.go
@@ -1,6 +1,4 @@
 // Package response contains helpers for rendering LXD HTTP responses.
-//
-//nolint:unused
 package response
 
 import (
@@ -10,7 +8,7 @@ import (
 // Operation
 //
 // swagger:response Operation
-type swaggerOperation struct {
+type swaggerOperation struct { //nolint:unused
 	// Empty sync response
 	// in: body
 	Body struct {
@@ -33,7 +31,7 @@ type swaggerOperation struct {
 // Empty sync response
 //
 // swagger:response EmptySyncResponse
-type swaggerEmptySyncResponse struct {
+type swaggerEmptySyncResponse struct { //nolint:unused
 	// Empty sync response
 	// in: body
 	Body struct {
@@ -51,7 +49,7 @@ type swaggerEmptySyncResponse struct {
 // Bad Request
 //
 // swagger:response BadRequest
-type swaggerBadRequest struct {
+type swaggerBadRequest struct { //nolint:unused
 	// Bad Request
 	// in: body
 	Body struct {
@@ -69,7 +67,7 @@ type swaggerBadRequest struct {
 // Forbidden
 //
 // swagger:response Forbidden
-type swaggerForbidden struct {
+type swaggerForbidden struct { //nolint:unused
 	// Bad Request
 	// in: body
 	Body struct {
@@ -87,7 +85,7 @@ type swaggerForbidden struct {
 // Precondition Failed
 //
 // swagger:response PreconditionFailed
-type swaggerPreconditionFailed struct {
+type swaggerPreconditionFailed struct { //nolint:unused
 	// Internal server Error
 	// in: body
 	Body struct {
@@ -105,7 +103,7 @@ type swaggerPreconditionFailed struct {
 // Internal Server Error
 //
 // swagger:response InternalServerError
-type swaggerInternalServerError struct {
+type swaggerInternalServerError struct { //nolint:unused
 	// Internal server Error
 	// in: body
 	Body struct {
@@ -123,7 +121,7 @@ type swaggerInternalServerError struct {
 // Not found
 //
 // swagger:response NotFound
-type swaggerNotFound struct {
+type swaggerNotFound struct { //nolint:unused
 	// Not found
 	// in: body
 	Body struct {
@@ -141,7 +139,7 @@ type swaggerNotFound struct {
 // Not implemented
 //
 // swagger:response NotImplemented
-type swaggerNotImplemented struct {
+type swaggerNotImplemented struct { //nolint:unused
 	// Not implemented
 	// in: body
 	Body struct {


### PR DESCRIPTION
The TICS scanner doesn't seem to recognise the file level `//nolint:unused` directive and report each structs as being unused so try to workaround that limitation.

Note that those structs are actually needed and they end up in the generate REST API doc.