### PR TITLE
lxd/device: Skip address conflict validation for instance NIC rename

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -402,6 +402,12 @@ func (d *nicBridged) checkAddressConflict() error {
 		// that has DNS enabled and is connected to the same untagged VLAN.
 		if d.network != nil && d.network.Config()["dns.mode"] != "none" && nicCheckDNSNameConflict(d.inst.Name(), inst.Name) {
 			if sameLogicalInstance {
+				// Skip NICs that are being renamed.
+				_, nicInPendingExpandedDevices := d.inst.ExpandedDevices()[nicName]
+				if !nicInPendingExpandedDevices {
+					return nil
+				}
+
 				return api.StatusErrorf(http.StatusConflict, "Instance DNS name %q conflict between %q and %q because both are connected to same network", strings.ToLower(inst.Name), d.name, nicName)
 			}
 

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -423,7 +423,7 @@ test_container_devices_nic_bridged() {
 
   # Test DHCP lease clearance.
   lxc delete "${ctName}" -f
-  lxc launch testimage "${ctName}" -p "${ctName}"
+  lxc launch testimage "${ctName}" -d "${SMALL_ROOT_DISK}" -p "${ctName}"
 
   # Request DHCPv4 lease with custom name (to check managed name is allocated instead).
   lxc exec "${ctName}" -- udhcpc -f -i eth0 -n -q -t5 -F "${ctName}custom"

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -67,7 +67,7 @@ test_container_devices_nic_bridged() {
   lxc profile device set "${ctName}" eth0 queue.tx.length "1200"
   lxc profile device set "${ctName}" eth0 hwaddr "${ctMAC}"
 
-  lxc init testimage "${ctName}" -p "${ctName}"
+  lxc init testimage "${ctName}" -d "${SMALL_ROOT_DISK}" -p "${ctName}"
 
   # Check that adding another NIC to the same network fails because it triggers duplicate instance DNS name checks.
   # Because this would effectively cause 2 NICs with the same instance name to be connected to the same network.
@@ -551,7 +551,7 @@ test_container_devices_nic_bridged() {
   fi
 
   # Check dnsmasq host file is updated on new device.
-  lxc init testimage "${ctName}" -p "${ctName}"
+  lxc init testimage "${ctName}" -d "${SMALL_ROOT_DISK}" -p "${ctName}"
   lxc config device add "${ctName}" eth0 nic nictype=bridged parent="${brName}" name=eth0 ipv4.address=192.0.2.200 ipv6.address=2001:db8::200
 
   ls -lR "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/"
@@ -704,7 +704,7 @@ test_container_devices_nic_bridged() {
   fi
 
   # Test interface naming scheme.
-  lxc init testimage test-naming
+  lxc init testimage -d "${SMALL_ROOT_DISK}" test-naming
   lxc start test-naming
   lxc query "/1.0/instances/test-naming/state" | jq -r .network.eth0.host_name | grep ^veth
   lxc stop -f test-naming
@@ -818,7 +818,7 @@ test_container_devices_nic_bridged() {
   lxc delete -f foo
 
   # Test container without extra network configuration can be restored from backup.
-  lxc init testimage foo -p "${ctName}"
+  lxc init testimage foo -d "${SMALL_ROOT_DISK}" -p "${ctName}"
   lxc export foo foo.tar.gz
   lxc import foo.tar.gz foo2
   rm foo.tar.gz


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15300.