### PR TITLE
Storage: Add all custom storage vols to instance's backup config

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -255,7 +255,8 @@ func backupWriteIndex(sourceInst instance.Instance, pool storagePools.Pool, opti
 		return os.ErrNotExist
 	}
 
-	config, err := pool.GenerateInstanceBackupConfig(sourceInst, snapshots, nil)
+	// Do not include any custom storage volumes (and their pools) in the backup config.
+	config, err := pool.GenerateInstanceBackupConfig(sourceInst, snapshots, nil, nil)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance backup config: %w", err)
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8283,8 +8283,13 @@ func (d *lxc) UpdateBackupFile() error {
 		return err
 	}
 
+	volBackupConf, err := pool.GenerateInstanceCustomVolumeBackupConfig(d, nil, true, nil)
+	if err != nil {
+		return fmt.Errorf("Failed generating instance custom volume config: %w", err)
+	}
+
 	// Use the global metadata version.
-	return pool.UpdateInstanceBackupFile(d, true, nil, config.DefaultMetadataVersion, nil)
+	return pool.UpdateInstanceBackupFile(d, true, volBackupConf, config.DefaultMetadataVersion, nil)
 }
 
 // Info returns "lxc" and the currently loaded version of LXC.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5324,7 +5324,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) (err error) {
 		}
 	}
 
-	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, d.op)
+	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, nil, d.op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance migration config: %w", err)
 	}
@@ -8284,7 +8284,7 @@ func (d *lxc) UpdateBackupFile() error {
 	}
 
 	// Use the global metadata version.
-	return pool.UpdateInstanceBackupFile(d, true, config.DefaultMetadataVersion, nil)
+	return pool.UpdateInstanceBackupFile(d, true, nil, config.DefaultMetadataVersion, nil)
 }
 
 // Info returns "lxc" and the currently loaded version of LXC.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6559,7 +6559,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
 	d.logger.Debug("Set migration offer volume size", logger.Ctx{"blockSize": blockSize})
 	offerHeader.VolumeSize = &blockSize
 
-	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, d.op)
+	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, nil, d.op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance migration config: %w", err)
 	}
@@ -8460,7 +8460,7 @@ func (d *qemu) UpdateBackupFile() error {
 	}
 
 	// Use the global metadata version.
-	return pool.UpdateInstanceBackupFile(d, true, config.DefaultMetadataVersion, nil)
+	return pool.UpdateInstanceBackupFile(d, true, nil, config.DefaultMetadataVersion, nil)
 }
 
 type cpuTopology struct {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8459,8 +8459,13 @@ func (d *qemu) UpdateBackupFile() error {
 		return err
 	}
 
+	volBackupConf, err := pool.GenerateInstanceCustomVolumeBackupConfig(d, nil, true, nil)
+	if err != nil {
+		return fmt.Errorf("Failed generating instance custom volume config: %w", err)
+	}
+
 	// Use the global metadata version.
-	return pool.UpdateInstanceBackupFile(d, true, nil, config.DefaultMetadataVersion, nil)
+	return pool.UpdateInstanceBackupFile(d, true, volBackupConf, config.DefaultMetadataVersion, nil)
 }
 
 type cpuTopology struct {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7019,6 +7019,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 	return &backupConfig.Config{
 		Version: api.BackupMetadataVersion2,
 		Volumes: []*backupConfig.Volume{volConfig},
+		Pools:   []*api.StoragePool{&b.db},
 	}, nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7041,13 +7041,14 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		return nil, err
 	}
 
-	volumeConfig := &backupConfig.Volume{
+	rootVolumeConfig := &backupConfig.Volume{
 		StorageVolume: volume.StorageVolume,
 	}
 
 	config := &backupConfig.Config{
 		Version: api.BackupMetadataVersion2,
 		Pools:   []*api.StoragePool{&b.db},
+		Volumes: []*backupConfig.Volume{rootVolumeConfig},
 	}
 
 	// Add profiles from instance.
@@ -7090,7 +7091,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 				return nil, errors.New("Instance snapshot record count doesn't match instance snapshot volume record count")
 			}
 
-			volumeConfig.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(dbVolSnaps))
+			rootVolumeConfig.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(dbVolSnaps))
 			for i := range dbVolSnaps {
 				foundInstanceSnapshot := false
 				for _, snap := range snapshots {
@@ -7106,7 +7107,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 
 				_, snapName, _ := api.GetParentAndSnapshotName(dbVolSnaps[i].Name)
 
-				volumeConfig.Snapshots = append(volumeConfig.Snapshots, &api.StorageVolumeSnapshot{
+				rootVolumeConfig.Snapshots = append(rootVolumeConfig.Snapshots, &api.StorageVolumeSnapshot{
 					Name:        snapName,
 					Description: dbVolSnaps[i].Description,
 					ExpiresAt:   &dbVolSnaps[i].ExpiryDate,
@@ -7118,7 +7119,6 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		}
 	}
 
-	config.Volumes = []*backupConfig.Volume{volumeConfig}
 	return config, nil
 }
 

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -182,6 +182,11 @@ func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snaps
 	return nil, nil
 }
 
+// GenerateInstanceCustomVolumeBackupConfig ...
+func (b *mockBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *backupConfigCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+	return nil, nil
+}
+
 // UpdateInstanceBackupFile ...
 func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
 	return nil

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -192,6 +192,11 @@ func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot 
 	return nil
 }
 
+// UpdateCustomVolumeBackupFiles ...
+func (b *mockBackend) UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error {
+	return nil
+}
+
 // CheckInstanceBackupFileSnapshots checks the snapshots in storage against the given backup config.
 func (b *mockBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
 	return nil, nil

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -178,12 +178,12 @@ func (b *mockBackend) GenerateCustomVolumeBackupConfig(projectName string, volNa
 }
 
 // GenerateInstanceBackupConfig ...
-func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // UpdateInstanceBackupFile ...
-func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, version uint32, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/cache.go
+++ b/lxd/storage/cache.go
@@ -1,0 +1,99 @@
+package storage
+
+import (
+	"fmt"
+
+	backupConfig "github.com/canonical/lxd/lxd/backup/config"
+	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/state"
+)
+
+// backupConfigCache is used to cache pools and volumes during backup config creation.
+type backupConfigCache struct {
+	pools map[string]Pool
+	// The volume cache is using the pool as its first dimension.
+	// By default all projects use features.storage.volumes=true which uses the volumes from the individual project.
+	// In this case the top level dimension only has an entry for the pool(s) which causes the cache to stay small.
+	// Having the project as the top level dimension would cause a duplicated pool entry under every project from which volumes are consumed:
+	// {
+	//  "pool1": {
+	//   "default": {<vols>},
+	//   "project1": {<vols>},
+	//   ...
+	//  },
+	//  ...
+	// }
+	volumes map[string]map[string]map[string]*backupConfig.Volume
+	state   *state.State
+}
+
+// newBackupConfigCache returns a new instance of the backup config cache.
+func newBackupConfigCache(backend *lxdBackend) *backupConfigCache {
+	return &backupConfigCache{
+		pools: map[string]Pool{
+			// Initialize the cache with the already existing backend's pool.
+			backend.name: backend,
+		},
+		volumes: map[string]map[string]map[string]*backupConfig.Volume{},
+		state:   backend.state,
+	}
+}
+
+// getPool returns the pool either by loading it from the DB or from the cache (preferred).
+func (b *backupConfigCache) getPool(name string) (Pool, error) {
+	// Load the pool if it cannot be found.
+	_, ok := b.pools[name]
+	if !ok {
+		var err error
+
+		// Custom volume's pool is not yet in the cache, load it.
+		pool, err := LoadByName(b.state, name)
+		if err != nil {
+			return nil, err
+		}
+
+		// Cache the pool.
+		b.pools[name] = pool
+	}
+
+	return b.pools[name], nil
+}
+
+// getVolume returns the volume's backup config either by loading it from the DB or from the cache (preferred).
+// If snapshots is true the volume's snapshots are included in the returned backup config.
+func (b *backupConfigCache) getVolume(projectName string, poolName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Volume, error) {
+	// Create pool cache.
+	_, ok := b.volumes[poolName]
+	if !ok {
+		b.volumes[poolName] = map[string]map[string]*backupConfig.Volume{}
+	}
+
+	// Create project cache.
+	_, ok = b.volumes[poolName][projectName]
+	if !ok {
+		b.volumes[poolName][projectName] = map[string]*backupConfig.Volume{}
+	}
+
+	_, ok = b.volumes[poolName][projectName][volName]
+	if !ok {
+		pool, err := b.getPool(poolName)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to retrieve pool of volume %q in pool %q: %w", volName, poolName, err)
+		}
+
+		volConfig, err := pool.GenerateCustomVolumeBackupConfig(projectName, volName, snapshots, op)
+		if err != nil {
+			return nil, fmt.Errorf("Failed generating backup config for volume %q in project %q: %w", volName, projectName, err)
+		}
+
+		vol, err := volConfig.CustomVolume()
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting the custom volume: %w", err)
+		}
+
+		// Cache the volume.
+		b.volumes[poolName][projectName][volName] = vol
+	}
+
+	return b.volumes[poolName][projectName][volName], nil
+}

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -75,6 +75,7 @@ type Pool interface {
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error
 	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error)
+	GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *backupConfigCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
 	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error)
 	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
 	CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -126,6 +126,7 @@ type Pool interface {
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
 	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
+	UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error
 	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
 	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -73,8 +73,8 @@ type Pool interface {
 	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstance(inst instance.Instance, op *operations.Operation) error
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, version uint32, op *operations.Operation) error
-	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
+	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error
+	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error)
 	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error)
 	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
 	CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1105,8 +1105,59 @@ test_backup_metadata() {
   tmpDir=$(mktemp -d -p "${TEST_DIR}" metadata-XXX)
 
   # Create an instance with one snapshot.
-  lxc init --empty c1 -d "${SMALL_ROOT_DISK}"
+  lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
   lxc snapshot c1
+
+  # Attach a disk from another pool with one snapshot.
+  custom_vol_pool="lxdtest-$(basename "${LXD_DIR}")-dir"
+  lxc storage create "${custom_vol_pool}" dir
+  lxc storage volume create "${custom_vol_pool}" foo
+  lxc storage volume snapshot "${custom_vol_pool}" foo
+  lxc storage volume attach "${custom_vol_pool}" foo c1 path=/mnt
+
+  lxc start c1
+  backup_yaml_path="${LXD_DIR}/containers/c1/backup.yaml"
+  cat "${backup_yaml_path}"
+
+  # Test the containers backup config contains the latest format.
+  [ "$(yq -r '.snapshots | length' < "${backup_yaml_path}")" = "1" ]
+  [ "$(yq -r .version < "${backup_yaml_path}")" = "${highest_version}" ]
+  [ "$(yq -r '.volumes | length' < "${backup_yaml_path}")" = "2" ]
+  [ "$(yq -r '.volumes.[0].snapshots | length' < "${backup_yaml_path}")" = "1" ]
+  [ "$(yq -r '.volumes.[1].snapshots | length' < "${backup_yaml_path}")" = "1" ]
+  [ "$(yq -r '.pools | length' < "${backup_yaml_path}")" = "2" ]
+
+  # Test custom volume changes are reflected in the config file.
+  lxc storage volume set "${custom_vol_pool}" foo user.foo bar # test volume config update
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .config."user.foo"' < "${backup_yaml_path}")" = "bar" ]
+  lxc storage volume unset "${custom_vol_pool}" foo user.foo
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .config."user.foo"' < "${backup_yaml_path}")" = "null" ]
+  [ "$(yq -r '.volumes | length' < "${backup_yaml_path}")" = "2" ]
+  [ "$(yq -r '.pools | length' < "${backup_yaml_path}")" = "2" ]
+  lxc storage volume detach "${custom_vol_pool}" foo c1 # test detaching/attaching vol and its effects on the list of vols and pools
+  [ "$(yq -r '.volumes | length' < "${backup_yaml_path}")" = "1" ]
+  [ "$(yq -r '.pools | length' < "${backup_yaml_path}")" = "1" ]
+  lxc storage volume attach "${custom_vol_pool}" foo c1 path=/mnt
+  [ "$(yq -r '.volumes | length' < "${backup_yaml_path}")" = "2" ]
+  [ "$(yq -r '.pools | length' < "${backup_yaml_path}")" = "2" ]
+
+  # Test custom volume snapshots changes are reflected in the config file.
+  lxc storage volume snapshot "${custom_vol_pool}" foo # test snapshot creation
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots | length' < "${backup_yaml_path}")" = "2" ]
+  lxc storage volume rm "${custom_vol_pool}" foo/snap1
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots | length' < "${backup_yaml_path}")" = "1" ]
+  lxc storage volume rename "${custom_vol_pool}" foo/snap0 foo/snap00 # test snapshot rename
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap00") | .name' < "${backup_yaml_path}")" = "snap00" ]
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .name' < "${backup_yaml_path}")" = "" ]
+  lxc storage volume rename "${custom_vol_pool}" foo/snap00 foo/snap0
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .name' < "${backup_yaml_path}")" = "snap0" ]
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap00") | .name' < "${backup_yaml_path}")" = "" ]
+  lxc storage volume set "${custom_vol_pool}" foo/snap0 --property description bar # test snapshot update (only description can be updated on snaps)
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .description' < "${backup_yaml_path}")" = "bar" ]
+  lxc storage volume unset "${custom_vol_pool}" foo/snap0 --property description
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .description' < "${backup_yaml_path}")" = "" ]
+
+  lxc stop -f c1
 
   # Export the instance without setting an export version.
   # The server should implicitly pick its latest supported version.
@@ -1172,6 +1223,8 @@ test_backup_metadata() {
 
   rm -rf "${tmpDir}/backup" "${tmpDir}/vol1.tar.gz"
   lxc storage volume delete "${poolName}" vol1
+  lxc storage volume delete "${custom_vol_pool}" foo
+  lxc storage delete "${custom_vol_pool}"
 
   rm -rf "${tmpDir}"
 }

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1118,6 +1118,7 @@ test_backup_metadata() {
   [ "$(yq .config.version < "${tmpDir}/backup/index.yaml")" = "${highest_version}" ]
   [ "$(yq '.config.volumes | length' < "${tmpDir}/backup/index.yaml")" = "1" ]
   [ "$(yq '.config.volumes.[0].snapshots | length' < "${tmpDir}/backup/index.yaml")" = "1" ]
+  [ "$(yq '.config.pools | length' < "${tmpDir}/backup/index.yaml")" = "1" ]
 
   rm -rf "${tmpDir}/backup" "${tmpDir}/c1.tar.gz"
 
@@ -1153,6 +1154,7 @@ test_backup_metadata() {
   [ "$(yq .config.instance < "${tmpDir}/backup/index.yaml")" = "null" ]
   [ "$(yq '.config.volumes | length' < "${tmpDir}/backup/index.yaml")" = "1" ]
   [ "$(yq '.config.volumes.[0].snapshots | length' < "${tmpDir}/backup/index.yaml")" = "1" ]
+  [ "$(yq '.config.pools | length' < "${tmpDir}/backup/index.yaml")" = "1" ]
 
   rm -rf "${tmpDir}/backup" "${tmpDir}/vol1.tar.gz"
 


### PR DESCRIPTION
Preceded by:
* https://github.com/canonical/lxd/pull/15775
* https://github.com/canonical/lxd/pull/15776
* https://github.com/canonical/lxd/pull/15777
* https://github.com/canonical/lxd/pull/15859

### Overview

This PR uses the new backup config metadata format introduced in https://github.com/canonical/lxd/pull/15129 to track all of an instance's custom storage volumes.
In addition all of the storage volume's storage pools are now listed too.

Whenever a custom volume (or its snapshots) gets updated, LXD has to check whether or not this custom volume is attached to any instance. If it's attached, with the changes proposed in this PR, LXD rewrites the backup config file to propagate the latest state of the volume.

### Detail

In order to pick up an instance's custom volume changes, the outcome of such a change has to be persisted in the parent instance's backup config.
LXD currently only has support for `GenerateCustomVolumeBackupConfig` which produces a backup config file (using the standard format) to be included in custom volume exports.

This PR grows a new `UpdateCustomVolumeBackupFile` (same as `UpdateInstanceBackupFile`) which allows updates of a custom volume to be persisted to file. With the only difference that those updates are written to all the instances using the custom volume.

As multiple instances can use the same volume, looking up all the necessary information to rebuild an instance's backup config might be resource intensive. Therefore the instance grows another `GenerateInstanceCustomVolumeBackupConfig` function which allows generating the backup config for the instance's custom volumes by leveraging caching mechanisms. Also an already prepared backup config can now be passed down to `GenerateInstanceBackupConfig` and `UpdateInstanceBackupFile` if its already crafted from the cache.

Having the `GenerateInstanceCustomVolumeBackupConfig` exported on the `Pool` interface allows arbitrary callers to either generate the custom volume's config to be passed when creating an instance's backup config or simply provide nothing. This is helpful in the case of exporting instances as the received backup doesn't contain any information about custom volumes attached to the respective instance.

Fixes https://github.com/canonical/lxd/issues/11712