### PR TITLE
Storage: Update instance backup file when root vol pool gets updated

### DIFF
--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -1137,6 +1137,43 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 	})
 }
 
+// PoolUsedByInstanceDevices finds instances using a pool in any of their devices (either directly or via their expanded profiles if
+// expandDevices is true) and passes them to instanceFunc for evaluation. If instanceFunc returns an error then it
+// is returned immediately. The instanceFunc is executed during a DB transaction, so DB queries are not permitted.
+// The instanceFunc is provided with a instance config, project config, instance's profiles and a list of device
+// names that are using the pool.
+func PoolUsedByInstanceDevices(s *state.State, poolName string, expandDevices bool, instanceFunc func(inst db.InstanceArgs, project api.Project, usedByDevices []string) error) error {
+	return s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			// Use local devices for usage check by if expandDevices is false (but don't modify instance).
+			devices := inst.Devices
+
+			// Expand devices for usage check if expandDevices is true.
+			if expandDevices {
+				devices = instancetype.ExpandInstanceDevices(devices.Clone(), inst.Profiles)
+			}
+
+			var usedByDevices []string
+
+			// Iterate through each of the instance's devices, looking for disks in the given pool.
+			for devName, dev := range devices {
+				if dev["pool"] == poolName {
+					usedByDevices = append(usedByDevices, devName)
+				}
+			}
+
+			if len(usedByDevices) > 0 {
+				err := instanceFunc(inst, p, usedByDevices)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	})
+}
+
 // VolumeUsedByExclusiveRemoteInstancesWithProfiles checks if custom volume is exclusively attached to a remote
 // instance. Returns the remote instance that has the volume exclusively attached. Returns nil if volume available.
 func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName string, projectName string, vol *api.StorageVolume) (*db.InstanceArgs, error) {

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1096,8 +1096,21 @@ test_backup_metadata() {
   tmpDir=$(mktemp -d)
 
   # Create an instance with one snapshot.
-  lxc init --empty c1 -d "${SMALL_ROOT_DISK}"
+  lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
   lxc snapshot c1
+
+  lxc start c1
+  backup_yaml_path="${LXD_DIR}/containers/c1/backup.yaml"
+  poolName="$(lxc profile device get default root pool)"
+  cat "${backup_yaml_path}"
+
+  # Test pool changes are reflected in the config file.
+  lxc storage set "${poolName}" user.foo bar
+  [ "$(yq '.pools.[] | select(.name == "'"${poolName}"'") | .config."user.foo"' < "${backup_yaml_path}")" = "bar" ]
+  lxc storage unset "${poolName}" user.foo
+  [ "$(yq '.pools.[] | select(.name == "'"${poolName}"'") | .config."user.foo"' < "${backup_yaml_path}")" = "null" ]
+
+  lxc stop -f c1
 
   # Export the instance without setting an export version.
   # The server should implicitly pick its latest supported version.
@@ -1129,7 +1142,6 @@ test_backup_metadata() {
   lxc delete -f c1
 
   # Create a custom storage volume with one snapshot.
-  poolName=$(lxc profile device get default root pool)
   lxc storage volume create "${poolName}" vol1 size=32MiB
   lxc storage volume snapshot "${poolName}" vol1
 


### PR DESCRIPTION
Fixes a general bug in LXD which caused an instance's backup file not to be updated when updating the storage pool of its root volume.

This was discovered whilst working on https://github.com/canonical/lxd/pull/15523.