### PR TITLE
Storage: Fix snapshot expiry date test regression

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -510,13 +510,7 @@ func autoCreateInstanceSnapshots(ctx context.Context, s *state.State, instances 
 			return err
 		}
 
-		expiry, err := shared.GetExpiry(time.Now().UTC(), inst.ExpandedConfig()["snapshots.expiry"])
-		if err != nil {
-			l.Error("Error getting snapshots.expiry date")
-			return err
-		}
-
-		err = inst.Snapshot(snapshotName, expiry, false)
+		err = inst.Snapshot(snapshotName, nil, false)
 		if err != nil {
 			l.Error("Error creating snapshot", logger.Ctx{"snapshot": snapshotName, "err": err})
 			return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3533,7 +3533,7 @@ func (d *lxc) snapshot(name string, expiry time.Time, stateful bool) error {
 }
 
 // Snapshot takes a new snapshot.
-func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *lxc) Snapshot(name string, expiry *time.Time, stateful bool) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2256,7 +2256,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	}
 
 	if snapName != "" && expiry != nil {
-		err := d.snapshot(snapName, *expiry, false)
+		err := d.snapshot(snapName, expiry, false)
 		if err != nil {
 			return "", nil, fmt.Errorf("Failed taking startup snapshot: %w", err)
 		}
@@ -3452,7 +3452,7 @@ func (d *lxc) RenderState(hostInterfaces []net.Interface) (*api.InstanceState, e
 }
 
 // snapshot creates a snapshot of the instance.
-func (d *lxc) snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *lxc) snapshot(name string, expiry *time.Time, stateful bool) error {
 	// Deal with state.
 	if stateful {
 		// Quick checks.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1449,7 +1449,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	}
 
 	if snapName != "" && expiry != nil {
-		err := d.snapshot(snapName, *expiry, false)
+		err := d.snapshot(snapName, expiry, false)
 		if err != nil {
 			err = fmt.Errorf("Failed taking startup snapshot: %w", err)
 			op.Done(err)
@@ -5011,7 +5011,7 @@ func (d *qemu) IsPrivileged() bool {
 }
 
 // snapshot creates a snapshot of the instance.
-func (d *qemu) snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *qemu) snapshot(name string, expiry *time.Time, stateful bool) error {
 	var err error
 	var monitor *qmp.Monitor
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5064,7 +5064,7 @@ func (d *qemu) snapshot(name string, expiry time.Time, stateful bool) error {
 }
 
 // Snapshot takes a new snapshot.
-func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
+func (d *qemu) Snapshot(name string, expiry *time.Time, stateful bool) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -93,7 +93,7 @@ type Instance interface {
 
 	// Snapshots & migration & backups.
 	Restore(source Instance, stateful bool) error
-	Snapshot(name string, expiry time.Time, stateful bool) error
+	Snapshot(name string, expiry *time.Time, stateful bool) error
 	Snapshots() ([]Instance, error)
 	Backups() ([]backup.InstanceBackup, error)
 	UpdateBackupFile() error

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/gorilla/mux"
 
@@ -342,19 +341,9 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid snapshot name: %w", err))
 	}
 
-	var expiry time.Time
-	if req.ExpiresAt != nil {
-		expiry = *req.ExpiresAt
-	} else {
-		expiry, err = shared.GetExpiry(time.Now().UTC(), inst.ExpandedConfig()["snapshots.expiry"])
-		if err != nil {
-			return response.BadRequest(err)
-		}
-	}
-
 	snapshot := func(op *operations.Operation) error {
 		inst.SetOperation(op)
-		return inst.Snapshot(req.Name, expiry, req.Stateful)
+		return inst.Snapshot(req.Name, req.ExpiresAt, req.Stateful)
 	}
 
 	resources := map[string][]api.URL{}

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -398,7 +398,7 @@ func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConf
 }
 
 // CreateCustomVolumeSnapshot ...
-func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate time.Time, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate *time.Time, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -129,7 +129,7 @@ type Pool interface {
 	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
 
 	// Custom volume snapshots.
-	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate time.Time, op *operations.Operation) error
+	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) error
 	RenameCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
 	DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error
 	UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1258,17 +1258,12 @@ func autoCreateCustomVolumeSnapshots(ctx context.Context, s *state.State, volume
 			return fmt.Errorf("Error retrieving next snapshot name for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}
 
-		expiry, err := shared.GetExpiry(time.Now().UTC(), v.Config["snapshots.expiry"])
-		if err != nil {
-			return fmt.Errorf("Error getting snapshot expiry for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
-		}
-
 		pool, err := storagePools.LoadByName(s, v.PoolName)
 		if err != nil {
 			return fmt.Errorf("Error loading pool for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}
 
-		err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, v.Description, expiry, nil)
+		err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, v.Description, nil, nil)
 		if err != nil {
 			return fmt.Errorf("Error creating snapshot for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -211,20 +211,9 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		return response.SmartError(err)
 	}
 
-	// Fill in the expiry.
-	var expiry time.Time
-	if req.ExpiresAt != nil {
-		expiry = *req.ExpiresAt
-	} else {
-		expiry, err = shared.GetExpiry(time.Now().UTC(), parentDBVolume.Config["snapshots.expiry"])
-		if err != nil {
-			return response.BadRequest(err)
-		}
-	}
-
 	// Create the snapshot.
 	snapshot := func(op *operations.Operation) error {
-		return details.pool.CreateCustomVolumeSnapshot(effectiveProjectName, details.volumeName, req.Name, req.Description, expiry, op)
+		return details.pool.CreateCustomVolumeSnapshot(effectiveProjectName, details.volumeName, req.Name, req.Description, req.ExpiresAt, op)
 	}
 
 	resources := map[string][]api.URL{}

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -387,9 +387,10 @@ test_snap_expiry() {
   lxc config set c1 snapshots.expiry '1d'
   lxc snapshot c1
 
-  # Get snapshot created_at and expires_at properties without microseconds.
-  created_at="$(lxc config get c1/snap1 --property created_at | awk -F. '{print $1}')"
-  expires_at="$(lxc config get c1/snap1 --property expires_at | awk -F. '{print $1}')"
+  # Get snapshot created_at and expires_at properties.
+  # Remove the " +0000 UTC" from the end of the timestamp so we can add one day using `date`.
+  created_at="$(lxc config get c1/snap1 --property created_at | awk -F' +' '{print $1}')"
+  expires_at="$(lxc config get c1/snap1 --property expires_at | awk -F' +' '{print $1}')"
 
   # Check if the expires_at propery is exactly 1d ahead.
   [ "$(date -d "${created_at} today + 1days")" = "$(date -d "${expires_at}")" ]

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -97,9 +97,10 @@ EOF
   lxc storage volume set "${storage_pool}" "${storage_volume}" snapshots.expiry '1d'
   lxc storage volume snapshot "${storage_pool}" "${storage_volume}"
 
-  # Get snapshot created_at and expires_at properties without microseconds.
-  created_at="$(lxc storage volume get "${storage_pool}" "${storage_volume}/snap1" --property created_at | awk -F. '{print $1}')"
-  expires_at="$(lxc storage volume get "${storage_pool}" "${storage_volume}/snap1" --property expires_at | awk -F. '{print $1}')"
+  # Get snapshot created_at and expires_at properties.
+  # Remove the " +0000 UTC" from the end of the timestamp so we can add one day using `date`.
+  created_at="$(lxc storage volume get "${storage_pool}" "${storage_volume}/snap1" --property created_at | awk -F' +' '{print $1}')"
+  expires_at="$(lxc storage volume get "${storage_pool}" "${storage_volume}/snap1" --property expires_at | awk -F' +' '{print $1}')"
 
   # Check if the expires_at propery is exactly 1d ahead.
   [ "$(date -d "${created_at} today + 1days")" = "$(date -d "${expires_at}")" ]


### PR DESCRIPTION
Applies the changes suggested in https://github.com/canonical/lxd/pull/15503#discussion_r2070417058 for both instances and custom vols. 

In addition the test suite is modified to not anymore strip off the microsecond portion of the timestamps.

Furthermore a bug is fixed which always set the zero timestamp for an instance's snapshot vol expiry. Before only the actual instance snapshot DB entry contained the expiry date. A small test for this is added too.