### PR TITLE
github: Update repo of lp-snap-build (stable-5.21)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -738,7 +738,7 @@ jobs:
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       PACKAGE: "lxd"
-      REPO: "git+ssh://lxdbot@git.launchpad.net/~canonical-lxd/lxd"
+      REPO: "git+ssh://lxdbot@git.launchpad.net/~lxd-snap/lxd"
       BRANCH: >-
         ${{ fromJson('{
           "main": "latest-edge",


### PR DESCRIPTION
Moving to https://launchpad.net/~lxd-snap/+snaps

(cherry picked from commit 5d6b575a0359e96fc9dd8d57f7add17794c1a462)