### PR TITLE
shared/cancel: Reworks Canceller to not embed Context

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -135,7 +135,7 @@ type Daemon struct {
 	// Status control.
 	startStopLock  sync.Mutex         // Prevent concurrent starts and stops.
 	setupChan      chan struct{}      // Closed when basic Daemon setup is completed
-	waitReady      *cancel.Canceller  // Cancelled when LXD is fully ready
+	waitReady      cancel.Canceller   // Cancelled when LXD is fully ready
 	shutdownCtx    context.Context    // Cancelled when shutdown starts.
 	shutdownCancel context.CancelFunc // Cancels the shutdownCtx to indicate shutdown starting.
 	shutdownDoneCh chan error         // Receives the result of the d.Stop() function and tells LXD to end.
@@ -198,7 +198,7 @@ func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 		http01Provider: acme.NewHTTP01Provider(),
 		os:             os,
 		setupChan:      make(chan struct{}),
-		waitReady:      cancel.New(context.Background()),
+		waitReady:      cancel.New(),
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
 		shutdownDoneCh: make(chan error),

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -133,12 +133,11 @@ type Daemon struct {
 	serverCertInt *shared.CertInfo // Do not use this directly, use servertCert func.
 
 	// Status control.
-	startStopLock  sync.Mutex         // Prevent concurrent starts and stops.
-	setupChan      chan struct{}      // Closed when basic Daemon setup is completed
-	waitReady      cancel.Canceller   // Cancelled when LXD is fully ready
-	shutdownCtx    context.Context    // Cancelled when shutdown starts.
-	shutdownCancel context.CancelFunc // Cancels the shutdownCtx to indicate shutdown starting.
-	shutdownDoneCh chan error         // Receives the result of the d.Stop() function and tells LXD to end.
+	startStopLock  sync.Mutex       // Prevent concurrent starts and stops.
+	setupChan      chan struct{}    // Closed when basic Daemon setup is completed
+	waitReady      cancel.Canceller // Cancelled when LXD is fully ready
+	shutdownCtx    cancel.Canceller // Cancelled when shutdown starts.
+	shutdownDoneCh chan error       // Receives the result of the d.Stop() function and tells LXD to end.
 
 	// Device monitor for watching filesystem events
 	devmonitor fsmonitor.FSMonitor
@@ -185,7 +184,7 @@ type DaemonConfig struct {
 func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 	lxdEvents := events.NewServer(daemon.Debug, daemon.Verbose, cluster.EventHubPush)
 	devLXDEvents := events.NewDevLXDServer(daemon.Debug, daemon.Verbose)
-	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	shutdownCtx := cancel.New()
 
 	d := &Daemon{
 		identityCache:  &identity.Cache{},
@@ -200,7 +199,6 @@ func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 		setupChan:      make(chan struct{}),
 		waitReady:      cancel.New(),
 		shutdownCtx:    shutdownCtx,
-		shutdownCancel: shutdownCancel,
 		shutdownDoneCh: make(chan error),
 	}
 
@@ -2048,7 +2046,7 @@ func cancelCancelableOps() error {
 // Stop stops the shared daemon.
 func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 	// Cancelling the context will make everyone aware that we're shutting down.
-	d.shutdownCancel()
+	d.shutdownCtx.Cancel()
 
 	d.startStopLock.Lock()
 	defer d.startStopLock.Unlock()

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -24,7 +24,7 @@ type listenerCommon struct {
 	EventListenerConnection
 
 	messageTypes []string
-	done         *cancel.Canceller
+	done         cancel.Canceller
 	id           string
 	lock         sync.Mutex
 	recvFunc     EventHandler
@@ -33,7 +33,7 @@ type listenerCommon struct {
 func (e *listenerCommon) start() {
 	logger.Debug("Event listener server handler started", logger.Ctx{"id": e.id, "local": e.LocalAddr(), "remote": e.RemoteAddr()})
 
-	e.Reader(e.done.Context, e.recvFunc)
+	e.Reader(e.done, e.recvFunc)
 	e.Close()
 }
 

--- a/lxd/events/devlxdEvents.go
+++ b/lxd/events/devlxdEvents.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -39,7 +38,7 @@ func (s *DevLXDServer) AddListener(instanceID int, connection EventListenerConne
 		listenerCommon: listenerCommon{
 			EventListenerConnection: connection,
 			messageTypes:            messageTypes,
-			done:                    cancel.New(context.Background()),
+			done:                    cancel.New(),
 			id:                      uuid.New().String(),
 		},
 		instanceID: instanceID,

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -83,7 +82,7 @@ func (s *Server) AddListener(projectName string, allProjects bool, projectPermis
 		listenerCommon: listenerCommon{
 			EventListenerConnection: connection,
 			messageTypes:            messageTypes,
-			done:                    cancel.New(context.Background()),
+			done:                    cancel.New(),
 			id:                      uuid.New().String(),
 			recvFunc:                recvFunc,
 		},

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -48,8 +48,8 @@ type execWs struct {
 	instance              instance.Instance
 	conns                 map[int]*websocket.Conn
 	connsLock             sync.Mutex
-	waitRequiredConnected *cancel.Canceller
-	waitControlConnected  *cancel.Canceller
+	waitRequiredConnected cancel.Canceller
+	waitControlConnected  cancel.Canceller
 	fds                   map[int]string
 	s                     *state.State
 }
@@ -666,8 +666,8 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 			ws.conns[execWSStderr] = nil
 		}
 
-		ws.waitRequiredConnected = cancel.New(context.Background())
-		ws.waitControlConnected = cancel.New(context.Background())
+		ws.waitRequiredConnected = cancel.New()
+		ws.waitControlConnected = cancel.New()
 
 		for i := range ws.conns {
 			ws.fds[i], err = shared.RandomCryptoString()

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -119,7 +119,7 @@ type Operation struct {
 	onDone    func(*Operation)
 
 	// Indicates if operation has finished.
-	finished *cancel.Canceller
+	finished cancel.Canceller
 
 	// Locking for concurent access to the Operation
 	lock sync.Mutex
@@ -149,7 +149,7 @@ func OperationCreate(s *state.State, projectName string, opClass OperationClass,
 	op.status = api.Pending
 	op.url = "/" + version.APIVersion + "/operations/" + op.id
 	op.resources = opResources
-	op.finished = cancel.New(context.Background())
+	op.finished = cancel.New()
 	op.state = s
 	op.logger = logger.AddContext(logger.Ctx{"operation": op.id, "project": op.projectName, "class": op.class.String(), "description": op.description})
 

--- a/lxd/patches_test.go
+++ b/lxd/patches_test.go
@@ -17,6 +17,7 @@ import (
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/entity"
 )
 
@@ -24,7 +25,7 @@ func Test_patchSplitIdentityCertificateEntityTypes(t *testing.T) {
 	// Set up test database.
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
-	ctx := context.Background()
+	ctx := cancel.New()
 
 	var groupID int
 	var certificateID int
@@ -127,7 +128,7 @@ func Test_patchOIDCGroupsClaimScope(t *testing.T) {
 
 		// Set the groups claim.
 		// Use default values for oidc.scopes
-		ctx := context.Background()
+		ctx := cancel.New()
 		err := cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			conf, err := clusterConfig.Load(ctx, tx)
 			require.NoError(t, err)
@@ -170,7 +171,7 @@ func Test_patchOIDCGroupsClaimScope(t *testing.T) {
 
 		// Set the groups claim.
 		// This time set oidc.scopes to already include the groups claim (i.e. this patch was already run on another member).
-		ctx := context.Background()
+		ctx := cancel.New()
 		err := cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			conf, err := clusterConfig.Load(ctx, tx)
 			require.NoError(t, err)

--- a/lxd/storage/s3/miniod/miniod.go
+++ b/lxd/storage/s3/miniod/miniod.go
@@ -47,7 +47,7 @@ type Process struct {
 	consoleURL   url.URL
 	username     string
 	password     string
-	cancel       *cancel.Canceller
+	cancel       cancel.Canceller
 	err          error
 }
 
@@ -218,7 +218,7 @@ func EnsureRunning(s *state.State, bucketVol storageDrivers.Volume) (*Process, e
 		consoleURL:   api.NewURL().Scheme("http").Host(fmt.Sprintf("%s:%d", minioHost, consolePort)).URL,
 		username:     minioAdminUser,      // Persistent admin user required to keep config between restarts.
 		password:     uuid.New().String(), // Random admin password for service.
-		cancel:       cancel.New(context.Background()),
+		cancel:       cancel.New(),
 	}
 
 	miniosMu.Lock()

--- a/shared/cancel/canceller.go
+++ b/shared/cancel/canceller.go
@@ -2,20 +2,66 @@ package cancel
 
 import (
 	"context"
+	"sync"
+	"time"
 )
 
-// Canceller is a simple wrapper for a cancellable context which makes the associated context.CancelFunc more easily
-// accessible.
-type Canceller struct {
+// Canceller extends context.Context with a built-in Cancel function.
+type Canceller interface {
 	context.Context
-	Cancel context.CancelFunc
+	Cancel()
 }
 
-// New returns a new canceller with the parent context.
-func New(ctx context.Context) *Canceller {
-	ctx, cancel := context.WithCancel(ctx)
-	return &Canceller{
-		Context: ctx,
-		Cancel:  cancel,
+// canceller is an implementation of Canceller that behaves similarly to context.WithCancel()
+// but does not use go routines, which makes it more convenient to store in a long-lived struct.
+// It implements the context.Context interface.
+type canceller struct {
+	ch   chan struct{}
+	once func()
+}
+
+// Err returns nil if Cancel() has not been called yet.
+// If Cancel() has been called then returns context.Canceled.
+// After Err returns a non-nil error, successive calls to Err return the same error.
+func (c *canceller) Err() error {
+	select {
+	case <-c.ch:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+// Cancel the Canceller.
+// Can be called multiple times safely.
+func (c *canceller) Cancel() {
+	c.once()
+}
+
+// Done returns a channel that's closed when the canceller.Cancel() is called.
+// Successive calls to Done return the same value.
+func (c *canceller) Done() <-chan struct{} {
+	return c.ch
+}
+
+// Value is not implemented.
+func (c *canceller) Value(key any) any {
+	return nil
+}
+
+// Deadline is not implemented.
+func (c *canceller) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+// New returns a new Canceller.
+func New() Canceller {
+	ch := make(chan struct{})
+
+	return &canceller{
+		ch: ch,
+		once: sync.OnceFunc(func() {
+			close(ch)
+		}),
 	}
 }

--- a/shared/cancel/canceller_test.go
+++ b/shared/cancel/canceller_test.go
@@ -1,0 +1,47 @@
+package cancel_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/shared/cancel"
+)
+
+func TestCancel(t *testing.T) {
+	c := cancel.New()
+
+	// Test Err returns nil before cancellation.
+	require.NoError(t, c.Err())
+
+	// Test c.Done() returns an unclosed channel.
+	isClosed := false
+	select {
+	case <-c.Done():
+		isClosed = true
+	default:
+	}
+
+	require.False(t, isClosed)
+
+	// Cancel the Canceller.
+	c.Cancel()
+
+	// Test successive calls to Err().
+	require.ErrorIs(t, c.Err(), context.Canceled)
+	require.ErrorIs(t, c.Err(), context.Canceled)
+
+	// Test c.Done() returns a closed channel.
+	isClosed = false
+	select {
+	case <-c.Done():
+		isClosed = true
+	default:
+	}
+
+	require.True(t, isClosed)
+
+	// Check Cancel can be called multiple times.
+	c.Cancel()
+}


### PR DESCRIPTION
Previously `Canceller` embedded a `context.WithCancel` and its associated cancel function.
This made it easy to leak the go routine created in `context.WithCancel` in a way that linters were not detecting.

This reworks `Canceller` to still implement the `context.Context` interface (so it can be passed to other functions as a context.Context), but avoids using `context.WithCancel` internally.