### PR TITLE
Update absolute docs links

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,2 +1,2 @@
 The LXD team uses GitHub for issue and feature tracking, not for user support.
-For information on how to get support, see [Support](https://documentation.ubuntu.com/lxd/en/latest/support/).
+For information on how to get support, see [Support](https://documentation.ubuntu.com/lxd/latest/support/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,4 +136,4 @@ If you add or update configuration options, regenerate and commit the documentat
 
 ## More information
 
-For more information, including details about contributing to the code as well as the documentation for LXD, see [How to contribute to LXD](https://documentation.ubuntu.com/lxd/en/latest/contributing/) in the documentation.
+For more information, including details about contributing to the code as well as the documentation for LXD, see [How to contribute to LXD](https://documentation.ubuntu.com/lxd/latest/contributing/) in the documentation.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You should consider using LXD if you want to containerize different environments
 
 ## Get started
 
-See [Getting started](https://documentation.ubuntu.com/lxd/en/latest/getting_started/) in the LXD documentation for installation instructions and first steps.
+See [Getting started](https://documentation.ubuntu.com/lxd/latest/getting_started/) in the LXD documentation for installation instructions and first steps.
 
 - Release announcements: [`https://discourse.ubuntu.com/c/lxd/news/`](https://discourse.ubuntu.com/c/lxd/news/143)
 - Release tarballs: [`https://github.com/canonical/lxd/releases/`](https://github.com/canonical/lxd/releases/)
-- Documentation: [`https://documentation.ubuntu.com/lxd/en/latest/`](https://documentation.ubuntu.com/lxd/en/latest/)
+- Documentation: [`https://documentation.ubuntu.com/lxd/latest/`](https://documentation.ubuntu.com/lxd/latest/)
 
 ## Status
 
@@ -41,7 +41,7 @@ macOS               | [Homebrew](https://formulae.brew.sh/formula/lxc)  | `brew 
 
 The LXD snap packaging repository is available [here](https://github.com/canonical/lxd-pkg-snap).
 
-For more instructions on installing LXD for a wide variety of Linux distributions and operating systems, and to install LXD from source, see [How to install LXD](https://documentation.ubuntu.com/lxd/en/latest/installing/) in the documentation.
+For more instructions on installing LXD for a wide variety of Linux distributions and operating systems, and to install LXD from source, see [How to install LXD](https://documentation.ubuntu.com/lxd/latest/installing/) in the documentation.
 
 ## Client SDK packages
 
@@ -54,7 +54,7 @@ Language  | URL
 Go        | https://pkg.go.dev/github.com/canonical/lxd/client
 Python    | https://github.com/canonical/pylxd
 
-For more information on using the LXD API, see [REST API](https://documentation.ubuntu.com/lxd/en/latest/restapi_landing/) in the documentation.
+For more information on using the LXD API, see [REST API](https://documentation.ubuntu.com/lxd/latest/restapi_landing/) in the documentation.
 
 ## Tools for managing LXD
 
@@ -81,9 +81,9 @@ Consider the following aspects to ensure that your LXD installation is secure:
 - Configure your network interfaces to be secure.
 - Do not use privileged containers unless required. If you use privileged containers, put appropriate security measures in place.
   <!-- Include end security -->
-  See [Container security](https://documentation.ubuntu.com/lxd/en/latest/explanation/security/#container-security) for more information.
+  See [Container security](https://documentation.ubuntu.com/lxd/latest/explanation/security/#container-security) for more information.
 
-See [Security](https://documentation.ubuntu.com/lxd/en/latest/explanation/security/) for detailed information.
+See [Security](https://documentation.ubuntu.com/lxd/latest/explanation/security/) for detailed information.
 
 **IMPORTANT:**
 <!-- Include start security note -->
@@ -119,7 +119,7 @@ See the [full service description](https://ubuntu.com/legal/ubuntu-pro-descripti
 
 ## Documentation
 
-The official documentation is available at: [`https://documentation.ubuntu.com/lxd/en/latest/`](https://documentation.ubuntu.com/lxd/en/latest/)
+The official documentation is available at: [`https://documentation.ubuntu.com/lxd/latest/`](https://documentation.ubuntu.com/lxd/latest/)
 
 You can find additional resources on the [website](https://canonical.com/lxd), on [YouTube](https://www.youtube.com/channel/UCuP6xPt0WTeZu32CkQPpbvA) and in the [Tutorials section](https://discourse.ubuntu.com/c/lxd/tutorials/146) in the forum.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,8 +1,8 @@
 # LXD documentation
 
-The LXD documentation is available at: <https://documentation.ubuntu.com/lxd/en/latest/>
+The LXD documentation is available at: <https://documentation.ubuntu.com/lxd/latest/>
 
-GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://documentation.ubuntu.com/lxd/en/latest/).
+GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://documentation.ubuntu.com/lxd/latest/).
 
 ## How it works
 
@@ -13,7 +13,7 @@ GitHub provides a basic rendering of the documentation as well, but important fe
 LXD's documentation is built with [Sphinx](https://www.sphinx-doc.org) and hosted on [Read the Docs](https://about.readthedocs.com/).
 
 It is written in [Markdown](https://commonmark.org/) with [MyST](https://myst-parser.readthedocs.io/) extensions.
-For syntax help and guidelines, see the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) and the [documentation cheat sheet](https://documentation.ubuntu.com/lxd/en/latest/doc-cheat-sheet-myst/) ([source](https://raw.githubusercontent.com/canonical/lxd/main/doc/doc-cheat-sheet-myst.md)).
+For syntax help and guidelines, see the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) and the [documentation cheat sheet](https://documentation.ubuntu.com/lxd/latest/doc-cheat-sheet-myst/) ([source](https://raw.githubusercontent.com/canonical/lxd/main/doc/doc-cheat-sheet-myst.md)).
 
 For structuring, the documentation uses the [Diátaxis](https://diataxis.fr/) approach.
 

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -59,11 +59,11 @@ copyright = '2014-%s %s' % (datetime.date.today().year, author)
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://documentation.ubuntu.com/lxd/en/latest/'
+ogp_site_url = 'https://documentation.ubuntu.com/lxd/latest/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = 'LXD documentation'
 # The URL of an image or logo that is used in the preview
-ogp_image = 'https://documentation.ubuntu.com/lxd/en/latest/_static/tag.png'
+ogp_image = 'https://documentation.ubuntu.com/lxd/latest/_static/tag.png'
 
 # Update with the local path to the favicon for your product
 # (default is the circle of friends)
@@ -158,7 +158,7 @@ linkcheck_ignore = [
     'http://localhost:8000',
     'http://localhost:8080',
     'http://localhost:8080/admin',
-    r'/lxd/en/latest/api/.*',
+    r'/lxd/latest/api/.*',
     r'/api/.*',
     # Those links may fail from time to time
     'https://www.dell.com/',
@@ -284,7 +284,7 @@ if os.path.exists('./related_topics.yaml'):
 if ('LOCAL_SPHINX_BUILD' in os.environ) and (os.environ['LOCAL_SPHINX_BUILD'] == 'True'):
     swagger_url_scheme = '/api/#{{path}}'
 else:
-    swagger_url_scheme = '/lxd/en/latest/api/#{{path}}'
+    swagger_url_scheme = '/lxd/latest/api/#{{path}}'
 
 myst_url_schemes = {
     'http': None,

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -261,4 +261,4 @@ Following the CLI prompts, a working MicroCloud will be ready within minutes.
 
 When the initialization is complete, you’ll have an OVN cluster, a Ceph cluster and a LXD cluster, and LXD itself will have been configured with both networking and storage suitable for use in a cluster.
 
-See the [MicroCloud documentation](https://canonical-microcloud.readthedocs-hosted.com) for more information.
+See the [MicroCloud documentation](https://documentation.ubuntu.com/microcloud/latest/microcloud/) for more information.

--- a/doc/myconf.py
+++ b/doc/myconf.py
@@ -152,12 +152,12 @@ intersphinx_mapping = {
     'cloud-init': ('https://cloudinit.readthedocs.io/en/latest/', None)
 }
 
-notfound_urls_prefix = "/lxd/en/latest/"
+notfound_urls_prefix = "/lxd/latest/"
 
 if ("LOCAL_SPHINX_BUILD" in os.environ) and (os.environ["LOCAL_SPHINX_BUILD"] == "True"):
     swagger_url_scheme = "/api/#{{path}}"
 else:
-    swagger_url_scheme = "/lxd/en/latest/api/#{{path}}"
+    swagger_url_scheme = "/lxd/latest/api/#{{path}}"
 
 myst_url_schemes = {
     "http": None,
@@ -202,9 +202,9 @@ exclude_patterns = ['html', 'README.md', '.sphinx', 'config_options_cheat_sheet.
 
 # Open Graph configuration
 
-ogp_site_url = "https://documentation.ubuntu.com/lxd/en/latest/"
+ogp_site_url = "https://documentation.ubuntu.com/lxd/latest/"
 ogp_site_name = "LXD documentation"
-ogp_image = "https://documentation.ubuntu.com/lxd/en/latest/_static/tag.png"
+ogp_image = "https://documentation.ubuntu.com/lxd/latest/_static/tag.png"
 
 # Links to ignore when checking links
 
@@ -212,7 +212,7 @@ linkcheck_ignore = [
     'https://127.0.0.1:8443/1.0',
     'https://web.libera.chat/#lxd',
     'http://localhost:8001',
-    r'/lxd/en/latest/api/.*',
+    r'/lxd/latest/api/.*',
     r'/api/.*'
 ]
 linkcheck_exclude_documents = [r'.*/manpages/.*']

--- a/grafana/LXD.json
+++ b/grafana/LXD.json
@@ -94,7 +94,7 @@
       "targetBlank": true,
       "title": "Documentation",
       "type": "link",
-      "url": "https://documentation.ubuntu.com/lxd/en/latest/"
+      "url": "https://documentation.ubuntu.com/lxd/latest/"
     }
   ],
   "liveNow": false,

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -69,7 +69,7 @@ func restServer(d *Daemon) *http.Server {
 	mux.SkipClean(true)
 	mux.UseEncodedPath() // Allow encoded values in path segments.
 
-	const errorMessage = `<html><title>The UI is not enabled</title><body><p>The UI is not enabled. For instructions to enable it check: <a href="https://documentation.ubuntu.com/lxd/en/latest/howto/access_ui/">How to access the LXD web UI</a></p></body></html>`
+	const errorMessage = `<html><title>The UI is not enabled</title><body><p>The UI is not enabled. For instructions to enable it check: <a href="https://documentation.ubuntu.com/lxd/latest/howto/access_ui/">How to access the LXD web UI</a></p></body></html>`
 
 	uiPath := os.Getenv("LXD_UI")
 	uiEnabled := uiPath != "" && shared.PathExists(uiPath)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2787,7 +2787,7 @@ func (d *qemu) generateConfigShare() error {
 	// rather than being enabled at boot.
 	lxdAgentServiceUnit := `[Unit]
 Description=LXD - agent
-Documentation=https://documentation.ubuntu.com/lxd/en/latest/
+Documentation=https://documentation.ubuntu.com/lxd/latest/
 Before=multi-user.target cloud-init.target cloud-init.service cloud-init-local.service
 DefaultDependencies=no
 

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -126,7 +126,7 @@ const clusterEditPrompt = `You should run this command only if:
  - You are *absolutely* sure all LXD daemons are stopped
  - This instance has the most up to date database
 
-See https://documentation.ubuntu.com/lxd/en/latest/howto/cluster_recover/#reconfigure-the-cluster for more info.`
+See https://documentation.ubuntu.com/lxd/latest/howto/cluster_recover/#reconfigure-the-cluster for more info.`
 
 const clusterEditComment = `# Member roles can be modified. Unrecoverable nodes should be given the role "spare".
 #
@@ -441,7 +441,7 @@ database, so you can possibly inspect it for further recovery.
 You'll be able to permanently delete from the database all information about
 former cluster members by running "lxc cluster remove <member-name> --force".
 
-See https://documentation.ubuntu.com/lxd/en/latest/howto/cluster_recover/#recover-from-quorum-loss for more
+See https://documentation.ubuntu.com/lxd/latest/howto/cluster_recover/#recover-from-quorum-loss for more
 info.`
 
 type cmdClusterRecoverFromQuorumLoss struct {

--- a/scripts/setup-grafana.sh
+++ b/scripts/setup-grafana.sh
@@ -12,7 +12,7 @@ SERVER_NAME="$(lxc info | awk '{if ($1 == "server_name:") print $2}')"
 IS_LXD_CLUSTERED=$(lxc info | grep "server_clustered:" | grep "false")
 if [ -z "$IS_LXD_CLUSTERED" ]; then
     echo "Error: LXD is clustered, this script only works for single node installations."
-    echo "See https://documentation.ubuntu.com/lxd/en/latest/metrics/ for more information."
+    echo "See https://documentation.ubuntu.com/lxd/latest/metrics/ for more information."
     exit 1
 fi
 
@@ -118,4 +118,4 @@ echo "Next steps:"
 echo "1. Wait for the container to finish booting"
 echo "2. Sign in with admin/admin to grafana at https://$CONTAINER_IP:3000"
 echo "3. Change password"
-echo "4. Create a dashboard, see https://documentation.ubuntu.com/lxd/en/latest/howto/grafana/ for more details."
+echo "4. Create a dashboard, see https://documentation.ubuntu.com/lxd/latest/howto/grafana/ for more details."


### PR DESCRIPTION
This PR updates absolute links to both the MicroCloud and LXD documentation due to both recently changing URLs to remove /en/ from the path and, in MicroCloud's case, moving to a subdirectory of documentation.ubuntu.com. Redirects are already in place, but this PR reduces the need for redirects.