### PR TITLE
doc: use double instead of single quotes around relatedlinks

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -1,6 +1,6 @@
 ---
 discourse: lxc:[LXD&#32;cluster&#32;on&#32;Raspberry&#32;Pi&#32;4](9076)
-relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
+relatedlinks: "[MicroCloud](https://canonical.com/microcloud)"
 ---
 
 (clustering)=

--- a/doc/explanation/authorization.md
+++ b/doc/explanation/authorization.md
@@ -1,5 +1,5 @@
 ---
-discourse: '[Identity&#32;and&#32;Access&#32;Management&#32;for&#32;LXD](41516)'
+discourse: "[Identity&#32;and&#32;Access&#32;Management&#32;for&#32;LXD](41516)"
 ---
 
 (authorization)=

--- a/doc/explanation/instances.md
+++ b/doc/explanation/instances.md
@@ -1,6 +1,6 @@
 ---
 discourse: lxc:[Overview&#32;-&#32;GUI&#32;inside&#32;Containers](8767),lxc:[Running&#32;virtual&#32;machines&#32;with&#32;LXD&#32;4.0](7519),lxc:[Install&#32;any&#32;OS&#32;via&#32;ISO&#32;in&#32;a&#32;Virtual&#32;machine/VM](9281)
-relatedlinks: '[LXD&#32;virtual&#32;machines:&#32;an&#32;overview](https://ubuntu.com/blog/lxd-virtual-machines-an-overview)'
+relatedlinks: "[LXD&#32;virtual&#32;machines:&#32;an&#32;overview](https://ubuntu.com/blog/lxd-virtual-machines-an-overview)"
 ---
 
 (containers-and-vms)=

--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[Running&#32;LXD&#32;in&#32;production&#32;-&#32;YouTube](https://www.youtube.com/watch?v=QyXOOE_4cm0)'
+relatedlinks: "[Running&#32;LXD&#32;in&#32;production&#32;-&#32;YouTube](https://www.youtube.com/watch?v=QyXOOE_4cm0)"
 ---
 
 (performance-tuning)=

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[Linux&#32;containers&#32;security](https://linuxcontainers.org/lxc/security/)'
+relatedlinks: "[Linux&#32;containers&#32;security](https://linuxcontainers.org/lxc/security/)"
 ---
 
 (exp-security)=

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
+relatedlinks: "[MicroCloud](https://canonical.com/microcloud)"
 ---
 
 (cluster-form)=

--- a/doc/howto/grafana.md
+++ b/doc/howto/grafana.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[LXD&#32;Grafana&#32;dashboard](https://grafana.com/grafana/dashboards/19131-lxd/)'
+relatedlinks: "[LXD&#32;Grafana&#32;dashboard](https://grafana.com/grafana/dashboards/19131-lxd/)"
 ---
 
 (grafana)=

--- a/doc/howto/images_create.md
+++ b/doc/howto/images_create.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[How&#32;to&#32;install&#32;a&#32;Windows&#32;11&#32;VM&#32;using&#32;LXD](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd)'
+relatedlinks: "[How&#32;to&#32;install&#32;a&#32;Windows&#32;11&#32;VM&#32;using&#32;LXD](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd)"
 ---
 
 (images-create)=

--- a/doc/howto/snap.md
+++ b/doc/howto/snap.md
@@ -1,5 +1,5 @@
 ---
-discourse: '[Managing&#32;the&#32;LXD&#32;snap&#32;package](37214)'
+discourse: "[Managing&#32;the&#32;LXD&#32;snap&#32;package](37214)"
 ---
 
 (howto-snap)=

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[Run&#32;system&#32;containers&#32;with&#32;LXD](https://canonical.com/lxd), [Open&#32;source&#32;for&#32;beginners:&#32;setting&#32;up&#32;your&#32;dev&#32;environment&#32;with&#32;LXD](https://ubuntu.com/blog/open-source-for-beginners-dev-environment-with-lxd)'
+relatedlinks: "[Run&#32;system&#32;containers&#32;with&#32;LXD](https://canonical.com/lxd), [Open&#32;source&#32;for&#32;beginners:&#32;setting&#32;up&#32;your&#32;dev&#32;environment&#32;with&#32;LXD](https://ubuntu.com/blog/open-source-for-beginners-dev-environment-with-lxd)"
 ---
 
 # LXD

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[How&#32;to&#32;install&#32;a&#32;Windows&#32;11&#32;VM&#32;using&#32;LXD](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd)'
+relatedlinks: "[How&#32;to&#32;install&#32;a&#32;Windows&#32;11&#32;VM&#32;using&#32;LXD](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd)"
 ---
 
 (instances)=

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[Introduction&#32;to&#32;LXD&#32;projects](https://ubuntu.com/tutorials/introduction-to-lxd-projects)'
+relatedlinks: "[Introduction&#32;to&#32;LXD&#32;projects](https://ubuntu.com/tutorials/introduction-to-lxd-projects)"
 ---
 
 (projects)=

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,6 +1,6 @@
 ---
-discourse: '[New&#32;LXD&#32;image&#32;server&#32;available&#32;(images.lxd.canonical.com)](43824),[Image&#32;server&#32;infrastructure](16647)'
-relatedlinks: '[Deploying&#32;a&#32;new&#32;LXD&#32;image&#32;server&#32;-&#32;YouTube](https://www.youtube.com/watch?v=pM0EgUqj2a0)'
+discourse: "[New&#32;LXD&#32;image&#32;server&#32;available&#32;(images.lxd.canonical.com)](43824),[Image&#32;server&#32;infrastructure](16647)"
+relatedlinks: "[Deploying&#32;a&#32;new&#32;LXD&#32;image&#32;server&#32;-&#32;YouTube](https://www.youtube.com/watch?v=pM0EgUqj2a0)"
 ---
 
 (remote-image-servers)=

--- a/doc/reference/storage_cephobject.md
+++ b/doc/reference/storage_cephobject.md
@@ -1,6 +1,6 @@
 ---
 discourse: lxc:[LXD&#32;object&#32;storage&#32;(S3&#32;API)](14579),lxc:[Introducing&#32;MicroCeph](15457)
-relatedlinks: '[Ceph&#32;and&#32;a&#32;LXD&#32;cluster&#32;-&#32;YouTube](https://youtube.com/watch?v=kVLGbvRU98A)'
+relatedlinks: "[Ceph&#32;and&#32;a&#32;LXD&#32;cluster&#32;-&#32;YouTube](https://youtube.com/watch?v=kVLGbvRU98A)"
 ---
 
 (storage-cephobject)=

--- a/doc/reference/uefi_variables.md
+++ b/doc/reference/uefi_variables.md
@@ -1,5 +1,5 @@
 ---
-discourse: '[LXD&#32;VM&#32;instance&#32;EFI&#32;Variables&#32;edit&#32;CLI](42313)'
+discourse: "[LXD&#32;VM&#32;instance&#32;EFI&#32;Variables&#32;edit&#32;CLI](42313)"
 ---
 
 # UEFI variables for VMs

--- a/doc/reference/vm_live_migration_internals.md
+++ b/doc/reference/vm_live_migration_internals.md
@@ -1,5 +1,5 @@
 ---
-discourse: '[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](50734)'
+discourse: "[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](50734)"
 ---
 
 (vm-live-migration-internals)=

--- a/doc/restapi_landing.md
+++ b/doc/restapi_landing.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: '[Directly&#32;interacting&#32;with&#32;the&#32;LXD&#32;API](https://ubuntu.com/blog/directly-interacting-with-the-lxd-api)'
+relatedlinks: "[Directly&#32;interacting&#32;with&#32;the&#32;LXD&#32;API](https://ubuntu.com/blog/directly-interacting-with-the-lxd-api)"
 ---
 
 (restapi)=


### PR DESCRIPTION
A `relatedlinks` link that has the title hard-coded is still trying to fetch from the link and is causing a build failure [here](https://launchpadlibrarian.net/791856650/buildlog_snap_ubuntu_noble_s390x_lxd-latest-candidate_BUILDING.txt.gz) as a result. Using double quotes instead of single quotes around the link might help with this. This PR updates all relatedlinks (including discourse links; they use the same relatedlinks extension) in the documentation to use double quotes. At the least, it won't hurt.