### PR TITLE
Storage: Fix CephFS mount timeout

### DIFF
--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -301,7 +301,7 @@ func (d *cephfs) Create() error {
 
 	// Mount the pool.
 	srcPath := strings.Join(monAddresses, ",") + ":/"
-	err = TryMount(srcPath, mountPoint, "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
+	err = TryMount(srcPath, mountPoint, "ceph", 0, d.getMountOptions(d.config["cephfs.user.name"], userSecret, fsName))
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func (d *cephfs) Delete(op *operations.Operation) error {
 
 	// Mount the pool.
 	srcPath := strings.Join(monAddresses, ",") + ":/"
-	err = TryMount(srcPath, mountPoint, "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
+	err = TryMount(srcPath, mountPoint, "ceph", 0, d.getMountOptions(d.config["cephfs.user.name"], userSecret, fsName))
 	if err != nil {
 		return err
 	}
@@ -545,7 +545,7 @@ func (d *cephfs) Mount() (bool, error) {
 	}
 
 	// Mount options.
-	options := fmt.Sprintf("name=%s,secret=%s,mds_namespace=%s", d.config["cephfs.user.name"], userSecret, fsName)
+	options := d.getMountOptions(d.config["cephfs.user.name"], userSecret, fsName)
 	if shared.IsTrue(d.config["cephfs.fscache"]) {
 		options += ",fsc"
 	}

--- a/lxd/storage/drivers/driver_cephfs_utils.go
+++ b/lxd/storage/drivers/driver_cephfs_utils.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/canonical/lxd/shared"
 )
@@ -85,4 +86,11 @@ func (d *cephfs) getConfig(clusterName string, userName string) ([]string, strin
 	}
 
 	return monitors, secret, nil
+}
+
+// getMountOptions returns the common mount options for volumes.
+func (d *cephfs) getMountOptions(name string, secret string, namespace string) string {
+	// The default mount_timeout is 60s.
+	// Setting it to 1s is the lowest possible and ensures LXD can retry in its own pace without waiting.
+	return fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v,mount_timeout=1", name, secret, namespace)
 }


### PR DESCRIPTION
When LXD starts up, it tries to mount all storage pools.
In case of CephFS, if the storage cluster is not reachable, each mount operation using `TryMount` will timeout after 60s ([default](https://docs.ceph.com/en/latest/man/8/mount.ceph/#basic)). As LXD retries 20 times (over 10s) this will cause LXD to wait for 10*60=600s (10mins) until it reaches ready state.

The PR sets the `mount_timeout` for CephFS vols to `1s` which seems to be the lowest possible. Setting it to `0` has the same effect as not setting it.