### PR TITLE
Daemon: Extend `waitready` with networks and storage pools

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -702,6 +702,8 @@ func (d *Daemon) State() *state.State {
 		StartTime:           d.startTime,
 		Authorizer:          d.authorizer,
 		UbuntuPro:           d.ubuntuPro,
+		NetworkReady:        d.waitNetworkReady,
+		StorageReady:        d.waitStorageReady,
 	}
 
 	s.LeaderInfo = func() (*state.LeaderInfo, error) {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -133,11 +133,13 @@ type Daemon struct {
 	serverCertInt *shared.CertInfo // Do not use this directly, use servertCert func.
 
 	// Status control.
-	startStopLock  sync.Mutex       // Prevent concurrent starts and stops.
-	setupChan      chan struct{}    // Closed when basic Daemon setup is completed
-	waitReady      cancel.Canceller // Cancelled when LXD is fully ready
-	shutdownCtx    cancel.Canceller // Cancelled when shutdown starts.
-	shutdownDoneCh chan error       // Receives the result of the d.Stop() function and tells LXD to end.
+	startStopLock    sync.Mutex       // Prevent concurrent starts and stops.
+	setupChan        chan struct{}    // Closed when basic Daemon setup is completed
+	waitReady        cancel.Canceller // Cancelled when LXD is fully ready
+	waitNetworkReady cancel.Canceller // Closed when all networks are ready.
+	waitStorageReady cancel.Canceller // Closed when all storage pools are ready.
+	shutdownCtx      cancel.Canceller // Cancelled when shutdown starts.
+	shutdownDoneCh   chan error       // Receives the result of the d.Stop() function and tells LXD to end.
 
 	// Device monitor for watching filesystem events
 	devmonitor fsmonitor.FSMonitor
@@ -187,19 +189,21 @@ func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 	shutdownCtx := cancel.New()
 
 	d := &Daemon{
-		identityCache:  &identity.Cache{},
-		config:         config,
-		devLXDEvents:   devLXDEvents,
-		events:         lxdEvents,
-		tasks:          task.NewGroup(),
-		clusterTasks:   task.NewGroup(),
-		db:             &db.DB{},
-		http01Provider: acme.NewHTTP01Provider(),
-		os:             os,
-		setupChan:      make(chan struct{}),
-		waitReady:      cancel.New(),
-		shutdownCtx:    shutdownCtx,
-		shutdownDoneCh: make(chan error),
+		identityCache:    &identity.Cache{},
+		config:           config,
+		devLXDEvents:     devLXDEvents,
+		events:           lxdEvents,
+		tasks:            task.NewGroup(),
+		clusterTasks:     task.NewGroup(),
+		db:               &db.DB{},
+		http01Provider:   acme.NewHTTP01Provider(),
+		os:               os,
+		setupChan:        make(chan struct{}),
+		waitReady:        cancel.New(),
+		waitNetworkReady: cancel.New(),
+		waitStorageReady: cancel.New(),
+		shutdownCtx:      shutdownCtx,
+		shutdownDoneCh:   make(chan error),
 	}
 
 	d.serverCert = func() *shared.CertInfo { return d.serverCertInt }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1823,12 +1823,20 @@ func networkStartup(stateFunc func() *state.State) error {
 					}
 
 					if remainingNetworks <= 0 {
+						// All networks are ready now after performing some retries.
+						// This unblocks any waitready caller using the --network flag.
+						s.NetworkReady.Cancel()
+
 						return // Our job here is done.
 					}
 				}
 			}
 		}()
 	} else {
+		// All networks are ready.
+		// This unblocks any waitready caller using the --network flag.
+		stateFunc().NetworkReady.Cancel()
+
 		logger.Info("All networks initialized")
 	}
 

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -24,6 +24,7 @@ import (
 	"github.com/canonical/lxd/lxd/sys"
 	"github.com/canonical/lxd/lxd/ubuntupro"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/cancel"
 )
 
 // State is a gateway to the two main stateful components of LXD, the database
@@ -102,6 +103,12 @@ type State struct {
 
 	// Ubuntu pro settings.
 	UbuntuPro *ubuntupro.Client
+
+	// NetworkReady can be used to track whether all networks are successfully started.
+	NetworkReady cancel.Canceller
+
+	// StorageReady can be used to track whether all storage pools are successfully started.
+	StorageReady cancel.Canceller
 }
 
 // LeaderInfo represents information regarding cluster member leadership.

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -152,12 +152,20 @@ func storageStartup(s *state.State) error {
 					}
 
 					if len(initPools) <= 0 {
+						// All storage pools are ready now after performing some retries.
+						// This unblocks any waitready caller using the --storage flag.
+						s.StorageReady.Cancel()
+
 						return // Our job here is done.
 					}
 				}
 			}
 		}()
 	} else {
+		// All storage pools are ready.
+		// This unblocks any waitready caller using the --storage flag.
+		s.StorageReady.Cancel()
+
 		logger.Info("All storage pools initialized")
 	}
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -455,6 +455,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_storage_volume_recover "Recover storage volumes"
     run_test test_syslog_socket "Syslog socket"
     run_test test_lxd_user "lxd user"
+    run_test test_waitready "waitready"
 fi
 
 # shellcheck disable=SC2034

--- a/test/suites/waitready.sh
+++ b/test/suites/waitready.sh
@@ -1,0 +1,82 @@
+test_waitready() {
+  # Create storage pool.
+  local lxd_backend storage_pool
+  lxd_backend=$(storage_backend "${LXD_DIR}")
+  storage_pool="lxdtest-$(basename "${LXD_DIR}")-pool"
+  br_name="lxdt$$"
+
+  lxc storage create "${storage_pool}" "${lxd_backend}"
+  lxc network create "${br_name}"
+
+  echo "==> Corrupt the network by setting an invalid external interface"
+  ip link add foo type bridge
+  ip addr add dev foo 10.1.123.10/24
+  # Inject the config setting manually to prevent validation by LXD.
+  network_id="$(lxd sql global "select id from networks where name='${br_name}'" -f csv)"
+  lxd sql global "INSERT INTO networks_config (network_id, node_id, key, value) VALUES (${network_id}, null, 'bridge.external_interfaces', 'foo')"
+
+  # Stop the daemon.
+  shutdown_lxd "${LXD_DIR}"
+
+  echo "==> Corrupt the storage pool directory to cause errors when LXD starts trying to start the pool"
+  # Perform this after stopping the daemon to make sure all mounts of the storage pool directory are given up.
+  rm -rf "${LXD_DIR}/storage-pools/${storage_pool}"
+  touch "${LXD_DIR}/storage-pools/${storage_pool}"
+
+  # Start the daemon.
+  respawn_lxd "${LXD_DIR}" true
+
+  # Wait for storage and network.
+  # When requesting both --network and --storage the request will already timeout on --network.
+  echo "==> LXD started but fails to start all networks and storage pools"
+  [ "$(lxd waitready --network --storage --timeout 1 2>&1)" = "Error: Networks not ready yet after 1s timeout" ]
+
+  # Not setting a timeout should have the same effect and return instantly.
+  [ "$(DEBUG="" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Networks not ready yet" ]
+
+  # The standard waitready without extra flags should still return with success.
+  lxd waitready
+
+  # The CLI reports the network and storage pool to be unavailable.
+  lxc network show "${br_name}" | grep -q "status: Unavailable"
+  lxc storage show "${storage_pool}" | grep -q "status: Unavailable"
+
+  echo "==> Restore the network by unsetting the external interface"
+  lxd sql global 'DELETE FROM networks_config WHERE key="bridge.external_interfaces"'
+  ip link del foo
+
+  # LXD retries starting the networks every 60s.
+  # Wait for 80s to ensure the network is now ready but the storage pool isn't.
+  echo "==> Networks will appear ready after the next retry"
+  [ "$(lxd waitready --network --storage --timeout 80 2>&1)" = "Error: Storage pools not ready yet after 80s timeout" ]
+
+  # Not setting a timeout should have the same effect and return instantly.
+  [ "$(DEBUG="" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Storage pools not ready yet" ]
+
+  # The standard waitready without extra flags should still return with success.
+  lxd waitready
+
+  # The CLI reports only the storage pool to be unavailable.
+  lxc network show "${br_name}" | grep -q "status: Created"
+  lxc storage show "${storage_pool}" | grep -q "status: Unavailable"
+
+  echo "==> Restore the storage pool directory"
+  rm "${LXD_DIR}/storage-pools/${storage_pool}"
+
+  # LXD retries starting the storage pools every 60s.
+  # The internal TryMount function retries 20 times over a course of 10s so we should account for this too.
+  # Wait for 80s to ensure the storage pool is now ready too.
+  echo "==> All resources will appear ready after the next retry window"
+  lxd waitready --network --storage --timeout 80
+
+  # The standard waitready without extra flags should still return with success.
+  lxd waitready
+
+  # The CLI reports both network and storage pool to be created.
+  lxc network show "${br_name}" | grep -q "status: Created"
+  lxc storage show "${storage_pool}" | grep -q "status: Created"
+
+  # Cleanup.
+  lxc storage delete "${storage_pool}"
+  lxc network delete "${br_name}"
+}


### PR DESCRIPTION
The new MicroCloud e2e test suite surfaced a situation where after rebooting a cluster member, MicroCeph/MicroOVN aren't yet fully up and running which causes LXD not being able to start the networks and storage pools in the first shot. 

Whilst LXD will retry in the background, the `lxc cluster restore` command should not be called until the networks and storage pools are ready.

Therefore two new flags `--network` and `--storage` are added to the `lxd waitready` command to allow a client to wait for all resources to be ready.